### PR TITLE
derive placement changed to allow handling after other transforms

### DIFF
--- a/test/path/guard.test.ts
+++ b/test/path/guard.test.ts
@@ -171,4 +171,27 @@ describe('guard', () => {
 		expect(correct.status).toBe(200)
 		expect(error.status).toBe(400)
 	})
+
+	it('apply derive after guard', async () => {
+		const app = new Elysia()
+			.guard({
+				headers: t.Object({
+					token: t.String()
+				})
+			})
+			.derive(({ headers: { token } }) => {
+				return { token: token.split(' ')[1] } //extract bearer token
+			})
+			.get('/token', ({ token }) => token)
+
+		const correct = await app.handle(
+			req('/token', {
+				headers: { token: 'Bearer 1234' }
+			})
+		)
+		const error = await app.handle(req('/token'))
+
+		expect(correct.status).toBe(200)
+		expect(error.status).toBe(400)
+	})
 })


### PR DESCRIPTION
Modifying how and where derive transform takes place. This allows derive to trigger after the validations have taken place. This allows for cases where you want validators to reject before deriving a value into decorators or stores.