### PR TITLE
fix: display the correct error message when calling .listen outside of bun

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3973,7 +3973,10 @@ export default class Elysia<
 		options: string | number | Partial<Serve>,
 		callback?: ListenCallback
 	) => {
-		if (!Bun) throw new Error('Bun to run')
+		if (typeof Bun === 'undefined')
+			throw new Error(
+				'.listen() is designed to run on Bun only. If you are running Elysia in other environment please use a dedicated plugin or export the handler via Elysia.fetch'
+			)
 
 		this.compile()
 
@@ -4012,11 +4015,6 @@ export default class Elysia<
 						fetch,
 						error: this.outerErrorHandler
 				  } as Serve)
-
-		if (typeof Bun === 'undefined')
-			throw new Error(
-				'.listen() is designed to run on Bun only. If you are running Elysia in other environment please use a dedicated plugin or export the handler via Elysia.fetch'
-			)
 
 		this.server = Bun?.serve(serve)
 


### PR DESCRIPTION
There was code to display this message but it didn't get hit because a second check which wasn't written correctly errors out first.

```diff
- ReferenceError: Bun is not defined
+ Error: .listen() is designed to run on Bun only. If you are running Elysia in other environment please use a dedicated plugin or export the handler via Elysia.fetch
```

Tested manually in Node. Attempted to test in Deno but their `--unstable-byonm` flag didn't seem to work, though it is possible to load the library through npm.