### PR TITLE
make decorators readonly when accessed through context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -65,7 +65,7 @@ export type Context<
 		path: string
 		request: Request
 		store: Decorators['store']
-	} & Decorators['request']
+	} & Readonly<Decorators['request']>
 >
 
 // Use to mimic request before mapping route
@@ -92,5 +92,5 @@ export type PreContext<
 		path: string
 		request: Request
 		store: Decorators['store']
-	} & Decorators['request']
+	} & Readonly<Decorators['request']>
 >

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -854,3 +854,37 @@ app.group(
 				)
 	)
 }
+
+// ? Decorators are Read-Only in context
+{
+	const app = new Elysia()
+		.decorate('a', {
+			b: 'c',
+			d: 54
+		})
+		.decorate('pi', 3.14)
+
+	app.get('/', (ctx) => {
+		type OnlyDecorators = Omit<
+			typeof ctx,
+			| 'params'
+			| 'request'
+			| 'body'
+			| 'headers'
+			| 'query'
+			| 'cookie'
+			| 'set'
+			| 'path'
+			| 'r'
+			| 'store'
+		>
+
+		expectTypeOf<OnlyDecorators>().toEqualTypeOf<{
+			readonly a: {
+				readonly b: 'c'
+				readonly d: 54
+			}
+			readonly pi: 3.14
+		}>()
+	})
+}


### PR DESCRIPTION

_The change is like 2 lines, but seems to have had a ripple effect causing a couple type errors, which I am working to fix_

_But I would still like your thoughts in the meantime_

---

This pr:
- changes the type of context to make decorators readonly
- adds a test

Why?
- currently it is a bit confusing what is the difference between `state` and `decorate`, to a new user it feels like the same thing just one ends up in `ctx` and one in `ctx.store`
- I would argue they should have a semantic difference, where `decorators` are immutable (ie a database client, or a config object) and shouldn't be modified, where `state` is mutable and can be modified
There is this part from the [context page of the docs](https://elysiajs.com/concept/handler.html#context) which I believe shares this sentiment:
> store: A global *mutable* store for Elysia instance

Making decorators readonly makes it more clear when a user should use `state` vs `decorate`, and provides additional safety for large, important global values you want ensure aren't modified