### PR TITLE
Fix package issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
+	"type": "commonjs",
 	"version": "1.1.2",
 	"author": {
 		"name": "saltyAom",
@@ -13,8 +14,8 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
-			"bun": "./dist/bun/index.js",
 			"types": "./dist/index.d.ts",
+			"bun": "./dist/bun/index.js",
 			"import": "./dist/index.mjs",
 			"require": "./dist/cjs/index.js"
 		},
@@ -33,10 +34,10 @@
 			"import": "./dist/context.mjs",
 			"require": "./dist/cjs/context.js"
 		},
-		"./cookie": {
-			"types": "./dist/cookie.d.ts",
-			"import": "./dist/cookie.mjs",
-			"require": "./dist/cjs/cookie.js"
+		"./cookies": {
+			"types": "./dist/cookies.d.ts",
+			"import": "./dist/cookies.mjs",
+			"require": "./dist/cjs/cookies.js"
 		},
 		"./error": {
 			"types": "./dist/error.d.ts",
@@ -48,10 +49,10 @@
 			"import": "./dist/handler.mjs",
 			"require": "./dist/cjs/handler.js"
 		},
-		"./schema": {
-			"types": "./dist/schema.d.ts",
-			"import": "./dist/schema.mjs",
-			"require": "./dist/cjs/schema.js"
+		"./sucrose": {
+			"types": "./dist/sucrose.d.ts",
+			"import": "./dist/sucrose.mjs",
+			"require": "./dist/cjs/sucrose.js"
 		},
 		"./trace": {
 			"types": "./dist/trace.d.ts",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 	],
 	"license": "MIT",
 	"scripts": {
-		"test": "npm run test:functionality && npm run test:types",
+		"test": "npm run test:functionality && npm run test:types && bunx publint",
 		"test:functionality": "bun test && npm run test:node",
 		"test:types": "tsc --project tsconfig.test.json",
 		"test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js && bun dist/bun/index.js",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"test:types": "tsc --project tsconfig.test.json",
 		"test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js && bun dist/bun/index.js",
 		"dev": "bun run --watch example/a.ts",
-		"build": "rimraf dist && bun build.ts",
+		"build": "rm -rf dist && bun build.ts",
 		"release": "npm run build && npm run test && npm publish"
 	},
 	"dependencies": {


### PR DESCRIPTION
When I was using elysia and went into its `package.json` thanks to [`vscode-publint`](https://github.com/kravetsone/vscode-publint), I saw errors in the package configuration:

```bash
PS Z:\PROJECTS\forks\elysia> bunx publint
elysia lint results:
Suggestions:
1. The package does not specify the type field. Environments may incorrectly identify a CJS file as ESM in the future. Consider adding "type": "commonjs".
Warnings:
1. pkg.exports["."].types types is interpreted as CJS when resolving with the "import" condition. This causes the types to be ambiguous when default importing the package due to its implied interop. Consider splitting out two "types" conditions for "import" and "require", and use the .mts extension, e.g. pkg.exports["."].import.types: "./dist/index.d.mts"   
2. pkg.exports["."].bun is ./dist/bun/index.js and is written in ESM, but is interpreted as CJS. Consider using the .mjs extension, e.g. ./dist/bun/index.mjs
Errors:
1. pkg.exports["."].types should be the first in the object as required by TypeScript.
2. pkg.exports["./cookie"].types is ./dist/cookie.d.ts but the file does not exist.
3. pkg.exports["./cookie"].import is ./dist/cookie.mjs but the file does not exist.
4. pkg.exports["./cookie"].require is ./dist/cjs/cookie.js but the file does not exist.
5. pkg.exports["./schema"].types is ./dist/schema.d.ts but the file does not exist.
6. pkg.exports["./schema"].import is ./dist/schema.mjs but the file does not exist.
7. pkg.exports["./schema"].require is ./dist/cjs/schema.js but the file does not exist.
```

after my Pull Request

```bash
PS Z:\PROJECTS\forks\elysia> bunx publint
elysia lint results:
Warnings:
1. pkg.exports["."].types types is interpreted as CJS when resolving with the "import" condition. This causes the types to be ambiguous when default importing the package due to its implied interop. Consider splitting out two "types" conditions for "import" and "require", and use the .mts extension, e.g. pkg.exports["."].import.types: "./dist/index.d.mts"   
2. pkg.exports["."].bun is ./dist/bun/index.js and is written in ESM, but is interpreted as CJS. Consider using the .mjs extension, e.g. ./dist/bun/index.mjs
```

change `cookie` export to `cookies` and `schema` to `sucrose` (because he is the only one without exports)

also added `bunx publint` to the `test` script to prevent it cause again



and maybe we can drop CommonJS build? 

https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require

> Since Node.js 22, you may be able to require() ESM modules. However, I strongly recommend moving to ESM instead.

It is also not needed in `Bun`