### PR TITLE
feat: add type to status -> HTTPStatus

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import type { Elysia, TypedRoute, SCHEMA } from '.'
+import type { Elysia, TypedRoute, SCHEMA, HTTPStatus } from '.'
 
 export type Context<
 	Route extends TypedRoute = TypedRoute,
@@ -17,7 +17,7 @@ export type Context<
 
 	set: {
 		headers: Record<string, string>
-		status?: number
+		status?: HTTPStatus
 		redirect?: string
 	}
 } & Record<typeof SCHEMA, Route>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2962,5 +2962,6 @@ export type {
 	MergeIfNotNull,
 	ElysiaDefaultMeta,
 	AnyTypedSchema,
-	DeepMergeTwoTypes
+	DeepMergeTwoTypes,
+	HTTPStatus
 } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -673,3 +673,77 @@ export type MaybePromise<T> = T | Promise<T>
 export type Prettify<T> = {
 	[K in keyof T]: T[K]
 } & {}
+
+/**
+ * @link https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+ */
+export type HTTPStatus =
+	// 2xx: Success - The action was successfully received, understood, and accepted
+	200 // OK
+	| 201 // Created
+	| 202 // Accepted
+	| 203 // Non-Authoritative Information
+	| 204 // No Content
+	| 205 // Reset Content
+	| 206 // Partial Content
+	| 207 // Multi-Status
+	| 208 // Already Reported
+	| 226 // IM Used
+
+	// 3xx: Redirection - Further action must be taken in order to complete the request
+	| 300 // Multiple Choices
+	| 301 // Moved Permanently
+	| 302 // Found
+	| 303 // See Other
+	| 304 // Not Modified
+	| 305 // Use Proxy
+	// | 306 // (Unused)
+	| 307 // Temporary Redirect
+	| 308 // Permanent Redirect
+
+	// 4xx: Client Error - The request contains bad syntax or cannot be fulfilled
+	| 400 // Bad Request
+	| 401 // Unauthorized
+	| 402 // Payment Required
+	| 403 // Forbidden
+	| 404 // Not Found
+	| 405 // Method Not Allowed
+	| 406 // Not Acceptable
+	| 407 // Proxy Authentication Required
+	| 408 // Request Timeout
+	| 409 // Conflict
+	| 410 // Gone
+	| 411 // Length Required
+	| 412 // Precondition Failed
+	| 413 // Content Too Large
+	| 414 // URI Too Long
+	| 415 // Unsupported Media Type
+	| 416 // Range Not Satisfiable
+	| 417 // Expectation Failed
+	// | 418 // (Unused)
+	| 421 // Misdirected Request
+	| 422 // Unprocessable Content
+	| 423 // Locked
+	| 424 // Failed Dependency
+	| 425 // Too Early
+	| 426 // Upgrade Required
+	| 427 // Unassigned
+	| 428 // Precondition Required
+	| 429 // Too Many Requests
+	| 430 // Unassigned
+	| 431 // Request Header Fields Too Large
+	| 451 // Unavailable For Legal Reasons
+
+	//  5xx: Server Error - The server failed to fulfill an apparently valid request
+	| 500 // Internal Server Error
+	| 501 // Not Implemented
+	| 502 // Bad Gateway
+	| 503 // Service Unavailable
+	| 504 // Gateway Timeout
+	| 505 // HTTP Version Not Supported
+	| 506 // Variant Also Negotiates
+	| 507 // Insufficient Storage
+	| 508 // Loop Detected
+	| 509 // Unassigned
+	// | 510 // Not Extended (OBSOLETED)
+	| 511 // Network Authentication Required


### PR DESCRIPTION
Hi !!!

I'm testing this framework that seems great to me!

Doing some testing, it occurred to me to add some improvement to the set.status. To avoid mistakes. 

For example


```
app.post("/test", ({ body, set }) => {
   set.status = 100 
   return body
})
```

It gives this error:

`
The status provided (100) must be 101 or in the range of [200, 599]
`

I came up with this solution:


```
	// 2xx: Success - The action was successfully received, understood, and accepted
	200 // OK
	| 201 // Created
	| 202 // Accepted
	| 203 // Non-Authoritative Information
	| 204 // No Content
	| 205 // Reset Content
	| 206 // Partial Content
	| 207 // Multi-Status
	| 208 // Already Reported
	| 226 // IM Used

	// 3xx: Redirection - Further action must be taken in order to complete the request
	| 300 // Multiple Choices
	| 301 // Moved Permanently
	| 302 // Found
	| 303 // See Other
	| 304 // Not Modified
	| 305 // Use Proxy
	// | 306 // (Unused)
	| 307 // Temporary Redirect
	| 308 // Permanent Redirect

	// 4xx: Client Error - The request contains bad syntax or cannot be fulfilled
	| 400 // Bad Request
	| 401 // Unauthorized
	| 402 // Payment Required
	| 403 // Forbidden
	| 404 // Not Found
	| 405 // Method Not Allowed
	| 406 // Not Acceptable
	| 407 // Proxy Authentication Required
	| 408 // Request Timeout
	| 409 // Conflict
	| 410 // Gone
	| 411 // Length Required
	| 412 // Precondition Failed
	| 413 // Content Too Large
	| 414 // URI Too Long
	| 415 // Unsupported Media Type
	| 416 // Range Not Satisfiable
	| 417 // Expectation Failed
	// | 418 // (Unused)
	| 421 // Misdirected Request
	| 422 // Unprocessable Content
	| 423 // Locked
	| 424 // Failed Dependency
	| 425 // Too Early
	| 426 // Upgrade Required
	| 427 // Unassigned
	| 428 // Precondition Required
	| 429 // Too Many Requests
	| 430 // Unassigned
	| 431 // Request Header Fields Too Large
	| 451 // Unavailable For Legal Reasons

	//  5xx: Server Error - The server failed to fulfill an apparently valid request
	| 500 // Internal Server Error
	| 501 // Not Implemented
	| 502 // Bad Gateway
	| 503 // Service Unavailable
	| 504 // Gateway Timeout
	| 505 // HTTP Version Not Supported
	| 506 // Variant Also Negotiates
	| 507 // Insufficient Storage
	| 508 // Loop Detected
	| 509 // Unassigned
	// | 510 // Not Extended (OBSOLETED)
	| 511 // Network Authentication Required

```
Reference link: 
https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml


Thank you very much for creating this framework!!
 
I am at your disposal if any changes, improvements, etc. need to be made.	
