### PR TITLE
fix: pass instance errors typings to local error hook

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -376,7 +376,7 @@ export type LocalHook<
 				/**
 				 * Catch error
 				 */
-				error?: WithArray<ErrorHandler>
+				error?: WithArray<ErrorHandler<Instance['error']>>
 				/**
 				 * Custom body parser
 				 */


### PR DESCRIPTION
Closes #107 

It seems that the instance's errors were just not being passed to "ErrorHandle" on LocalHook