### PR TITLE
fix: preserve query params for mounted handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
 	mergeLifeCycle,
 	filterGlobalHook,
 	asGlobal,
-	getHostname
+	replaceUrlPath
 } from './utils'
 
 import {
@@ -1695,7 +1695,10 @@ export default class Elysia<
 
 			const handler: Handler<any, any> = async ({ request, path }) =>
 				run(
-					new Request(getHostname(request.url) + path || '/', request)
+					new Request(
+						replaceUrlPath(request.url, path || '/'),
+						request
+					)
 				)
 
 			this.all('/', handler as any, {
@@ -1712,7 +1715,7 @@ export default class Elysia<
 		const handler: Handler<any, any> = async ({ request, path }) =>
 			handle!(
 				new Request(
-					getHostname(request.url) + path.slice(length) || '/',
+					replaceUrlPath(request.url, path.slice(length) || '/'),
 					request
 				)
 			)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,11 @@ import type {
 const isObject = (item: any): item is Object =>
 	item && typeof item === 'object' && !Array.isArray(item)
 
-export const getHostname = (url: string) => url.slice(0, url.indexOf('/', 11))
+export const replaceUrlPath = (url: string, pathname: string) => {
+	const urlObject = new URL(url)
+	urlObject.pathname = pathname
+	return urlObject.toString()
+}
 
 const isClass = (v: Object) =>
 	(typeof v === 'function' && /^\s*class\s+/.test(v.toString())) ||

--- a/test/core/mount.test.ts
+++ b/test/core/mount.test.ts
@@ -14,4 +14,15 @@ describe('Mount', () => {
 				.then((x) => x.text())
 		).toBe('http://elysiajs.com/')
 	})
+	it('preserve request URL with query', async () => {
+		const plugin = new Elysia().get('/', ({ request }) => request.url)
+
+		const app = new Elysia().mount('/mount', plugin.handle)
+
+		expect(
+			await app
+				.handle(new Request('http://elysiajs.com/mount/?a=1'))
+				.then((x) => x.text())
+		).toBe('http://elysiajs.com/?a=1')
+	})
 })


### PR DESCRIPTION
Query parameters weren't preserved for a mounted handler. This was because the new request url passed to the handler was assembled using only the hostname and path.

This fixes  #329