### PR TITLE
fix: cookie decode value might be null

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -350,6 +350,7 @@ export const parseCookie = async (
 			jar[name] = {
 				value: v
 			}
+			continue
 		}
 
 		const start = value.charCodeAt(0)

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -346,6 +346,12 @@ export const parseCookie = async (
 			}
 		}
 
+		if (value == null) {
+			jar[name] = {
+				value: v
+			}
+		}
+
 		const start = value.charCodeAt(0)
 		if (start === 123 || start === 91)
 			try {


### PR DESCRIPTION
For example, if my cookie is 
```  
"cookie": "access-currency-info=%7B%22accessLangList%22%3A%5B%7B%22id%22%3A144%2C%22theDefault%22%3Atrue%2C%22accessLangCode%22%3A%22en-US%22%2C%22accessLangName%22%3A%22English%22%7D%2C%7B%22id%22%3A144%2C%22theDefault%22%3Afalse%2C%22accessLangCode%22%3A%22zh-CN%22%2C%22accessLangName%22%3A%22%u7B80%u4F53%u4E2D%u6587%22%7D%5D%2C%22currencyList%22%3A%5B%7B%22id%22%3A144%2C%22theDefault%22%3Atrue%2C%22currencyCode%22%3A%22MYR%22%2C%22currencyName%22%3A%22%u6797%u5409%u7279%22%2C%22currencySymbol%22%3A%22RM%22%2C%22symbolPosition%22%3A%22L%22%7D%5D%2C%22receiptCountryList%22%3A%5B%7B%22id%22%3A144%2C%22theDefault%22%3Atrue%2C%22receiptCountryCode%22%3A%22143749%22%2C%22receiptCountryName%22%3A%22Malaysia%22%7D%5D%2C%22lang%22%3A%22en-US%22%2C%22accessLangName%22%3A%22English%22%2C%22currency%22%3A%22MYR%22%2C%22channel%22%3A%22SEA_MY%22%2C%22id%22%3A%22SEA_MY%22%2C%22symbol%22%3A%22RM%22%2C%22currencyName%22%3A%22%u6797%u5409%u7279%22%2C%22symbolPosition%22%3A%22L%22%2C%22siteName%22%3A%22%22%2C%22siteCode%22%3A%22%22%2C%22areaName%22%3A%22Malaysia%22%2C%22receiptCountryName%22%3A%22Malaysia%22%2C%22receiptCountryCode%22%3A%22143749%22%2C%22actionType%22%3A%22set%22%7D"
```

it will cause the following exception to occur
```
987 |         }
988 |         if (!decoded)
989 |           throw new InvalidCookieSignature(name);
990 |       }
991 |     }
992 |     const start = value.charCodeAt(0);
                        ^
TypeError: null is not an object (evaluating 'value.charCodeAt')
      at /project/node_modules/.pnpm/elysia@1.0.16_@sinclair+typebox@0.32.20_openapi-types@12.1.3_typescript@5.4.5/node_modules/elysia/dist/index.mjs:992:19
      at parseCookie (/project/node_modules/.pnpm/elysia@1.0.16_@sinclair+typebox@0.32.20_openapi-types@12.1.3_typescript@5.4.5/node_modules/elysia/dist/index.mjs:956:26)
      at handle (:50:32)
      at map (:251:12)
```
