### PR TITLE
Make "isProduction" default to true unless explicitly in development

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -16,7 +16,7 @@ export const ERROR_CODE = Symbol('ElysiaErrorCode')
 export const ELYSIA_RESPONSE = Symbol('ElysiaResponse')
 export type ELYSIA_RESPONSE = typeof ELYSIA_RESPONSE
 
-export const isProduction = (env?.NODE_ENV ?? env?.ENV) === 'production'
+export const isProduction = (env?.NODE_ENV ?? env?.ENV) !== 'development'
 
 export type ElysiaErrors =
 	| InternalServerError


### PR DESCRIPTION
This causes, for example, /bun:info to leak system information, when the NODE_ENV is not explicitly set to production. Some users may use prod, dev, staging, etc., so this fixes that problem.