### PR TITLE
🎉: feat: add `UnionEnum` type with JSON schema enum usage

### DIFF
--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -316,9 +316,11 @@ TypeRegistry.Set<TUnionEnum>('UnionEnum', (schema, value) => {
 
 type NonEmptyArray<T> = [T, ...T[]]
 
-export type TEnumValue = number | string | null;
+export type TEnumValue = number | string | null
 
-export interface TUnionEnum<T extends NonEmptyArray<TEnumValue> = [TEnumValue]> extends TSchema {
+export interface TUnionEnum<T extends NonEmptyArray<TEnumValue> = [TEnumValue]>
+	extends TSchema {
+	type?: 'number' | 'string' | 'null'
 	[Kind]: 'UnionEnum'
 	static: T[number]
 	enum: T
@@ -599,7 +601,7 @@ export const ElysiaType = {
 			? { type: 'string' }
 			: values.every((value) => typeof value === 'number')
 				? { type: 'number' }
-				: values.every((value) => value === 'null')
+				: values.every((value) => value === null)
 					? { type: 'null' }
 					: {}
 

--- a/test/type-system/union-enum.test.ts
+++ b/test/type-system/union-enum.test.ts
@@ -1,0 +1,43 @@
+import Elysia, { t } from '../../src'
+import { describe, expect, it } from 'bun:test'
+import { Value } from '@sinclair/typebox/value'
+import { post } from '../utils'
+
+describe('TypeSystem - UnionEnum', () => {
+	it('Create', () => {
+		expect(Value.Create(t.UnionEnum(['some', 'data']))).toEqual('some')
+	})
+
+	it('Check', () => {
+		const schema = t.UnionEnum(['some', 'data', null])
+
+		expect(Value.Check(schema, 'some')).toBe(true)
+		expect(Value.Check(schema, 'data')).toBe(true)
+		expect(Value.Check(schema, null)).toBe(true)
+
+		expect(Value.Check(schema, { deep: 2 })).toBe(false)
+		expect(Value.Check(schema, 'yay')).toBe(false)
+		expect(Value.Check(schema, 42)).toBe(false)
+		expect(Value.Check(schema, {})).toBe(false)
+		expect(Value.Check(schema, undefined)).toBe(false)
+	})
+	it('Integrate', async () => {
+		const app = new Elysia().post('/', ({ body }) => body, {
+			body: t.Object({
+				value: t.UnionEnum(['some', 1, null])
+			})
+		})
+
+		const res1 = await app.handle(post('/', { value: 1 }))
+		expect(res1.status).toBe(200)
+
+		const res2 = await app.handle(post('/', { value: null }))
+		expect(res2.status).toBe(200)
+
+		const res3 = await app.handle(post('/', { value: 'some' }))
+		expect(res3.status).toBe(200)
+
+		const res4 = await app.handle(post('/', { value: 'data' }))
+		expect(res4.status).toBe(422)
+	})
+})

--- a/test/type-system/union-enum.test.ts
+++ b/test/type-system/union-enum.test.ts
@@ -21,13 +21,27 @@ describe('TypeSystem - UnionEnum', () => {
 		expect(Value.Check(schema, {})).toBe(false)
 		expect(Value.Check(schema, undefined)).toBe(false)
 	})
+	it('JSON schema', () => {
+		expect(t.UnionEnum(['some', 'data'])).toMatchObject({
+			type: 'string',
+			enum: ['some', 'data']
+		})
+		expect(t.UnionEnum(['some', 1]).type).toBeUndefined()
+		expect(t.UnionEnum([2, 1])).toMatchObject({
+			type: 'number',
+			enum: [2, 1]
+		})
+		expect(t.UnionEnum([null])).toMatchObject({
+			type: 'null',
+			enum: [null]
+		})
+	})
 	it('Integrate', async () => {
 		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.Object({
 				value: t.UnionEnum(['some', 1, null])
 			})
 		})
-
 		const res1 = await app.handle(post('/', { value: 1 }))
 		expect(res1.status).toBe(200)
 


### PR DESCRIPTION
```ts
it('JSON schema', () => {
		expect(t.UnionEnum(['some', 'data'])).toMatchObject({
			type: 'string',
			enum: ['some', 'data']
		})
		expect(t.UnionEnum(['some', 1]).type).toBeUndefined()
		expect(t.UnionEnum([2, 1])).toMatchObject({
			type: 'number',
			enum: [2, 1]
		})
		expect(t.UnionEnum([null])).toMatchObject({
			type: 'null',
			enum: [null]
		})
})
```


Related - https://github.com/elysiajs/elysia/issues/512

JSON Schem 7 spec - https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2
Docs - https://json-schema.org/understanding-json-schema/reference/enum