### PR TITLE
fix(handler.ts): empty body custom response when set.headers is empty

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -329,9 +329,9 @@ export const mapResponse = (
 
 			default:
 				if (response instanceof Response)
-					return new Response(JSON.stringify(response), {
+					return new Response(response.body, {
 						headers: {
-							'content-type': 'application/json'
+							'Content-Type': 'application/json'
 						}
 					})
 
@@ -584,9 +584,9 @@ export const mapEarlyResponse = (
 
 			default:
 				if (response instanceof Response)
-					return new Response(JSON.stringify(response), {
+					return new Response(response.body, {
 						headers: {
-							'content-type': 'application/json'
+							'Content-Type': 'application/json'
 						}
 					})
 
@@ -676,9 +676,9 @@ export const mapCompactResponse = (response: unknown): Response => {
 
 		default:
 			if (response instanceof Response)
-				return new Response(JSON.stringify(response), {
+				return new Response(response.body, {
 					headers: {
-						'content-type': 'application/json'
+						'Content-Type': 'application/json'
 					}
 				})
 

--- a/test/response/custom-response.test.ts
+++ b/test/response/custom-response.test.ts
@@ -1,0 +1,41 @@
+import { Elysia } from '../../src'
+import { describe, expect, it } from 'bun:test'
+import { req } from '../utils'
+
+
+class CustomResponse extends Response { }
+
+describe('Custom Response Type', () => {
+    it('returns custom response when set headers is not empty', async () => {
+        const app = new Elysia()
+            .get('/', ({ set }) => {
+                set.headers['X-POWERED-BY'] = 'Elysia'
+                return new CustomResponse('Shuba Shuba', {
+                    headers: {
+                        duck: 'shuba duck'
+                    },
+                    status: 418
+                })
+            })
+            .listen(8080)
+
+        const response = await app.handle(req('/'))
+
+        expect(await response.text()).toBe('Shuba Shuba')
+        expect(response.headers.get('duck')).toBe('shuba duck')
+        expect(response.headers.get('X-POWERED-BY')).toBe('Elysia')
+        expect(response.status).toBe(418)
+    })
+
+    it('returns custom response when set headers is empty', async () => {
+        const app = new Elysia()
+            .get('/', () => {
+                return new CustomResponse('Shuba Shuba')
+            })
+            .listen(8080)
+
+        const response = await app.handle(req('/'))
+
+        expect(await response.text()).toBe('Shuba Shuba')
+    })
+})

--- a/test/units/map-compact-response.test.ts
+++ b/test/units/map-compact-response.test.ts
@@ -6,6 +6,8 @@ class Student {
 	constructor(public name: string) {}
 }
 
+class CustomResponse extends Response {}
+
 describe('Map Compact Response', () => {
 	it('map string', async () => {
 		const response = mapCompactResponse('Shiroko')
@@ -104,6 +106,14 @@ describe('Map Compact Response', () => {
 
 	it('map Response', async () => {
 		const response = mapCompactResponse(new Response('Shiroko'))
+
+		expect(response).toBeInstanceOf(Response)
+		expect(await response.text()).toEqual('Shiroko')
+		expect(response.status).toBe(200)
+	})
+
+	it('map custom Response', async () => {
+		const response = mapCompactResponse(new CustomResponse('Shiroko'))
 
 		expect(response).toBeInstanceOf(Response)
 		expect(await response.text()).toEqual('Shiroko')

--- a/test/units/map-response.test.ts
+++ b/test/units/map-response.test.ts
@@ -21,6 +21,8 @@ class Student {
 	constructor(public name: string) {}
 }
 
+class CustomResponse extends Response {}
+
 describe('Map Response', () => {
 	it('map string', async () => {
 		const response = mapResponse('Shiroko', defaultContext)
@@ -120,6 +122,14 @@ describe('Map Response', () => {
 
 	it('map Response', async () => {
 		const response = mapResponse(new Response('Shiroko'), defaultContext)
+
+		expect(response).toBeInstanceOf(Response)
+		expect(await response.text()).toEqual('Shiroko')
+		expect(response.status).toBe(200)
+	})
+
+	it('map custom Response', async () => {
+		const response = mapResponse(new CustomResponse('Shiroko'), defaultContext)
 
 		expect(response).toBeInstanceOf(Response)
 		expect(await response.text()).toEqual('Shiroko')


### PR DESCRIPTION
Fixes: #421 
Related: #422 

@saltyaom Thanks for applying #422 , however there was a small bug where the response is still empty when set.headers is empty. This PR applies the fix for that.