### PR TITLE
export LifeCycleType so plugins can offer scope as an option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4982,6 +4982,7 @@ export type {
 	LifeCycleEvent,
 	TraceEvent,
 	LifeCycleStore,
+  LifeCycleType,
 	MaybePromise,
 	ListenCallback,
 	UnwrapSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4982,7 +4982,7 @@ export type {
 	LifeCycleEvent,
 	TraceEvent,
 	LifeCycleStore,
-  LifeCycleType,
+	LifeCycleType,
 	MaybePromise,
 	ListenCallback,
 	UnwrapSchema,


### PR DESCRIPTION
It's useful for plugins that delegate the scope to the users to being able to use the type directly like

```typescript
import { LifeCycleType } from 'elysia';

export interface PluginOptions {
  as?: LifeCycleType;
  // more options
}