### PR TITLE
Fix: account for non-200 response schemas

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,18 @@ export type UnwrapSchema<
 		: Definitions
 	: unknown
 
+export type SuccessfulResponse<T = unknown> =
+	| { 200: T }
+	| { 201: T }
+	| { 202: T }
+	| { 203: T }
+	| { 204: T }
+	| { 205: T }
+	| { 206: T }
+	| { 207: T }
+	| { 208: T }
+	| { 226: T }
+
 export interface UnwrapRoute<
 	in out Schema extends InputSchema<any>,
 	in out Definitions extends DefinitionBase['type'] = {}
@@ -216,9 +228,7 @@ export interface UnwrapRoute<
 	cookie: UnwrapSchema<Schema['cookie'], Definitions>
 	response: Schema['response'] extends TSchema | string
 		? UnwrapSchema<Schema['response'], Definitions>
-		: Schema['response'] extends {
-				200: TAnySchema | string
-		  }
+		: Schema['response'] extends SuccessfulResponse<TAnySchema | string>
 		? {
 				[k in keyof Schema['response']]: UnwrapSchema<
 					Schema['response'][k],
@@ -393,7 +403,7 @@ export type Handler<
 	Path extends string = ''
 > = (
 	context: Context<Route, Singleton, Path>
-) => Route['response'] extends { 200: unknown }
+) => Route['response'] extends SuccessfulResponse
 	? Response | MaybePromise<Route['response'][keyof Route['response']]>
 	: Response | MaybePromise<Route['response']>
 
@@ -407,9 +417,9 @@ export type InlineHandler<
 	},
 	Path extends string = ''
 > =
-	| ((context: Context<Route, Singleton, Path>) => Route['response'] extends {
-			200: unknown
-	  }
+	| ((
+			context: Context<Route, Singleton, Path>
+	  ) => Route['response'] extends SuccessfulResponse
 			?
 					| Response
 					| MaybePromise<
@@ -427,7 +437,7 @@ export type InlineHandler<
 			: Response | MaybePromise<Route['response']>)
 	| (unknown extends Route['response']
 			? string | number | Object
-			: Route['response'] extends { 200: unknown }
+			: Route['response'] extends SuccessfulResponse
 			? Route['response'][keyof Route['response']]
 			: Route['response'])
 
@@ -937,7 +947,7 @@ type _ComposeElysiaResponse<Response, Handle> = Prettify<
 					? Status
 					: never]: ErrorResponse['response']
 		  }
-		: Response extends { 200: unknown }
+		: Response extends SuccessfulResponse
 		? Response
 		: {
 				200: Response

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1102,6 +1102,8 @@ app.resolve(({ headers }) => {
 	const app = new Elysia()
 		.get('', () => 'a')
 		.get('/true', () => true)
+		.post('', () => 'a', { response: { 201: t.String() } })
+		.post('/true', () => true, { response: { 202: t.Boolean() } })
 		.get('/error', ({ error }) => error("I'm a teapot", 'a'))
 		.post('/mirror', ({ body }) => body)
 		.get('/immutable', '1')
@@ -1124,8 +1126,16 @@ app.resolve(({ headers }) => {
 		200: string
 	}>()
 
+	expectTypeOf<app['index']['post']['response']>().toEqualTypeOf<{
+		201: string
+	}>()
+
 	expectTypeOf<app['true']['get']['response']>().toEqualTypeOf<{
 		200: boolean
+	}>()
+
+	expectTypeOf<app['true']['post']['response']>().toEqualTypeOf<{
+		202: boolean
 	}>()
 
 	expectTypeOf<app['error']['get']['response']>().toEqualTypeOf<{


### PR DESCRIPTION
Allows success responses to derive their schema/type from non-200 status codes.

Fix https://github.com/elysiajs/elysia/issues/592