### PR TITLE
fix: Using a query key that contains a hyphen or a dot raises a SyntaxError

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -753,7 +753,7 @@ export const composeHandler = ({
 					.join('\n')}
 
 				c.query = {
-					${destructured.map((name, index) => `${name}: a${index}`).join(', ')}
+					${destructured.map((name, index) => `'${name}': a${index}`).join(', ')}
 				}
 			} else {
 				c.query = {}

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -16,6 +16,38 @@ describe('Query Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('validate with hyphen in key', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ query }) => query['character-name'],
+			{
+				query: t.Object({
+					'character-name': t.String()
+				})
+			}
+		)
+		const res = await app.handle(req('/?character-name=sucrose'))
+
+		expect(await res.text()).toBe('sucrose')
+		expect(res.status).toBe(200)
+	})
+
+	it('validate with dot in key', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ query }) => query['character.name'],
+			{
+				query: t.Object({
+					'character.name': t.String()
+				})
+			}
+		)
+		const res = await app.handle(req('/?character.name=sucrose'))
+
+		expect(await res.text()).toBe('sucrose')
+		expect(res.status).toBe(200)
+	})
+
 	it('validate multiple', async () => {
 		const app = new Elysia().get('/', ({ query }) => query, {
 			query: t.Object({


### PR DESCRIPTION
Fixes #461 

Fixed a bug in parsing queries that have a hyphen or a dot in its key. The bug was in creating `c.query` in fnLiteral variable in composeHandler function. Fixed by adding single quotes around `${name}` when creating `c.query`.

Also added unit tests for both cases.

First time contributing so feedback is appreciated!