### PR TITLE
Fix #470 & #469

### DIFF
--- a/test/path/plugin.test.ts
+++ b/test/path/plugin.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from '../../src'
+
+describe.only('plugin', () => {
+	it('scoped plugin routes are visible in app.routes', () => {
+		const plugin = new Elysia({ prefix: '/v1', scoped: true })
+			.get('', () => '')
+			.put('/new', () => '')
+
+		const app = new Elysia().use(plugin)
+
+		expect(app.routes.some((r) => r.path === '/v1/new')).toBeTrue()
+	})
+
+	it('plugin routes are visible in app.routes', () => {
+		const plugin = new Elysia({ prefix: '/v1', scoped: false })
+			.get('', () => '')
+			.put('/new', () => '')
+
+		const app = new Elysia().use(plugin)
+
+		expect(app.routes.some((r) => r.path === '/v1/new')).toBeTrue()
+	})
+})

--- a/test/plugins/errorPropagation.test.ts
+++ b/test/plugins/errorPropagation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from '../../src'
+import { req } from '../utils'
+
+describe('Error correctly passed to outer elysia instance', () => {
+	it('Global error handler is run', async () => {
+		let globalHandlerRun = false
+
+		const mainApp = new Elysia().onError(() => {
+			globalHandlerRun = true
+			return 'Fail'
+		})
+
+		const plugin = new Elysia().get('/foo', () => {
+			throw new Error('Error')
+		})
+
+		mainApp.use(plugin)
+
+		const res = await (await mainApp.handle(req('/foo'))).text()
+
+		expect(res).toBe('Fail')
+		expect(globalHandlerRun).toBeTrue()
+	})
+
+	it('Plugin global handler is executed before plugin handler', async () => {
+		//I would expect the plugin error handler to be executed
+
+		let globalHandlerRun = false
+		let localHandlerRun = false
+
+		const mainApp = new Elysia().onError(() => {
+			globalHandlerRun = true
+			return 'Fail'
+		})
+
+		const plugin = new Elysia({
+			prefix: '/a'
+		})
+			.onError(() => {
+				localHandlerRun = true
+				return 'FailPlugin'
+			})
+			.get('/foo', () => {
+				throw new Error('Error')
+			})
+
+		mainApp.use(plugin)
+
+		const res = await (await mainApp.handle(req('/a/foo'))).text()
+
+		expect(res).toBe('Fail')
+		expect(localHandlerRun).toBeFalse()
+		expect(globalHandlerRun).toBeTrue()
+	})
+
+	it('Scoped plugin error handler bails before global handler is executed', async () => {
+		let globalHandlerRun = false
+		let localHandlerRun = false
+
+		const mainApp = new Elysia().onError(() => {
+			globalHandlerRun = true
+			return 'Fail'
+		})
+
+		const plugin = new Elysia({
+			scoped: true,
+			prefix: '/a'
+		})
+			.onError(() => {
+				localHandlerRun = true
+				return 'FailPlugin'
+			})
+			.get('/foo', () => {
+				throw new Error('Error')
+			})
+
+		mainApp.use(plugin)
+
+		const res = await (await mainApp.handle(req('/a/foo'))).text()
+
+		expect(res).toBe('FailPlugin')
+		expect(localHandlerRun).toBeTrue()
+		expect(globalHandlerRun).toBeFalse()
+	})
+
+	it('Scoped plugin error handler is run before global handler', async () => {
+		let globalHandlerRun = false
+		let localHandlerRun = false
+
+		const mainApp = new Elysia().onError(() => {
+			globalHandlerRun = true
+			return 'Fail'
+		})
+
+		const plugin = new Elysia({
+			scoped: true,
+			prefix: '/a'
+		})
+			.onError(() => {
+				localHandlerRun = true
+			})
+			.get('/foo', () => {
+				throw new Error('Error')
+			})
+
+		mainApp.use(plugin)
+
+		const res = await (await mainApp.handle(req('/a/foo'))).text()
+
+		expect(res).toBe('Fail')
+		expect(localHandlerRun).toBeTrue()
+		expect(globalHandlerRun).toBeTrue()
+	})
+})


### PR DESCRIPTION
expose nested scoped plugin routes in app.routes  fixes: elysiajs/elysia#470
run parent error handler if plugin onError completes without handling  fixes: elysiajs/elysia#469

The following code snippet seems to work fine and I didn't notice any regressions. Using the below code global error handlers are now executed as expected, but I did not test other handlers like `onRequest onBeforeHandle, ...` which probably should also be forwarded?  What would be the correct way to fix this?

````
plugin.event.error.push(...this.event.error);
````

Swagger is now working with nested plugins and our tests also seem to pass.

![image](https://github.com/elysiajs/elysia/assets/9025925/3a034ef4-134e-4e48-8b9a-48f85ea998fc)
