### PR TITLE
Merge response schema from parent scope

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,6 +124,21 @@ export const primitiveHooks = [
 	'detail'
 ] as const
 
+function mergeResponses(a: InputSchema['response'], b: InputSchema['response']) {
+	
+	// If both are Record<number, ...> then merge them,
+	// giving preference to b.
+	type RecordNumber = Record<number, any>
+	const isRecordNumber = (x: typeof a | typeof b): x is RecordNumber =>
+		typeof x === 'object' && Object.keys(x).every(isNumericString)
+
+	if (isRecordNumber(a) && isRecordNumber(b)) {
+		return { ...(a as RecordNumber), ...(b as RecordNumber) }
+	}
+
+	return b ?? a;
+}
+
 export const mergeHook = (
 	a?: LocalHook<any, any, any, any> | LifeCycleStore,
 	b?: LocalHook<any, any, any, any>
@@ -170,7 +185,7 @@ export const mergeHook = (
 		// @ts-ignore
 		query: b?.query ?? a?.query,
 		// @ts-ignore
-		response: b?.response ?? a?.response,
+		response: mergeResponses(a?.response, b?.response),
 		type: a?.type || b?.type,
 		detail: mergeDeep(
 			// @ts-ignore


### PR DESCRIPTION
Hello!

This relates to issue #246 and [issue 75 for elysia-swagger](https://github.com/elysiajs/elysia-swagger/issues/75)

## Summary:

If you have a parent scope (from a guard/plugin etc.) whose response schema is specified as a `Record<number, ...>`, and then you have a child scope which exposes another set of responses, e.g.

```typescript
const app = new Elysia()
  .guard({
    response: {
      401: t.String()
    }
  })
  .get(
    '/',
    () => { /* ... */ },
    {
      response: {
        200: t.String()
      }
    }
  )
```

You'd expect that the possible response codes the `/` route can return is `[401, 200]`. However, instead the child overrides the parent and the only possible response code is `200`. This causes issues for API documentation (i.e., using the swagger plugin), in which you might want to document that e.g., all endpoints which sit behind an `auth` guard have the potential to return a 401.

From what I understand, the same issue exists with `body`, `query`, etc., but a workaround exists because those fields are `TObject`s, and so are able to specify `{ additionalProperties: true }`, which results in a deep merge from the parent scope.

This PR contains a fix for this issue for the `response` field: If both parent and child specify `response` as a `Record<number, ...>` then they are shallow merged. If this behaviour is undesirable, the user can explicitly remove an inherited response code by specifying e.g. `401: undefined`.

Thanks!