### PR TITLE
Fix `INVALID_COOKIE_SIGNATURE` error not calling `onError` handler

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -565,65 +565,6 @@ export const composeHandler = ({
 				`
 	}
 
-	if (hasCookie) {
-		const get = (name: keyof CookieOptions, defaultValue?: unknown) => {
-			// @ts-ignore
-			const value = cookieMeta?.[name] ?? defaultValue
-			if (!value)
-				return typeof defaultValue === 'string'
-					? `${name}: "${defaultValue}",`
-					: `${name}: ${defaultValue},`
-
-			if (typeof value === 'string') return `${name}: '${value}',`
-			if (value instanceof Date)
-				return `${name}: new Date(${value.getTime()}),`
-
-			return `${name}: ${value},`
-		}
-
-		const options = cookieMeta
-			? `{
-			secrets: ${
-				cookieMeta.secrets !== undefined
-					? typeof cookieMeta.secrets === 'string'
-						? `'${cookieMeta.secrets}'`
-						: '[' +
-							cookieMeta.secrets.reduce(
-								(a, b) => a + `'${b}',`,
-								''
-							) +
-							']'
-					: 'undefined'
-			},
-			sign: ${
-				cookieMeta.sign === true
-					? true
-					: cookieMeta.sign !== undefined
-						? '[' +
-							cookieMeta.sign.reduce(
-								(a, b) => a + `'${b}',`,
-								''
-							) +
-							']'
-						: 'undefined'
-			},
-			${get('domain')}
-			${get('expires')}
-			${get('httpOnly')}
-			${get('maxAge')}
-			${get('path', '/')}
-			${get('priority')}
-			${get('sameSite')}
-			${get('secure')}
-		}`
-			: 'undefined'
-
-		if (hasHeaders)
-			fnLiteral += `\nc.cookie = await parseCookie(c.set, c.headers.cookie, ${options})\n`
-		else
-			fnLiteral += `\nc.cookie = await parseCookie(c.set, c.request.headers.get('cookie'), ${options})\n`
-	}
-
 	if (hasQuery) {
 		const destructured = <
 			{
@@ -888,6 +829,65 @@ export const composeHandler = ({
 		maybeStream
 
 	const requestMapper = `, c.request`
+
+	if (hasCookie) {
+		const get = (name: keyof CookieOptions, defaultValue?: unknown) => {
+			// @ts-ignore
+			const value = cookieMeta?.[name] ?? defaultValue
+			if (!value)
+				return typeof defaultValue === 'string'
+					? `${name}: "${defaultValue}",`
+					: `${name}: ${defaultValue},`
+
+			if (typeof value === 'string') return `${name}: '${value}',`
+			if (value instanceof Date)
+				return `${name}: new Date(${value.getTime()}),`
+
+			return `${name}: ${value},`
+		}
+
+		const options = cookieMeta
+			? `{
+			secrets: ${
+				cookieMeta.secrets !== undefined
+					? typeof cookieMeta.secrets === 'string'
+						? `'${cookieMeta.secrets}'`
+						: '[' +
+							cookieMeta.secrets.reduce(
+								(a, b) => a + `'${b}',`,
+								''
+							) +
+							']'
+					: 'undefined'
+			},
+			sign: ${
+				cookieMeta.sign === true
+					? true
+					: cookieMeta.sign !== undefined
+						? '[' +
+							cookieMeta.sign.reduce(
+								(a, b) => a + `'${b}',`,
+								''
+							) +
+							']'
+						: 'undefined'
+			},
+			${get('domain')}
+			${get('expires')}
+			${get('httpOnly')}
+			${get('maxAge')}
+			${get('path', '/')}
+			${get('priority')}
+			${get('sameSite')}
+			${get('secure')}
+		}`
+			: 'undefined'
+
+		if (hasHeaders)
+			fnLiteral += `\nc.cookie = await parseCookie(c.set, c.headers.cookie, ${options})\n`
+		else
+			fnLiteral += `\nc.cookie = await parseCookie(c.set, c.request.headers.get('cookie'), ${options})\n`
+	}
 
 	fnLiteral += `c.route = \`${path}\`\n`
 

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -272,4 +272,26 @@ describe('error', () => {
 			somePretty: 'json'
 		})
 	})
+
+	it('handle cookie signature error', async () => {
+		const app = new Elysia({
+			cookie: { secrets: 'secrets', sign: ['session'] }
+		})
+			.onError(({ code, error }) => {
+				if (code === 'INVALID_COOKIE_SIGNATURE')
+					return 'Where is the signature?'
+			})
+			.get('/', ({ cookie: { session } }) => '')
+
+		const root = await app.handle(
+			new Request('http://localhost/', {
+				headers: {
+					Cookie: 'session=1234'
+				}
+			})
+		)
+
+		expect(await root.text()).toBe('Where is the signature?')
+		expect(root.status).toBe(400)
+	})
 })


### PR DESCRIPTION
- fixes #707
- test added under `test/lifecycle/error.test.ts`
   - Not sure if it's the correct place to be instead of `core/handler-error.test.ts` or `cookie/signature-test.ts`
- Simply moved the `hasCookie` after `try {` (before body parsing)
  - It might be better to give separate try catch but I wasn't sure 
  - It made more sense to be move the logic after body parsing like in dynamic handler case but I was trying to minimize the change.
  - Also, this leaves other errors like `t.Cookie required secret which is not set in ...` to still have same issues