### PR TITLE
fix: prevent information loss in string to number conversion

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -2,7 +2,7 @@
 import { parse } from 'cookie'
 import type { Context } from './context'
 
-import { isNumericString, unsignCookie } from './utils'
+import { isParseableNumericString, unsignCookie } from './utils';
 import { InvalidCookieSignature } from './error'
 
 export interface CookieOptions {
@@ -431,7 +431,7 @@ export const parseCookie = async (
 			}
 
 		// @ts-ignore
-		if (isNumericString(value)) value = +value
+		if (isParseableNumericString(value)) value = +value
 		// @ts-ignore
 		else if (value === 'true') value = true
 		// @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {
 	traceBackMacro,
 	replaceUrlPath,
 	primitiveHooks,
-	isNumericString
+	isParseableNumericString
 } from './utils'
 
 import {
@@ -3200,7 +3200,7 @@ export default class Elysia<
 					} catch {
 						// Not empty
 					}
-				else if (isNumericString(message)) message = +message
+				else if (isParseableNumericString(message)) message = +message
 			}
 
 			if (transform?.length)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -585,3 +585,8 @@ export const traceBackMacro = (
 
 export const isNumericString = (message: string) =>
 	!Number.isNaN(parseInt(message))
+
+export const isParseableNumericString = (message: string) => {
+	if (!isNumericString(message)) return false
+	return (+message).toString() === message
+}


### PR DESCRIPTION
Closes #410

Fixes cases when numeric string value should stay as string such as long tokens with numeric values like:

- `0000000000000000000000000000000000000000`
- `1111111111111111111111111111111111111111`