### PR TITLE
Add `closeActiveConnections` to server.stop(), like exists in native bun

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5972,15 +5972,24 @@ export default class Elysia<
 	 * // Sometime later
 	 * app.stop()
 	 * ```
+	 *
+	 * @example
+	 * ```typescript
+	 * const app = new Elysia()
+	 *     .get("/", () => 'hi')
+	 *     .listen(3000)
+	 *
+	 * app.stop(true) // Abruptly any requests inflight
+	 * ```
 	 */
-	stop = async () => {
+	stop = async (closeActiveConnections?: boolean) => {
 		if (!this.server)
 			throw new Error(
 				"Elysia isn't running. Call `app.listen` to start the server."
 			)
 
 		if (this.server) {
-			this.server.stop()
+			this.server.stop(closeActiveConnections)
 			this.server = null
 
 			if (this.event.stop.length)

--- a/test/core/stop.test.ts
+++ b/test/core/stop.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test'
+
+import { Elysia } from '../../src'
+
+describe('Stop', () => {
+
+    it("shuts down the server when stop(true) is called", async () => {
+        const app = new Elysia();
+        app.get("/health", "hi");
+
+        const port = 8080;
+        const server = app.listen(port);
+
+        await fetch(`http://localhost:${port}/health`);
+
+        await server.stop(true);
+
+        // Check if the server is still running
+        try {
+            await fetch(`http://localhost:${port}/health`);
+            throw new Error("Server is still running after teardown");
+        } catch (error) {
+            expect((error as Error).message).toContain('Unable to connect');
+        }
+    })
+
+    it("does not shut down the server when stop(false) is called", async () => {
+        const app = new Elysia();
+        app.get("/health", "hi");
+
+        const port = 8081;
+        const server = app.listen(port);
+
+        await fetch(`http://localhost:${port}/health`)
+
+        await server.stop(false);
+
+        // Check if the server is still running
+        try {
+            const response = await fetch(`http://localhost:${port}/health`);
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe("hi");
+        } catch (error) {
+            throw new Error("Server unexpectedly shut down");
+        }
+    })
+
+})


### PR DESCRIPTION
This fixes #806, by adding support for Bun server's native `closeActiveConnections?: boolean` option on `server.stop()`. 

```ts
const app = new Elysia()
     .get("/", () => 'hi')
     .listen(3000)

// The boolean argument here is optional, new, and mimics native bun.
app.stop(true) // Abruptly any requests inflight
```