### PR TITLE
Fixed issue where query params with + sign did not get converted to a…

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -734,7 +734,8 @@ export const composeHandler = ({
 
 		if (!referenceFullQuery && destructured.length) {
 			fnLiteral += `if(c.qi !== -1) {
-				const url = decodeURIComponent(c.request.url.slice(c.qi + 1))
+				const requestUrl = c.request.url.slice(c.qi + 1).replaceAll('+', ' ')
+				const url = decodeURIComponent(requestUrl)
 				let memory = 0
 
 				${destructured

--- a/test/path/path.test.ts
+++ b/test/path/path.test.ts
@@ -126,6 +126,13 @@ describe('Path', () => {
 		expect(await res.text()).toBe('Shirakami Fubuki')
 	})
 
+	it('parse a querystring with a space', async () => {
+		const app = new Elysia().get('/', ({ query: { id } }) => id)
+		const res = await app.handle(req('/?id=test+123%2B'))
+
+		expect(await res.text()).toBe('test 123+')
+	})
+
 	it('handle body', async () => {
 		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.String()


### PR DESCRIPTION
Currently when the query param ?id=test+123%2B is part of the URL the query will return with the + sign instead of a space.

As seen here: Chrome just replaces the + with a space: https://chromium.googlesource.com/chromium/src.git/+/62.0.3178.1/third_party/google_input_tools/third_party/closure_library/closure/goog/string/string.js?autodive=0%2F%2F%2F%2F#486

Added a test to verify it works as expected.