### PR TITLE
fix: WS: Correct handling of Buffer object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2369,15 +2369,17 @@ export default class Elysia<
 		})
 
 		const parseMessage = (message: any) => {
-			const start = message.charCodeAt(0)
-
-			if (start === 47 || start === 123)
-				try {
-					message = JSON.parse(message)
-				} catch {
-					// Not empty
-				}
-			else if (!Number.isNaN(+message)) message = +message
+			if (typeof message === 'string') {
+				const start = message?.charCodeAt(0)
+	
+				if (start === 47 || start === 123)
+					try {
+						message = JSON.parse(message)
+					} catch {
+						// Not empty
+					}
+				else if (!Number.isNaN(+message)) message = +message
+			}
 
 			if (transform?.length)
 				for (let i = 0; i < transform.length; i++) {

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -61,6 +61,12 @@ export class ElysiaWS<
 			if (this.validator?.Check(data) === false)
 				throw new ValidationError('message', this.validator, data)
 
+			if (Buffer.isBuffer(data)) {
+				this.raw.send(data as unknown as Buffer)
+
+				return this
+			}
+
 			if (typeof data === 'object') data = JSON.stringify(data)
 
 			this.raw.send(data as unknown as string)

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -212,4 +212,30 @@ describe('WebSocket message', () => {
 		await wsClosed(ws)
 		app.stop()
 	})
+
+	it('should be able to receive binary data', async () => {
+		const plugin = new Elysia().ws('/ws', {
+			message(ws, message) {
+				ws.send(message)
+			}
+		})
+
+		const app = new Elysia().use(plugin).listen(0)
+
+		const ws = newWebsocket(app.server!)
+
+		await wsOpen(ws)
+
+		const message = wsMessage(ws)
+
+		ws.send(new Uint8Array(3))
+
+		const { type, data } = await message
+
+		expect(type).toBe('message')
+		expect(data).toBe(new Uint8Array(3))
+
+		await wsClosed(ws)
+		app.stop()
+	})
 })

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -233,7 +233,7 @@ describe('WebSocket message', () => {
 		const { type, data } = await message
 
 		expect(type).toBe('message')
-		expect(data).toBe(new Uint8Array(3))
+		expect(data).toEqual(new Uint8Array(3))
 
 		await wsClosed(ws)
 		app.stop()

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -49,7 +49,7 @@ describe('WebSocket message', () => {
 		const { type, data } = await message
 
 		expect(type).toBe('message')
-		expect(data).toBe('::1')
+		expect(data === '::1' || data === '::ffff:127.0.0.1').toBeTruthy()
 
 		await wsClosed(ws)
 		app.stop()

--- a/test/ws/utils.ts
+++ b/test/ws/utils.ts
@@ -21,6 +21,5 @@ export const wsClosed = async (ws: WebSocket) => {
 
 export const wsMessage = (ws: WebSocket) =>
 	new Promise<MessageEvent<string | Buffer>>((resolve) => {
-		
 		ws.onmessage = resolve
 	})

--- a/test/ws/utils.ts
+++ b/test/ws/utils.ts
@@ -21,5 +21,6 @@ export const wsClosed = async (ws: WebSocket) => {
 
 export const wsMessage = (ws: WebSocket) =>
 	new Promise<MessageEvent<string | Buffer>>((resolve) => {
+		
 		ws.onmessage = resolve
 	})


### PR DESCRIPTION
## Related issue: 

#247

## Summary of the issue:

The issue is caused by the library always assuming that the message is `string`, or it will be stringified.

When the client sends a binary frame, the library always `JSON.stringify` the message including the `Buffer` object. 

## What this PR change:

This PR is change the codes so that,

- On `parseMessage`, if the message is not `string`, it will skip parsing as either `JSON` string or `Number`
- On `send` method, if the message is in `Buffer` format, it will transmit as-is and not `JSON.stringify` as it did before.

Also, this PR adds a test to target this issue.

PS: On testing, I've found that `should respond with remoteAddress` always returns false due to the difference in the format of the remote address. So I've added that kind of address format so the test can be passed.