### PR TITLE
Add support for "parse" lifecycle event for websockets.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1846,6 +1846,7 @@ export default class Elysia<Instance extends ElysiaInstance = ElysiaInstance> {
 				return 'Expected a websocket connection'
 			},
 			{
+				parse: options.parse,
 				beforeHandle: options.beforeHandle,
 				transform: options.transform,
 				schema: {

--- a/src/ws/types.ts
+++ b/src/ws/types.ts
@@ -11,7 +11,8 @@ import type {
 	ExtractPath,
 	WithArray,
 	NoReturnHandler,
-	HookHandler
+	HookHandler,
+	BodyParser
 } from '../types'
 
 export type WSTypedSchema<ModelName extends string = string> = Omit<
@@ -144,6 +145,7 @@ export type ElysiaWSOptions<
 	> extends infer WS
 	? {
 			schema?: Schema
+			parse?: WithArray<BodyParser[]>
 			beforeHandle?: WithArray<HookHandler<Schema>>
 			transform?: WithArray<NoReturnHandler<TypedWSSchemaToRoute<Schema>>>
 			transformMessage?: WithArray<


### PR DESCRIPTION
One of the clients in my project tries to open a websocket connection with the content type set to "application/json", but without sending a request body. This results in an error in the compiled handler (line 71 in compose.ts), so in order to fix this, I would need support for the "parse" lifecycle event also for websockets.

The other solution would be to do a more fine-grained handling of errors in the generated code in compose.ts, but for now I like the simplicity of the approach with only one try-catch block for everything.