### PR TITLE
Fix Unable to dereference schema with  'undefined' when using t.Ref

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,7 +168,7 @@ export const getSchemaValidator = (
 			Code: () => ''
 		} as unknown as TypeCheck<TSchema>
 
-	return TypeCompiler.Compile(schema)
+	return TypeCompiler.Compile(schema, Object.values(models))
 }
 
 export const getResponseSchemaValidator = (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,7 +188,7 @@ export const getResponseSchemaValidator = (
 
 	const maybeSchemaOrRecord = typeof s === 'string' ? models[s] : s
 
-	const compile = (schema: TSchema) => {
+	const compile = (schema: TSchema, references?: TSchema[]) => {
 		if (dynamic)
 			return {
 				schema,
@@ -200,7 +200,7 @@ export const getResponseSchemaValidator = (
 				Code: () => ''
 			} as unknown as TypeCheck<TSchema>
 
-		return TypeCompiler.Compile(schema)
+		return TypeCompiler.Compile(schema, references)
 	}
 
 	if (Kind in maybeSchemaOrRecord) {
@@ -208,7 +208,7 @@ export const getResponseSchemaValidator = (
 			maybeSchemaOrRecord.additionalProperties = additionalProperties
 
 		return {
-			200: compile(maybeSchemaOrRecord)
+			200: compile(maybeSchemaOrRecord, Object.values(models))
 		}
 	}
 
@@ -224,7 +224,7 @@ export const getResponseSchemaValidator = (
 					'additionalProperties' in schema === false
 
 				// Inherits model maybe already compiled
-				record[+status] = Kind in schema ? compile(schema) : schema
+				record[+status] = Kind in schema ? compile(schema, Object.values(models)) : schema
 			}
 
 			return undefined
@@ -239,7 +239,7 @@ export const getResponseSchemaValidator = (
 		// Inherits model maybe already compiled
 		record[+status] =
 			Kind in maybeNameOrSchema
-				? compile(maybeNameOrSchema)
+				? compile(maybeNameOrSchema, Object.values(models))
 				: maybeNameOrSchema
 	})
 


### PR DESCRIPTION
When I define a typebox object with `$id` at `Elysia.model` and I use `t.Ref` in hooks then it will throw the error `Unable to dereference schema with $id 'undefined'` when starting the server.

This PR will add model references to TypeCompiler.Compile to fix this issue.

Error example:

```
new Elysia()
    .model({
        user: t.Object(
            {
                id: t.Number()
            },
            {
                $id: "user"
            }
        )
    })
    .get(
        "/",
        () => ({
            success: true,
            data: {
                id: 1
            }
        }),
        {
            response: {
                200: t.Object({
                    success: t.Boolean(),
                    data: t.Ref("user")
                })
            }
        }
    )
    .listen(3000)
```