### PR TITLE
Fix 204 returning internal server error

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -157,7 +157,7 @@ const composeValidationFactory = (
 
 		let code = '\n' + injectResponse + '\n'
 
-		code += `const er = ${name}[ELYSIA_RESPONSE]\n`
+		code += `const er = ${name} ? ${name}[ELYSIA_RESPONSE] : null\n`
 
 		if (normalize)
 			code += `

--- a/test/response/non-200-response.test.ts
+++ b/test/response/non-200-response.test.ts
@@ -1,0 +1,21 @@
+import { Elysia, t } from '../../src'
+import { describe, expect, it } from 'bun:test'
+import { req } from '../utils'
+
+describe('Non 200 Response Type', () => {
+    it('returns 204', async () => {
+        const app = new Elysia()
+            .get('/', ({ set }) => {
+                set.status = 204
+            }, {
+                response: {
+                    204: t.Undefined()
+                }
+            })
+            .listen(3000)
+
+        const response = await app.handle(req('/'))
+
+        expect(response.status).toBe(204)
+    })
+})

--- a/test/response/non-200-response.test.ts
+++ b/test/response/non-200-response.test.ts
@@ -9,7 +9,7 @@ describe('Non 200 Response Type', () => {
                 set.status = 204
             }, {
                 response: {
-                    204: t.Undefined()
+                    204: t.Void()
                 }
             })
             .listen(3000)


### PR DESCRIPTION
When a route with a 204 would be called it would cause an internal server error with the message: 

> undefined is not an object (evaluating 'r[ELYSIA_RESPONSE]'

```
new Elysia()
.get("/fails", ({ set }) => {
  set.status = 204;
}, {
    response: {
      204: t.Void()
    }
})
```
This PR fixes this and added a test to avoid regression.
