### PR TITLE
Cookie removal options now default to the cookie's own options

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -176,6 +176,13 @@ export class Cookie<T = unknown> implements CookieOptions {
 	) {
 		if (this.value === undefined) return
 
+		options ??= {
+			domain: this.domain,
+			path: this.path,
+			sameSite: this.sameSite,
+			secure: this.secure
+		}
+
 		this.set({
 			domain: options?.domain,
 			expires: new Date(0),


### PR DESCRIPTION
Hi there!

I'm not sure whether you'd consider this a bug, but it certainly caused me some confusion in my own project and I think the behaviour is a bit unintuitive:

If a cookie was created with non-default option values (e.g., `secure`, `domain`, `path`) but then those options are left blank/not provided when calling that cookie's `.remove()` method, then the browser (I've tested with Chrome version 121.0.6167.187) won't delete the cookie.

I found that a common pattern in my own code to avoid this problem was to use `cookie.remove(cookie)`, but this seems clunky.

This PR includes a fix which makes the options to the `remove()` method fall back on the cookie's own option values if none are specified.

Note that this fallback only happens if the entire `options` argument to `remove` is `undefined`. You can still provide an `options` argument whose fields have values of `undefined` and those will be honoured.

Thanks :)