### PR TITLE
🔧 fix: types in `MaybeEmpty`

### DIFF
--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -412,13 +412,13 @@ export const ElysiaType = {
 				return [value]
 			})
 			.Encode((value) => value),
-	Nullable: <T extends TSchema>(schema: T): TUnion<[T, TNull]> =>
-		t.Union([t.Null(), schema]) as any,
+	Nullable: <T extends TSchema>(schema: T) =>
+		t.Union([t.Null(), schema]),
 	/**
 	 * Allow Optional, Nullable and Undefined
 	 */
-	MaybeEmpty: <T extends TSchema>(schema: T): TUnion<[T, TUndefined]> =>
-		t.Union([t.Null(), t.Undefined(), schema]) as any,
+	MaybeEmpty: <T extends TSchema>(schema: T) =>
+		t.Union([t.Null(), t.Undefined(), schema]),
 	Cookie: <T extends TProperties>(
 		properties: T,
 		{


### PR DESCRIPTION
I remove explicit types and useless any

```ts
Nullable: <T extends TSchema>(schema: T) =>
		t.Union([t.Null(), schema]),
	/**
	 * Allow Optional, Nullable and Undefined
	 */
	MaybeEmpty: <T extends TSchema>(schema: T) =>
		t.Union([t.Null(), t.Undefined(), schema]),
```

The implementation was lying to us in the types and TNull was missing there
```ts
: TUnion<[T, TUndefined]> =>
		t.Union([t.Null(), t.Undefined(), schema]) as any,
```

Until @SaltyAom merge this, you can use the [`bun patch`](https://bun.sh/docs/install/patch)