### PR TITLE
Fix: Websocket ID not the same for `open` and `close` functions

### DIFF
--- a/example/websocket.ts
+++ b/example/websocket.ts
@@ -5,6 +5,10 @@ const app = new Elysia()
 	.ws('/ws', {
 		open(ws) {
 			ws.subscribe('asdf')
+			console.log('Open Connection:', ws.id)
+		},
+		close(ws) {
+			console.log('Closed Connection:', ws.id)
 		},
 		message(ws, message) {
 			ws.publish('asdf', message)

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -7,6 +7,7 @@ import { ValidationError } from '../error'
 import type { Context } from '../context'
 
 import type { DecoratorBase, RouteSchema } from '../types'
+import { randomInt } from 'crypto'
 
 export const websocket: WebSocketHandler<any> = {
 	open(ws) {
@@ -25,6 +26,7 @@ export const websocket: WebSocketHandler<any> = {
 
 export class ElysiaWS<
 	WS extends ServerWebSocket<{
+		id?: number
 		validator?: TypeCheck<TSchema>
 	}>,
 	Route extends RouteSchema = RouteSchema,
@@ -35,12 +37,17 @@ export class ElysiaWS<
 		resolve: {}
 	}
 > {
-	id: number
+	get id(): number {
+		return this.raw.data.id as number
+	}
+	set id(newID: number) {
+		this.raw.data.id = newID
+	}
 	validator?: TypeCheck<TSchema>
 
 	constructor(public raw: WS, public data: Context<Route, Decorators>) {
 		this.validator = raw.data.validator
-		this.id = Date.now()
+		this.id = raw.data.id ?? randomInt(Number.MAX_SAFE_INTEGER)
 	}
 
 	get publish() {


### PR DESCRIPTION
## Bug

This is to address this issue #381

When `open` and `close` functions are run, the passed `ElysiaWS` objects are different. This is due to the fact that each time `open`/`close` is run they recreate the `ElysiaWS` object which recreates the ID:

![image](https://github.com/elysiajs/elysia/assets/14119482/176556cd-54f3-4ade-ab27-92cd7bd89900)

And here's the offending code `src/index.ts:3234` and `src/index.ts:3264`:

![image](https://github.com/elysiajs/elysia/assets/14119482/3534a388-d38b-4ccb-bf8c-1b59e141db88)

The fix I came to that doesn't break anything really is to use a getter/setter for the `id` prop on `ElysiaWS` class and storing the id in the raw bunjs/uWebSocket socket (`ElysiaWS.raw`).

## Moving away from `Date.now()`

You'll probably notice that I used `randomInt()` instead of `Date.now()`. This is because if you run `Date.now()`/`performance.now()` you'll notice that there are duplicates. Of course `performance.now()` has less duplicates but still for a simple test with only 100 iterations the best I could get was 97-98 none-duplicates.

I tried different solutions like `Date.now() + Math.random()` but still got duplicates. So `crypto`'s `randomInt` was the best I could find, had 100% success rate when creating unique IDs. But if you can think of a better more efficient solution, please do share.

Here's how I got to this solution, in case you end up trying to find a simpler answer:

- Just change the ID back to the correct one after creating `ElysiaWS` object in `close` function. (Problem was where does one store IDs and how does one get the ID back)
- Create `Map` with raw socket as key and ID as value. (whilst doing this I found the `data` prop in raw socket, ended up running with that instead)