### PR TITLE
fixes elysiajs/elysia#458 , fixes elysiajs/elysia/#457

### DIFF
--- a/example/http.ts
+++ b/example/http.ts
@@ -1,124 +1,17 @@
-import { Elysia, t } from '../src'
-
-const t1 = performance.now()
-const loggerPlugin = new Elysia()
-	.get('/hi', () => 'Hi')
-	.decorate('log', () => 'A')
-	.decorate('date', () => new Date())
-	.state('fromPlugin', 'From Logger')
-	.use((app) => app.state('abc', 'abc'))
+import { Elysia } from '../src'
 
 const app = new Elysia()
-	.onRequest(({ set }) => {
-		set.headers = {
-			'Access-Control-Allow-Origin': '*'
-		}
-	})
-	.use(loggerPlugin)
-	.state('build', Date.now())
-	.get('/', () => 'Elysia')
-	.get('/tako', () => Bun.file('./example/takodachi.png'))
-	.get('/json', () => ({
-		hi: 'world'
-	}))
-	.get('/root/plugin/log', ({ log, store: { build } }) => {
-		log()
 
-		return build
-	})
-	.get('/wildcard/*', () => 'Hi Wildcard')
-	.get('/query', () => 'Elysia', {
-		beforeHandle: ({ query, log }) => {
-			console.log('Name:', query?.name)
+const plugin = new Elysia({
+	prefix: '/plugin',
+	scoped: true
+}).get('/testPrivate', () => 'OK')
 
-			if (query?.name === 'aom') return 'Hi saltyaom'
-		},
-		query: t.Object({
-			name: t.String()
-		})
-	})
-	.post('/json', async ({ body }) => body, {
-		body: t.Object({
-			name: t.String(),
-			additional: t.String()
-		})
-	})
-	.post('/transform-body', async ({ body }) => body, {
-		beforeHandle: (ctx) => {
-			ctx.body = {
-				...ctx.body,
-				additional: 'Elysia'
-			}
-		},
-		body: t.Object({
-			name: t.String(),
-			additional: t.String()
-		})
-	})
-	.get('/id/:id', ({ params: { id } }) => id, {
-		transform({ params }) {
-			params.id = +params.id
-		},
-		params: t.Object({
-			id: t.Number()
-		})
-	})
-	.post('/new/:id', async ({ body, params }) => body, {
-		params: t.Object({
-			id: t.Number()
-		}),
-		body: t.Object({
-			username: t.String()
-		})
-	})
-	.get('/trailing-slash', () => 'A')
-	.group('/group', (app) => {
-		return app
-			.onBeforeHandle<{
-				query: {
-					name: string
-				}
-			}>(({ query }) => {
-				if (query?.name === 'aom') return 'Hi saltyaom'
-			})
-			.get('/', () => 'From Group')
-			.get('/hi', () => 'HI GROUP')
-			.get('/elysia', () => 'Welcome to Elysian Realm')
-			.get('/fbk', () => 'FuBuKing')
-	})
-	.get('/response-header', ({ set }) => {
-		set.status = 404
-		set.headers['a'] = 'b'
+const plugin2 = new Elysia({
+	prefix: '/plugindeep',
+	scoped: true
+}).get('/testPrivate', () => 'OK')
 
-		return 'A'
-	})
-	.get('/this/is/my/deep/nested/root', () => 'Hi')
-	.get('/build', ({ store: { build } }) => build)
-	.get('/ref', ({ date }) => date())
-	.get('/response', () => new Response('Hi'))
-	.get('/error', () => new Error('Something went wrong'))
-	.get('/401', ({ set }) => {
-		set.status = 401
+app.use(plugin).use(plugin2)
 
-		return 'Status should be 401'
-	})
-	.get('/timeout', async () => {
-		await new Promise((resolve) => setTimeout(resolve, 2000))
-
-		return 'A'
-	})
-	.all('/all', () => 'hi')
-	.onError(({ code, error, set }) => {
-		if (code === 'NOT_FOUND') {
-			set.status = 404
-
-			return 'Not Found :('
-		}
-	})
-	.listen(8080, ({ hostname, port }) => {
-		console.log(`🦊 Elysia is running at http://${hostname}:${port}`)
-	})
-
-const t2 = performance.now()
-
-console.log('took', t2 - t1, 'ms')
+app.listen(9001)

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ export default class Elysia<
 					? path
 					: `/${path}`
 
-			if (this.config.prefix && !skipPrefix)
+			if (this.config.prefix && !skipPrefix && !this.config.scoped)
 				path = this.config.prefix + path
 
 			if (localHook?.type)
@@ -1896,7 +1896,20 @@ export default class Elysia<
 
 			if (plugin.config.aot) plugin.compile()
 
-			const instance = this.mount(plugin.fetch)
+			if (isScoped && !plugin.config.prefix) {
+				console.warn(
+					'When using scoped plugins it is recommended to use a prefix, else routing may not work correctly for the second scoped instance'
+				)
+			}
+
+			let instance
+
+			if (isScoped && plugin.config.prefix) {
+				instance = this.mount(plugin.config.prefix + '/', plugin.fetch)
+			} else {
+				instance = this.mount(plugin.fetch)
+			}
+
 			this.routes = this.routes.concat(instance.routes)
 
 			return this

--- a/test/scoped/scoped.test.ts
+++ b/test/scoped/scoped.test.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { describe, expect, it } from 'bun:test'
+import Elysia from '../../src'
+import { req } from '../utils'
+
+describe('Scope', () => {
+	it('Multiple scopes registering all routes', async () => {
+		const app = new Elysia()
+
+		const plugin = new Elysia({
+			prefix: 'Plugin',
+			scoped: true
+		}).get('/testPrivate', () => 'OK')
+
+		const plugin2 = new Elysia({
+			prefix: 'PluginNext',
+			scoped: true
+		}).get('/testPrivate', () => 'OK')
+
+		app.use(plugin).use(plugin2)
+
+		const res = await app.handle(req('/Plugin/testPrivate'))
+
+		expect(res.status).toBe(200)
+
+		const res1 = await app.handle(req('/PluginNext/testPrivate'))
+		expect(res1.status).toBe(200)
+	})
+})


### PR DESCRIPTION
- scoped plugin instances now respect the prefix property. 
- adding a second scoped plugin does not unmount the route handler of a previously added scoped instance anymore. 
In order for this to function a prefix has to be used. 

All tests as welll as my new test are passing. I didn't do perform manual tests for functionalities like `guard` which also was bugged.

````typescript
const app = new Elysia();

const plugin = new Elysia({
  prefix: "Plugin",
  scoped: true,
}).get("/testPrivate", () => "OK");

const plugin2 = new Elysia({
  prefix: "PluginNext",
  scoped: true,
}).get("/testPrivate", () => "OK");

app.use(plugin).use(plugin2);

const res = await app.handle(req("/Plugin/testPrivate"));

expect(res.status).toBe(200);

const res1 = await app.handle(req("/PluginNext/testPrivate"));
expect(res1.status).toBe(200);
````
resolves #458 
resolves #457
