### PR TITLE
🔧 fix: parse json body when setting type to json

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -609,12 +609,12 @@ export const composeHandler = ({
 					case 'json':
 					case 'application/json':
 						if (hasErrorHandler)
-							fnLiteral += `const body = await c.request.text()
+							fnLiteral += `const reqBody = await c.request.text()
 							
 							try {
-								c.body = JSON.parse(body)
+								c.body = JSON.parse(reqBody)
 							} catch {
-								throw new ParseError('Failed to parse body as found: ' + (typeof body === "string" ? "'" + body + "'" : body), body)
+								throw new ParseError('Failed to parse body as found: ' + (typeof reqBody === "string" ? "'" + reqBody + "'" : reqBody), reqBody)
 							}`
 						else fnLiteral += `c.body = await c.request.json()`
 						break


### PR DESCRIPTION
Fixes: #542 

Fixes a bug where an error would happen when trying to parse a body and the type is set to `type: "json"` or `type: "application/json"`

The problem was in composed handler where `body` variable in `try` block was used in checking instead of `body` validator.

Fixed by renaming the `body` variable in `try` block to `reqBody`