### PR TITLE
fix: guard sandbox did not inherit global config.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1276,7 +1276,10 @@ export default class Elysia<
 			return this
 		}
 
-		const instance = new Elysia<any>()
+		const instance = new Elysia<any>({
+			...this.config,
+			prefix: ''
+		})
 		instance.store = this.store
 
 		const sandbox = run(instance)


### PR DESCRIPTION
I haven't encountered any issues with the previous code. However, in the group feature section, there is a sandbox instance that creates a new Elysia instance with the configuration of the previous instance. The group operates somewhat like a guard, so the guard should create a sandbox instance in a same way of group.

This seems to relate to #323.