### PR TITLE
Port can be dynamically configured

### DIFF
--- a/example/port.ts
+++ b/example/port.ts
@@ -1,0 +1,13 @@
+import { Elysia } from '../src'
+
+new Elysia()
+	.decorate('port', 9876)
+	.get('/', () => {
+		return 'hello'
+	})
+	.listen(
+		({ port }) => port,
+		({ hostname, port }) => {
+			console.log(`🦊 running at http://${hostname}:${port}`)
+		}
+	)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5227,7 +5227,7 @@ export default class Elysia<
 	 * ```
 	 */
 	listen = (
-		options: string | number | Partial<Serve>,
+		options: string | number | ((data: Singleton['decorator']) => number | string) | Partial<Serve>,
 		callback?: ListenCallback
 	) => {
 		if (typeof Bun === 'undefined')
@@ -5242,6 +5242,9 @@ export default class Elysia<
 				throw new Error('Port must be a numeric value')
 
 			options = parseInt(options)
+		}
+		if (typeof options === 'function') {
+			options = options(this.decorator)
 		}
 
 		const fetch = this.fetch


### PR DESCRIPTION
decorate is read-only.so It's best for dynamically configuring ports
<img width="763" alt="image" src="https://github.com/user-attachments/assets/7211fa58-acdd-4998-a9e5-03da317dbd3f">
