### PR TITLE
fix: groups with prefixed instance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,12 +173,13 @@ export default class Elysia<
 		hook?: LocalHook<any, any, string>,
 		{ allowMeta = false } = {
 			allowMeta: false as boolean | undefined
-		}
+		},
+		skipPrefix?: boolean
 	) {
 		path =
 			path === '' ? path : path.charCodeAt(0) === 47 ? path : `/${path}`
 
-		if (this.config.prefix) path = this.config.prefix + path
+		if (this.config.prefix && !skipPrefix) path = this.config.prefix + path
 
 		const defs = this.meta.defs
 
@@ -931,7 +932,9 @@ export default class Elysia<
 						handler,
 						mergeHook(hooks, {
 							error: sandbox.event.error
-						})
+						}),
+						undefined,
+						true
 					)
 				}
 			}

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -139,4 +139,14 @@ describe('group', () => {
 		expect(correct.status).toBe(200)
 		expect(error.status).toBe(400)
 	})
+
+	it('validate request with prefix', async () => {
+		const app = new Elysia({ prefix: '/api' }).group('/v1', (app) =>
+			app.get('', () => 'Hello')
+		)
+
+		const res = await app.handle(req('/api/v1'))
+
+		expect(res.status).toBe(200)
+	})
 })


### PR DESCRIPTION
Hi!

As i already mentioned this on Discord, groups do not work correctly with the new plugin model introduced in 0.6, this fixes that issue.

![image](https://github.com/elysiajs/elysia/assets/5439229/5efc91b0-c8b9-486d-a9fb-425de54e4fdc)

There is still an issue with the inferred type when we use a plugin prefix, but hopefully we can fix that too in the near future.