### PR TITLE
Allow 'true' as option for Record-type params

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -168,7 +168,9 @@ export type UnwrapRoute<
 	> extends infer A extends Record<string, any>
 		? A
 		: undefined
-	params: UnwrapSchema<
+	params: Schema['params'] extends true
+	?  Record<string, string>
+	: UnwrapSchema<
 		Schema['params'],
 		Definitions
 	> extends infer A extends Record<string, any>
@@ -316,7 +318,7 @@ export interface InputSchema<Name extends string = string> {
 	body?: TSchema | Name
 	headers?: TObject | Name
 	query?: TObject | Name
-	params?: TObject | Name
+	params?: TObject | Name | true
 	cookie?: TObject | Name
 	response?:
 		| TSchema


### PR DESCRIPTION
This would enable the following syntax:

```ts
// Let's assume this returns an array of paths like
// ['/some/:path', '/some/other/route']
// And that the files in the pages/ folder all export some Handlers
const dynamicRoutes = glob("pages/**/index.tsx");

const app = new Elysia();

dynamicRoutes.map(path =>
  app.
    .get(path, (ctx) => {
        // ctx.params is of type Record<string, string>
      },
      {
        params: true
      }
    )
)
```

While at the moment you get:.

```ts
const app = new Elysia()
  .get('/whatever/route/with/maybe/params' as string,
  (ctx) => {
    // ctx.params is of type never
  })
```

Which would greatly enable the flexibility of Elysia, particularly when it comes to building frameworks on top of it. Handlers can then have their own inner validation of the params.