### PR TITLE
reexport TSchema from typebox

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3338,4 +3338,4 @@ export type {
 	TraceStream
 } from './types'
 
-export type { Static } from '@sinclair/typebox'
+export type { Static, TSchema } from '@sinclair/typebox'


### PR DESCRIPTION
I need it to make a generic schema in Deno and can't import from `esm.sh/@sinclair/typebox` because it isn't compatible with the types from `esm.sh/elysia` (they use unique symbols internally)