### PR TITLE
feat: add `hide` props in `detail` types for hide route from OpenAPI/swagger document

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -940,7 +940,12 @@ export type Isolate<T> = {
 	[P in keyof T]: T[P]
 }
 
-export type DocumentDecoration = Partial<OpenAPIV3.OperationObject>
+export type DocumentDecoration = Partial<OpenAPIV3.OperationObject> & {
+	/** 
+	 * Pass `true` to hide route from OpenAPI/swagger document
+	 * */
+	hide?: boolean
+}
 
 export type LocalHook<
 	LocalSchema extends InputSchema,


### PR DESCRIPTION
Exclude from OpenAPI/swagger file routes with inspired by [@fastify/swagger hide paths](https://github.com/fastify/fastify-swagger?tab=readme-ov-file#hide-a-route)

```ts
detail: {
    hide: true
}
```

example

```ts
const app = new Elysia()
                        .use(swagger())
			.get("/public", "omg")
			.guard({
				detail: {
					hide: true
				}
			})
			.get("/hidden", "ok")
```

Should be merged with https://github.com/elysiajs/elysia-swagger/pull/137

Close/helps https://github.com/elysiajs/elysia/issues/412