### PR TITLE
parseQuery is able to return Record<string, string | string[] | undefined>

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -28,7 +28,7 @@ export type Context<
 	{
 		body: Route['body']
 		query: undefined extends Route['query']
-			? Record<string, string | undefined>
+			? Record<string, string | string[] | undefined>
 			: Route['query']
 		params: undefined extends Route['params']
 			? Path extends `${string}/${':' | '*'}${string}`


### PR DESCRIPTION
I've created this PR because [I made a pr to eden](https://github.com/elysiajs/eden/pull/79) and because `fast-querystring` is able to handle arrays in a query string. Elysia uses `fast-querystring` to decode the query strings from requests thus, this more accurately reflects those capabilities.