### PR TITLE
fix: support for module promise in `Elysia#use`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2534,25 +2534,31 @@ export default class Elysia<
 				plugin
 					.then((plugin) => {
 						if (typeof plugin === 'function') {
-							return plugin(
-								this as unknown as any
-							) as unknown as Elysia
+							return plugin(this)
 						}
 
-						if (typeof plugin.default === 'function')
-							return plugin.default(
-								this as unknown as any
-							) as unknown as Elysia
+						if (plugin instanceof Elysia) {
+							return this._use(plugin)
+						}
 
-						return this._use(plugin as any)
+						if (typeof plugin.default === 'function') {
+							return plugin.default(this)
+						}
+
+						if (plugin.default instanceof Elysia) {
+							return this._use(plugin.default)
+						}
+
+						throw new Error(
+							'Invalid plugin type. Expected Elysia instance, function, or module with "default" as Elysia instance or function that returns Elysia instance.'
+						)
 					})
 					.then((x) => x.compile())
 			)
+			return this
+		}
 
-			return this as unknown as any
-		} else return this._use(plugin)
-
-		return this
+		return this._use(plugin)
 	}
 
 	private _use(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2496,7 +2496,7 @@ export default class Elysia<
 	 */
 	use(
 		plugin:
-			| Elysia<any, any, any, any, any, any, any, any>
+			| MaybePromise<Elysia<any, any, any, any, any, any, any, any>>
 			| Elysia<any, any, any, any, any, any, any, any>[]
 			| MaybePromise<
 					(


### PR DESCRIPTION
The following use case was broken: Calling `app.use(import("./routes"))` where the "./routes" module has a default export that is an Elysia instance.

I‘m doing `instanceof Elysia` checks on the promise result and the module‘s "default" export, so a more informative error can be thrown, where before the app would crash with some obscure TypeError with a message of "Right side of assignment cannot be destructured" within the `Elysia#_use` method.