### PR TITLE
fix: type-system standalone import

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
 	"license": "MIT",
 	"scripts": {
 		"test": "npm run test:functionality && npm run test:types",
-		"test:functionality": "bun test && npm run test:node",
+		"test:functionality": "bun test && bun run test:imports && npm run test:node",
+		"test:imports": "bun run ./test/type-system/import.ts",
 		"test:types": "tsc --project tsconfig.test.json",
 		"test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js && bun dist/bun/index.js",
 		"dev": "bun run --watch example/a.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -520,20 +520,20 @@ export default class Elysia<
 							models,
 							additionalProperties: !this.config.normalize,
 							coerce: true,
-							additionalCoerce: stringToStructureCoercions
+							additionalCoerce: stringToStructureCoercions()
 						}),
 						params: getSchemaValidator(cloned.params, {
 							dynamic,
 							models,
 							coerce: true,
-							additionalCoerce: stringToStructureCoercions
+							additionalCoerce: stringToStructureCoercions()
 						}),
 						query: getSchemaValidator(cloned.query, {
 							dynamic,
 							models,
 							normalize,
 							coerce: true,
-							additionalCoerce: stringToStructureCoercions
+							additionalCoerce: stringToStructureCoercions()
 						}),
 						cookie: cookieValidator(),
 						response: getResponseSchemaValidator(cloned.response, {
@@ -565,7 +565,8 @@ export default class Elysia<
 									models,
 									additionalProperties: !normalize,
 									coerce: true,
-									additionalCoerce: stringToStructureCoercions
+									additionalCoerce:
+										stringToStructureCoercions()
 								}
 							))
 						},
@@ -578,7 +579,8 @@ export default class Elysia<
 									dynamic,
 									models,
 									coerce: true,
-									additionalCoerce: stringToStructureCoercions
+									additionalCoerce:
+										stringToStructureCoercions()
 								}
 							))
 						},
@@ -591,7 +593,8 @@ export default class Elysia<
 									dynamic,
 									models,
 									coerce: true,
-									additionalCoerce: stringToStructureCoercions
+									additionalCoerce:
+										stringToStructureCoercions()
 								}
 							))
 						},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -781,17 +781,24 @@ export const checksum = (s: string) => {
 	return (h = h ^ (h >>> 9))
 }
 
-export const stringToStructureCoercions = [
-	{
-		from: t.Object({}),
-		to: () => t.ObjectString({}),
-		excludeRoot: true
-	},
-	{
-		from: t.Array(t.Any()),
-		to: () => t.ArrayString(t.Any())
+let _stringToStructureCoercions: ReplaceSchemaTypeOptions[]
+
+export const stringToStructureCoercions = () => {
+	if (!_stringToStructureCoercions) {
+		_stringToStructureCoercions = [
+			{
+				from: t.Object({}),
+				to: () => t.ObjectString({}),
+				excludeRoot: true
+			},
+			{
+				from: t.Array(t.Any()),
+				to: () => t.ArrayString(t.Any())
+			}
+		] satisfies ReplaceSchemaTypeOptions[]
 	}
-] satisfies ReplaceSchemaTypeOptions[]
+	return _stringToStructureCoercions
+}
 
 export const getCookieValidator = ({
 	validator,
@@ -811,7 +818,7 @@ export const getCookieValidator = ({
 		models,
 		additionalProperties: true,
 		coerce: true,
-		additionalCoerce: stringToStructureCoercions
+		additionalCoerce: stringToStructureCoercions()
 	})
 
 	if (isNotEmpty(defaultConfig)) {

--- a/test/type-system/import.ts
+++ b/test/type-system/import.ts
@@ -1,0 +1,7 @@
+try {
+	const { TypeSystem } = await import('../../src/type-system')
+	console.log(TypeSystem && `✅ TypeSystem import works!`)
+} catch (cause) {
+	throw new Error('❌ TypeSystem import failed', { cause })
+}
+export {}


### PR DESCRIPTION
Closes https://github.com/elysiajs/elysia/issues/723

---

- lazy instantiation of `stringToStructureCoercions` fixed it
- I added a new `script` to test standalone import. it doesn't work with `bun test` because `elysia/index.ts` is loaded before `elysia/type-system.ts`