### PR TITLE
Export InlineError as a type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,8 @@ import {
 	ValidationError,
 	type ParseError,
 	type NotFoundError,
-	type InternalServerError
+	type InternalServerError,
+	inlineError
 } from './error'
 
 import type {
@@ -5049,6 +5050,8 @@ export {
 	InternalServerError,
 	InvalidCookieSignature
 } from './error'
+
+export type InlineError = typeof inlineError
 
 export type { Context, PreContext } from './context'
 


### PR DESCRIPTION
If we want to put our request handlers into separate files, we may want to be able to specify the type for the inlineError handler that we will end up passing in.