### PR TITLE
refactor: Better naming and structure for dependency injection methods

### DIFF
--- a/example/combined-plugin.ts
+++ b/example/combined-plugin.ts
@@ -1,9 +1,9 @@
 import { Elysia, t } from '../src'
 
-const counter = (app: Elysia) => app.state('nested-counter', 1)
+const counter = (app: Elysia) => app.setStore('nested-counter', 1)
 
 new Elysia()
 	.decorate('getDate', () => new Date())
-	.state('counter', 1)
+	.setStore('counter', 1)
 	.use(counter)
 	.get('/:id', ({ params, getDate, store }) => getDate())

--- a/example/counter.ts
+++ b/example/counter.ts
@@ -1,6 +1,6 @@
 import { Elysia } from '../src'
 
 new Elysia()
-	.state('counter', 0)
+	.setStore('counter', 0)
 	.get('/', ({ store }) => store.counter++)
 	.listen(8080)

--- a/example/derive.ts
+++ b/example/derive.ts
@@ -1,13 +1,13 @@
 import { Elysia } from '../src'
 
 new Elysia()
-	.state('counter', 0)
-	.derive(({ store }) => ({
+	.setStore('counter', 0)
+	.decorateOnRequest(({ store }) => ({
 		increase() {
 			store.counter++
 		}
 	}))
-	.derive(({ store }) => ({
+	.setStoreOnRequest(({ store }) => ({
 		doubled: store.counter * 2,
 		tripled: store.counter * 3
 	}))

--- a/example/guard.ts
+++ b/example/guard.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from '../src'
 
 new Elysia()
-	.state('name', 'salt')
+	.setStore('name', 'salt')
 	.get('/', ({ store: { name } }) => `Hi ${name}`, {
 		schema: {
 			query: t.Object({

--- a/example/hook.ts
+++ b/example/hook.ts
@@ -2,7 +2,7 @@ import { Elysia } from '../src'
 
 new Elysia()
 	// Create global mutable state
-	.state('counter', 0)
+	.setStore('counter', 0)
 	// Increase counter by 1 on every request on any handler
 	.onTransform(({ store }) => {
 		store.counter++

--- a/example/http.ts
+++ b/example/http.ts
@@ -5,8 +5,8 @@ const loggerPlugin = (app: Elysia, { prefix = '/fbk' } = {}) =>
 		.get('/hi', () => 'Hi')
 		.decorate('log', () => 'A')
 		.decorate('date', () => new Date())
-		.state('fromPlugin', 'From Logger')
-		.use((app) => app.state('abc', 'abc'))
+		.setStore('fromPlugin', 'From Logger')
+		.use((app) => app.setStore('abc', 'abc'))
 
 const app = new Elysia()
 	.onRequest(({ set }) => {
@@ -15,7 +15,7 @@ const app = new Elysia()
 		}
 	})
 	.use(loggerPlugin)
-	.state('build', Date.now())
+	.setStore('build', Date.now())
 	.get('/', () => 'Elysia')
 	.get('/tako', () => Bun.file('./example/takodachi.png'))
 	.get('/json', () => ({
@@ -83,13 +83,14 @@ const app = new Elysia()
 	})
 	.get('/trailing-slash', () => 'A')
 	.group('/group', (app) => {
-		return app.onBeforeHandle<{
-			query: {
-				name: string
-			}
-		}>(({ query }) => {
-			if (query?.name === 'aom') return 'Hi saltyaom'
-		})
+		return app
+			.onBeforeHandle<{
+				query: {
+					name: string
+				}
+			}>(({ query }) => {
+				if (query?.name === 'aom') return 'Hi saltyaom'
+			})
 			.get('/', () => 'From Group')
 			.get('/hi', () => 'HI GROUP')
 			.get('/elysia', () => 'Welcome to Elysian Realm')

--- a/example/router.ts
+++ b/example/router.ts
@@ -5,7 +5,7 @@ const prefix =
 	(app: Elysia) =>
 		app.group(`${prefix}/api`, (app) =>
 			app
-				.state('b', 'b')
+				.setStore('b', 'b')
 				.get('/2', () => 2)
 				.guard({}, (app) => app.get('/do', () => 'something'))
 				.group('/v2', (app) =>
@@ -18,4 +18,3 @@ const a = new Elysia()
 	.guard({}, (app) => app.get('/guard', () => 'a'))
 	.use(prefix('prefixed'))
 	.listen(8080)
-

--- a/example/store.ts
+++ b/example/store.ts
@@ -2,5 +2,5 @@ import { Elysia } from '../src'
 
 new Elysia()
 	// Create globally mutable store
-	.state('name', 'Fubuki')
+	.setStore('name', 'Fubuki')
 	.get('/id/:id', ({ params: { id }, store: { name } }) => `${id} ${name}`)

--- a/example/type-inference.ts
+++ b/example/type-inference.ts
@@ -1,6 +1,6 @@
 import { Elysia } from '../src'
 
-const counter = (app: Elysia) => app.state('counter', 0)
+const counter = (app: Elysia) => app.setStore('counter', 0)
 
 new Elysia()
 	.use(counter)

--- a/example/websocket.ts
+++ b/example/websocket.ts
@@ -2,7 +2,7 @@ import { Elysia, t, ws } from '../src'
 
 const app = new Elysia()
 	.use(ws())
-	.state('start', 'here')
+	.setStore('start', 'here')
 	.ws('/ws', {
 		open(ws) {
 			ws.subscribe('asdf')

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -34,3 +34,44 @@ describe('decorators', () => {
 		expect(res).toBe('world')
 	})
 })
+
+describe('decorateOnRequest', () => {
+	it('work', async () => {
+		const app = new Elysia()
+			.decorateOnRequest(() => ({
+				hi: () => 'hi'
+			}))
+			.get('/', ({ hi }) => hi())
+
+		const res = await app.handle(req('/')).then((t) => t.text())
+		expect(res).toBe('hi')
+	})
+
+	it('inherits plugin', async () => {
+		const plugin = () => (app: Elysia) =>
+			app.decorateOnRequest(() => ({
+				hi: () => 'hi'
+			}))
+
+		const app = new Elysia().use(plugin()).get('/', ({ hi }) => hi())
+
+		const res = await app.handle(req('/')).then((t) => t.text())
+		expect(res).toBe('hi')
+	})
+
+	it('can mutate store', async () => {
+		const app = new Elysia()
+			.setStore('counter', 1)
+			.decorateOnRequest(({ store }) => ({
+				increase: () => store.counter++
+			}))
+			.get('/', ({ store, increase }) => {
+				increase()
+
+				return store.counter
+			})
+
+		const res = await app.handle(req('/')).then((t) => t.text())
+		expect(res).toBe('2')
+	})
+})

--- a/test/elysia.test.ts
+++ b/test/elysia.test.ts
@@ -6,11 +6,23 @@ import { req } from './utils'
 describe('Elysia', () => {
 	it('handle state', async () => {
 		const app = new Elysia()
-			.state('a', 'a')
+			.setStore('a', 'a')
 			.get('/', ({ store: { a } }) => a)
 		const res = await app.handle(req('/'))
 
 		expect(await res.text()).toBe('a')
+	})
+
+	it('handle request state', async () => {
+		let id = 0
+
+		const app = new Elysia()
+			.setStoreOnRequest(() => ({ requestId: ++id }))
+			.get('/', ({ store: { requestId } }) => requestId)
+		const res1 = await app.handle(req('/'))
+		const res2 = await app.handle(req('/'))
+
+		expect((await res1.text()) === (await res2.text())).toBeFalsy()
 	})
 
 	// https://github.com/oven-sh/bun/issues/1523


### PR DESCRIPTION
Implement #34.

I marked the old API as deprecated. If removal is prefered, I'll remove them instead.