### PR TITLE
fix: modules test

### DIFF
--- a/test/core/modules.test.ts
+++ b/test/core/modules.test.ts
@@ -125,7 +125,7 @@ describe('Modules', () => {
 		expect(res).toBe('hi')
 	})
 
-	describe('handle async plugin', async () => {
+	it('handle async plugin', async () => {
 		const a = (config = {}) =>
 			new Elysia({
 				name: 'a',


### PR DESCRIPTION
replace `describe` with `it` because of this
```
test/core/modules.test.ts:
134 | 
135 |           const app = new Elysia().use(a()).compile()
136 | 
137 |           await app.modules
138 | 
139 |           expect(app.routes.length).toBe(1)
     ^
TestNotRunningError: expect() must be called in a test
```