### PR TITLE
Fix #635 - Use StaticDecode<> instead of Static<> to get type of inpu…

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 import type { Elysia } from '.'
 import type { Serve, Server, WebSocketHandler } from 'bun'
 
-import type { TSchema, TObject, Static, TAnySchema } from '@sinclair/typebox'
+import type { TSchema, TObject, StaticDecode, TAnySchema } from '@sinclair/typebox'
 import type { TypeCheck } from '@sinclair/typebox/compiler'
 
 import type { OpenAPIV3 } from 'openapi-types'
@@ -202,7 +202,7 @@ export type UnwrapSchema<
 > = undefined extends Schema
 	? unknown
 	: Schema extends TSchema
-	? Static<NonNullable<Schema>>
+	? StaticDecode<NonNullable<Schema>>
 	: Schema extends string
 	? Definitions extends Record<Schema, infer NamedSchema>
 		? NamedSchema


### PR DESCRIPTION
…t schema

This will infer the correct type with Typebox Transform Types (https://github.com/sinclairzx81/typebox?tab=readme-ov-file#transform-types) are used