### PR TITLE
Fixing types recognition in elysia.route and hook handlers (before and after)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,8 @@ import type {
 	HigherOrderFunction,
 	ResolvePath,
 	JoinPath,
-	ValidatorLayer
+	ValidatorLayer,
+	RouteConfig
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any, any>
@@ -437,7 +438,7 @@ export default class Elysia<
 		path: string,
 		handle: Handler<any, any, any> | any,
 		localHook?: LocalHook<any, any, any, any, any, any>,
-		{ allowMeta = false, skipPrefix = false } = {
+		{ allowMeta = false, skipPrefix = false }: RouteConfig = {
 			allowMeta: false as boolean | undefined,
 			skipPrefix: false as boolean | undefined
 		}
@@ -4522,11 +4523,8 @@ export default class Elysia<
 			Definitions['error'],
 			Metadata['macro'],
 			JoinPath<BasePath, Path>
-		> & {
-			config: {
-				allowMeta?: boolean
-			}
-		}
+		> &
+			Partial<{ config: RouteConfig }>
 	): Elysia<
 		BasePath,
 		Scoped,

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,6 +301,11 @@ export interface DefinitionBase {
 
 export type RouteBase = Record<string, unknown>
 
+export interface RouteConfig {
+	allowMeta?: boolean | undefined
+	skipPrefix?: boolean | undefined
+}
+
 export interface MetadataBase {
 	schema: RouteSchema
 	macro: BaseMacro
@@ -640,7 +645,7 @@ export type OptionalHandler<
 	Path extends string = ''
 > =
 	Handler<Route, Singleton, Path> extends (
-		context: infer Context
+		context: Context<Route, Singleton, Path>
 	) => infer Returned
 		? (context: Context) => Returned | MaybePromise<void>
 		: never
@@ -656,7 +661,7 @@ export type AfterHandler<
 	Path extends string = ''
 > =
 	Handler<Route, Singleton, Path> extends (
-		context: infer Context
+		context: Context<Route, Singleton, Path>
 	) => infer Returned
 		? (
 				context: Prettify<


### PR DESCRIPTION
### Context:
i'm creating my elysia app using a clean architecture approach, so i was typing my adapter for http method handlers and middlewares when i faced this "type" problem.

![elysia-3](https://github.com/user-attachments/assets/b5b93c05-368a-4ce6-9372-f2d5001ceafb)

#### the problem
I was forced to pass a empty config object instead just using the default config as the private "add" method  already do.
![elysia](https://github.com/user-attachments/assets/83756b5e-ce10-446f-b103-99ff24ef3fe7)

Solving this problem, i faced another one while typing my context parameter as Context, the type inference does not recognize the object as Context properly. 
![elysia-2](https://github.com/user-attachments/assets/4938863d-29d4-4167-976b-e3d80ba85001)
