### PR TITLE
fix: Numeric Cookie with length >= 16 cant be parsed to number

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -583,4 +583,16 @@ export const traceBackMacro = (
 	}
 }
 
-export const isNumericString = (message: string) => message.trim().length !== 0 && !Number.isNaN(Number(message))
+export const isNumericString = (message: string): boolean => {
+	if (message.length < 16)
+		return message.trim().length !== 0 && !Number.isNaN(Number(message))
+
+	// if 16 digit but less then 9,007,199,254,740,991 then can be parsed
+	if (message.length === 16) {
+		const numVal = Number(message)
+		if (numVal.toString() === message)
+			return message.trim().length !== 0 && !Number.isNaN(numVal)
+	}
+
+	return false
+}

--- a/test/units/numeric.test.ts
+++ b/test/units/numeric.test.ts
@@ -6,6 +6,7 @@ describe('Numeric string', () => {
 		expect(isNumericString('69')).toBe(true)
 		expect(isNumericString('69.420')).toBe(true)
 		expect(isNumericString('00093281')).toBe(true)
+		expect(isNumericString(Number.MAX_SAFE_INTEGER.toString())).toBe(true)
 	})
 
 	it('invalid string', async () => {
@@ -13,6 +14,9 @@ describe('Numeric string', () => {
 		expect(isNumericString('69,420')).toBe(false)
 		expect(isNumericString('0O093281')).toBe(false)
 		expect(isNumericString(crypto.randomUUID())).toBe(false)
+		expect(isNumericString('9007199254740995')).toBe(false)
+		expect(isNumericString('123456789012345678')).toBe(false)
+		expect(isNumericString('123123.999999999999')).toBe(false)
 	})
 
 	it('invalid on empty', async () => {


### PR DESCRIPTION
this fixes #473
in https://github.com/elysiajs/elysia/blob/6fd8753fa2cf45f34a2af7f63a49659a987a87f7/src/utils.ts#L586

added extra checks to  return false if `message.length > 16`
or
double check the string if  `message.length = 16` by converting to string and comparing to message

if less then 16 then do normal checking
```ts
	if (message.length < 16)
		return message.trim().length !== 0 && !Number.isNaN(Number(message))
```

```ts
	// if 16 digit but less then 9,007,199,254,740,991 then can be parsed
	if (message.length === 16) {
		const numVal = Number(message)
		if (numVal.toString() === message)
			return message.trim().length !== 0 && !Number.isNaN(numVal)
	}
```