### PR TITLE
Fix callback return types for derive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5183,7 +5183,7 @@ export default class Elysia<
 			>
 		) => MaybePromise<Derivative> extends { store: any }
 			? never
-			: Derivative
+			: MaybePromise<Derivative>
 	): Elysia<
 		BasePath,
 		Scoped,
@@ -5226,7 +5226,7 @@ export default class Elysia<
 			>
 		) => MaybePromise<Derivative> extends { store: any }
 			? never
-			: Derivative
+			: MaybePromise<Derivative>
 	): Scoped extends true
 		? Elysia<
 				BasePath,


### PR DESCRIPTION
The `transform` callback type signature for derive did not allow it to return a promise. This PR fixes that.