### PR TITLE
Add test for #issue397

### DIFF
--- a/test/core/scoped.test.ts
+++ b/test/core/scoped.test.ts
@@ -71,8 +71,8 @@ describe('Scoped', () => {
 
 	it('multible scoped events', async () => {
 
-		const first = new Elysia({ scoped: true }).get("/first", () => "first");
-		const second = new Elysia({ scoped: true }).get("/second", () => "second");
+		const first = new Elysia({ name: "first", scoped: true }).get("/first", () => "first");
+		const second = new Elysia({name: "second", scoped: true }).get("/second", () => "second");
 
 		const app = new Elysia().use(first).use(second);
 

--- a/test/core/scoped.test.ts
+++ b/test/core/scoped.test.ts
@@ -49,26 +49,6 @@ describe('Scoped', () => {
 		expect(count).toBe(1)
 	})
 
-	it('encapsulate request event', async () => {
-		let count = 0
-
-		const scoped = new Elysia({
-			name: 'scoped',
-			scoped: true
-		})
-			.onRequest(() => {
-				count++
-			})
-			.get('/scoped', () => 'A')
-
-		const app = new Elysia().use(scoped).get('/', () => 'A')
-
-		await app.handle(req('/'))
-		await app.handle(req('/scoped'))
-
-		expect(count).toBe(1)
-	})
-
 	it('encapsulate afterhandle event', async () => {
 		let count = 0
 

--- a/test/core/scoped.test.ts
+++ b/test/core/scoped.test.ts
@@ -68,4 +68,22 @@ describe('Scoped', () => {
 
 		expect(count).toBe(1)
 	})
+
+	it('multible scoped events', async () => {
+
+		const first = new Elysia({ scoped: true }).get("/first", () => "first");
+		const second = new Elysia({ scoped: true }).get("/second", () => "second");
+
+		const app = new Elysia().use(first).use(second).listen(3000);
+
+		const firstResponse = await app.handle(req("/first"))
+		const secondResponse = await app.handle(req("/second"))
+
+		const firstText = await firstResponse.text()
+		const secondText = await secondResponse.text()
+
+		expect(firstText).toBe("first")
+		expect(secondText).toBe("second")
+	})
+
 })

--- a/test/core/scoped.test.ts
+++ b/test/core/scoped.test.ts
@@ -74,13 +74,13 @@ describe('Scoped', () => {
 		const first = new Elysia({ scoped: true }).get("/first", () => "first");
 		const second = new Elysia({ scoped: true }).get("/second", () => "second");
 
-		const app = new Elysia().use(first).use(second).listen(3000);
+		const app = new Elysia().use(first).use(second);
 
-		const firstResponse = await app.handle(req("/first"))
-		const secondResponse = await app.handle(req("/second"))
+		const firstResponse = await app.handle(req("/first"));
+		const secondResponse = await app.handle(req("/second"));
 
-		const firstText = await firstResponse.text()
-		const secondText = await secondResponse.text()
+		const firstText = await firstResponse.text();
+		const secondText = await secondResponse.text();
 
 		expect(firstText).toBe("first")
 		expect(secondText).toBe("second")


### PR DESCRIPTION
This merge request adds a test to cover the issue mentioned in #397.

Below is the test. It was inspired from @rimelke who commented on the issue.

``` ts
it('multible scoped events', async () => {

	const first = new Elysia({ name: "first", scoped: true }).get("/first", () => "first");
	const second = new Elysia({name: "second", scoped: true }).get("/second", () => "second");

	const app = new Elysia().use(first).use(second);

	const firstResponse = await app.handle(req("/first"));
	const secondResponse = await app.handle(req("/second"));

	const firstText = await firstResponse.text();
	const secondText = await secondResponse.text();

	expect(firstText).toBe("first")
	expect(secondText).toBe("second")
})
```

Note i also removed a dublicate test found at https://github.com/elysiajs/elysia/blob/1b3b9243cccd9ff2536c5b40f99a12ffae964ddd/test/core/scoped.test.ts#L32-L70