### PR TITLE
feat: add `cookie.remove` options

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -171,13 +171,17 @@ export class Cookie<T = unknown> implements CookieOptions {
 		return this.sync() as any
 	}
 
-	remove() {
+	remove(options?: Pick<CookieOptions, "domain" | "path" | "sameSite" | "secure">) {
 		if (this.value === undefined) return
 
 		this.set({
-			value: '' as any,
+			domain: options?.domain,
 			expires: new Date(0),
 			maxAge: 0,
+			path: options?.path,
+			sameSite: options?.sameSite,
+			secure: options?.secure,
+			value: '' as any,
 		})
 	}
 

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -171,7 +171,9 @@ export class Cookie<T = unknown> implements CookieOptions {
 		return this.sync() as any
 	}
 
-	remove(options?: Pick<CookieOptions, "domain" | "path" | "sameSite" | "secure">) {
+	remove(
+		options?: Pick<CookieOptions, 'domain' | 'path' | 'sameSite' | 'secure'>
+	) {
 		if (this.value === undefined) return
 
 		this.set({
@@ -181,7 +183,7 @@ export class Cookie<T = unknown> implements CookieOptions {
 			path: options?.path,
 			sameSite: options?.sameSite,
 			secure: options?.secure,
-			value: '' as any,
+			value: '' as any
 		})
 	}
 

--- a/test/cookie/explicit.test.ts
+++ b/test/cookie/explicit.test.ts
@@ -121,14 +121,19 @@ describe('Explicit Cookie', () => {
 		const { cookie, set } = create()
 
 		cookie.name = new Cookie('himari')
-		cookie.name.remove({path: "/", domain: "elysiajs.com", sameSite: "lax", secure: true })
+		cookie.name.remove({
+			path: '/',
+			domain: 'elysiajs.com',
+			sameSite: 'lax',
+			secure: true
+		})
 
 		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
 			Date.now()
 		)
-		expect(set.cookie?.name.path).toBe("/")
-		expect(set.cookie?.name.domain).toBe("elysiajs.com")
-		expect(set.cookie?.name.sameSite).toBe("lax")
+		expect(set.cookie?.name.path).toBe('/')
+		expect(set.cookie?.name.domain).toBe('elysiajs.com')
+		expect(set.cookie?.name.sameSite).toBe('lax')
 		expect(set.cookie?.name.secure).toBeTrue()
 	})
 })

--- a/test/cookie/explicit.test.ts
+++ b/test/cookie/explicit.test.ts
@@ -106,7 +106,7 @@ describe('Explicit Cookie', () => {
 		expect(set.cookie?.name).toEqual({ value: 'himari' })
 	})
 
-	it('remove cookie', () => {
+	it('remove cookie without options', () => {
 		const { cookie, set } = create()
 
 		cookie.name = new Cookie('himari')
@@ -115,5 +115,20 @@ describe('Explicit Cookie', () => {
 		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
 			Date.now()
 		)
+	})
+
+	it('remove cookie with options', () => {
+		const { cookie, set } = create()
+
+		cookie.name = new Cookie('himari')
+		cookie.name.remove({path: "/", domain: "elysiajs.com", sameSite: "lax", secure: true })
+
+		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
+			Date.now()
+		)
+		expect(set.cookie?.name.path).toBe("/")
+		expect(set.cookie?.name.domain).toBe("elysiajs.com")
+		expect(set.cookie?.name.sameSite).toBe("lax")
+		expect(set.cookie?.name.secure).toBeTrue()
 	})
 })

--- a/test/cookie/implicit.test.ts
+++ b/test/cookie/implicit.test.ts
@@ -173,14 +173,19 @@ describe('Implicit Cookie', () => {
 		} = create()
 
 		name.value = 'himari'
-		name.remove({path: "/", domain: "elysiajs.com", sameSite: "lax", secure: true })
+		name.remove({
+			path: '/',
+			domain: 'elysiajs.com',
+			sameSite: 'lax',
+			secure: true
+		})
 
 		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
 			Date.now()
 		)
-		expect(set.cookie?.name.path).toBe("/")
-		expect(set.cookie?.name.domain).toBe("elysiajs.com")
-		expect(set.cookie?.name.sameSite).toBe("lax")
+		expect(set.cookie?.name.path).toBe('/')
+		expect(set.cookie?.name.domain).toBe('elysiajs.com')
+		expect(set.cookie?.name.sameSite).toBe('lax')
 		expect(set.cookie?.name.secure).toBeTrue()
 	})
 })

