### PR TITLE
fix: shift promise in `PromiseGroup` even when rejected

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -768,10 +768,10 @@ export class PromiseGroup implements PromiseLike<void> {
 		while (this.promises.length > 0) {
 			try {
 				await this.promises[0]
-				this.promises.shift()
 			} catch (error) {
 				this.onError(error)
 			}
+			this.promises.shift()
 		}
 		this.root = null
 	}


### PR DESCRIPTION
This fixes a bug introduced in #549 where a rejected promise wouldn't be removed from its `PromiseGroup` instance.
