### PR TITLE
Fix ValueError constructor error on isProduction

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -179,9 +179,7 @@ export class ValidationError extends Error {
 			// @ts-expect-error
 			value = value.response
 
-		const error = isProduction
-			? undefined
-			: 'Errors' in validator
+		const error = 'Errors' in validator
 				? validator.Errors(value).First()
 				: Value.Errors(validator, value).First()
 


### PR DESCRIPTION
- Fixes #787

From what I understand, the `error` variable here doesn't seem necessary to be `undefined` in `isProduction` case
- If `customError` is not given in schema, it will create message using the `error` variable here in `isProduction` case.
- If `customError` is given, I think it's better for the user to handle `isProduction` case in the `customError` function itself.