--- a/test/cookie/implicit.test.ts
+++ b/test/cookie/implicit.test.ts
@@ -152,7 +152,7 @@ describe('Implicit Cookie', () => {
 		expect(set.cookie?.name).toEqual({ value: '' })
 	})
 
-	it('Remove cookie', () => {
+	it('Remove cookie without options', () => {
 		const {
 			cookie: { name },
 			set
@@ -164,5 +164,23 @@ describe('Implicit Cookie', () => {
 		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
 			Date.now()
 		)
+	})
+
+	it('Remove cookie with options', () => {
+		const {
+			cookie: { name },
+			set
+		} = create()
+
+		name.value = 'himari'
+		name.remove({path: "/", domain: "elysiajs.com", sameSite: "lax", secure: true })
+
+		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
+			Date.now()
+		)
+		expect(set.cookie?.name.path).toBe("/")
+		expect(set.cookie?.name.domain).toBe("elysiajs.com")
+		expect(set.cookie?.name.sameSite).toBe("lax")
+		expect(set.cookie?.name.secure).toBeTrue()
 	})
 })

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -58,6 +58,11 @@ const app = new Elysia({
 
 		return 'Deleted'
 	})
+	.get('/remove-with-options', ({ cookie }) => {
+		for (const self of Object.values(cookie)) self.remove({ path: "/", domain: "elysiajs.com", sameSite: "lax", secure: true})
+
+		return 'Deleted'
+	})
 
 describe('Cookie Response', () => {
 	it('set cookie', async () => {
@@ -127,7 +132,7 @@ describe('Cookie Response', () => {
 		])
 	})
 
-	it('remove cookie', async () => {
+	it('remove cookie without options', async () => {
 		const response = await app.handle(
 			req('/remove', {
 				headers: {
@@ -146,6 +151,27 @@ describe('Cookie Response', () => {
 		)
 
 		expect(getCookies(response)[0]).toInclude(`council=; Max-Age=0; Expires=${new Date(0).toUTCString()}`)
+	})
+
+	it('remove cookie with options', async () => {
+		const response = await app.handle(
+			req('/remove-with-options', {
+				headers: {
+					cookie:
+						'council=' +
+						encodeURIComponent(
+							JSON.stringify([
+								{
+									name: 'Rin',
+									affilation: 'Administration'
+								}
+							])
+						)
+				}
+			})
+		)
+
+		expect(getCookies(response)[0]).toInclude(`council=; Max-Age=0; Domain=elysiajs.com; Path=/; Expires=${new Date(0).toUTCString()}; Secure; SameSite=Lax`)
 	})
 
 	it('sign cookie', async () => {

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -59,7 +59,13 @@ const app = new Elysia({
 		return 'Deleted'
 	})
 	.get('/remove-with-options', ({ cookie }) => {
-		for (const self of Object.values(cookie)) self.remove({ path: "/", domain: "elysiajs.com", sameSite: "lax", secure: true})
+		for (const self of Object.values(cookie))
+			self.remove({
+				path: '/',
+				domain: 'elysiajs.com',
+				sameSite: 'lax',
+				secure: true
+			})
 
 		return 'Deleted'
 	})
@@ -150,7 +156,9 @@ describe('Cookie Response', () => {
 			})
 		)
 
-		expect(getCookies(response)[0]).toInclude(`council=; Max-Age=0; Expires=${new Date(0).toUTCString()}`)
+		expect(getCookies(response)[0]).toInclude(
+			`council=; Max-Age=0; Expires=${new Date(0).toUTCString()}`
+		)
 	})
 
 	it('remove cookie with options', async () => {
@@ -171,7 +179,11 @@ describe('Cookie Response', () => {
 			})
 		)
 
-		expect(getCookies(response)[0]).toInclude(`council=; Max-Age=0; Domain=elysiajs.com; Path=/; Expires=${new Date(0).toUTCString()}; Secure; SameSite=Lax`)
+		expect(getCookies(response)[0]).toInclude(
+			`council=; Max-Age=0; Domain=elysiajs.com; Path=/; Expires=${new Date(
+				0
+			).toUTCString()}; Secure; SameSite=Lax`
+		)
 	})
 
 	it('sign cookie', async () => {


### PR DESCRIPTION
When deleting a cookie, you need to match all attributes (path, domain, secure, sameSite) too, else you might run into issues with removing a cookie.

For example Firefox does not immaterially delete the cookie, if `path` is set on creation, but not on delete.

Since I thought the implementation for this is rather straight forward I didn't start a discussion about it. Let me know if something is wrong and I'll update it :)

This PR is related to #255 but that issue is more about `@elysiajs/cookie`.