### PR TITLE
⚡️Fixing issues that cause %26 (&) to be interpreted as & (query separator)

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -557,7 +557,7 @@ export const composeHandler = ({
 			!destructured.length
 		) {
 			fnLiteral += `if(c.qi !== -1) {
-				c.query = parseQuery(decodeURIComponent(c.request.url.slice(c.qi + 1)).replace(/\\+/g, ' '))
+				c.query = parseQuery(c.request.url.slice(c.qi + 1))
 			} else c.query = {}`
 		} else {
 			fnLiteral += `if(c.qi !== -1) {


### PR DESCRIPTION
Patch for https://github.com/elysiajs/elysia/issues/567

Before:
`/?foo=b%26r`
```
foo=b
r=
```

After:
`/?foo=b%26r`
```
foo=b&r
```

