### PR TITLE
Fixing "ReadableStream is locked"

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -176,7 +176,9 @@ export const mapResponse = (
 					'abort',
 					{
 						handleEvent() {
-							;(response as ReadableStream).cancel(request)
+							;
+							if (!request?.signal.aborted)
+								(response as ReadableStream).cancel(request)
 						}
 					},
 					{
@@ -302,7 +304,9 @@ export const mapResponse = (
 					'abort',
 					{
 						handleEvent() {
-							;(response as ReadableStream).cancel(request)
+							;
+							if (!request?.signal.aborted)
+								(response as ReadableStream).cancel(request)
 						}
 					},
 					{
@@ -458,7 +462,9 @@ export const mapEarlyResponse = (
 					'abort',
 					{
 						handleEvent() {
-							;(response as ReadableStream).cancel(request)
+							;
+							if (!request?.signal.aborted)
+								(response as ReadableStream).cancel(request)
 						}
 					},
 					{
@@ -588,7 +594,9 @@ export const mapEarlyResponse = (
 					'abort',
 					{
 						handleEvent() {
-							;(response as ReadableStream).cancel(request)
+							;
+							if (!request?.signal.aborted)
+								(response as ReadableStream).cancel(request)
 						}
 					},
 					{
@@ -707,7 +715,9 @@ export const mapCompactResponse = (
 				'abort',
 				{
 					handleEvent() {
-						;(response as ReadableStream).cancel(request)
+						;
+						if (!request?.signal.aborted)
+							(response as ReadableStream).cancel(request)
 					}
 				},
 				{


### PR DESCRIPTION
Fixing error return that cause server stop when the HTTP TEXT Stream is closed by the client before the server close it.
Initial Error:
```
1134 |         request?.signal.addEventListener(
1135 |           "abort",
1136 |           {
1137 |             handleEvent() {
1138 |               ;
1139 |               response.cancel(request);
                           ^
TypeError: ReadableStream is locked
      at cancel (:1:21)
      at handleEvent (/root/Projects/dark-utilities/backend-api/node_modules/elysia/dist/index.mjs:1139:15)
```

How to reproduce ?
```ts
    app.post('/api/v1/device/:id/shell', async ({ jwt, set, headers, request }) => {
        return new Stream(async (controller) => {
            setTimeout(() => {
                controller.send('Hello, World!');
                // client closed the connection at 5000ms before the server could complete the response
                controller.close();
            }, 10000);
        });
    });
 ```