### PR TITLE
Fix: Typebox isn't able to deref nested references

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -714,10 +714,10 @@ export const getResponseSchemaValidator = (
 	const compile = (schema: TSchema, references?: TSchema[]) => {
 		const cleaner = (value: unknown) => {
 			if (!value || typeof value !== 'object')
-				return Value.Clean(schema, value)
+        return Value.Clean(schema, references || [], value)
 
-			if (Array.isArray(value)) value = Value.Clean(schema, value)
-			else value = Value.Clean(schema, value)
+      if (Array.isArray(value)) value = Value.Clean(schema, references || [], value)
+      else value = Value.Clean(schema, references || [], value)
 
 			return value
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -589,7 +589,8 @@ export const getSchemaValidator = <T extends TSchema | string | undefined>(
 	if (schema.type === 'object' && 'additionalProperties' in schema === false)
 		schema.additionalProperties = additionalProperties
 
-	const cleaner = (value: unknown) => Value.Clean(schema, value)
+  const references = Object.values(models)
+	const cleaner = (value: unknown) => Value.Clean(schema, references, value)
 
 	if (dynamic) {
 		const validator = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -589,7 +589,7 @@ export const getSchemaValidator = <T extends TSchema | string | undefined>(
 	if (schema.type === 'object' && 'additionalProperties' in schema === false)
 		schema.additionalProperties = additionalProperties
 
-  const references = Object.values(models)
+	const references = Object.values(models)
 	const cleaner = (value: unknown) => Value.Clean(schema, references, value)
 
 	if (dynamic) {
@@ -715,10 +715,10 @@ export const getResponseSchemaValidator = (
 	const compile = (schema: TSchema, references?: TSchema[]) => {
 		const cleaner = (value: unknown) => {
 			if (!value || typeof value !== 'object')
-        return Value.Clean(schema, references || [], value)
+				return Value.Clean(schema, references || [], value)
 
-      if (Array.isArray(value)) value = Value.Clean(schema, references || [], value)
-      else value = Value.Clean(schema, references || [], value)
+			if (Array.isArray(value)) value = Value.Clean(schema, references || [], value)
+			else value = Value.Clean(schema, references || [], value)
 
 			return value
 		}
@@ -1195,7 +1195,7 @@ export const createMacroManager =
 			| {
 					insert?: 'before' | 'after'
 					stack?: 'global' | 'local'
-			  }
+				}
 			| MaybeArray<HookContainer>,
 		fn?: MaybeArray<HookContainer>
 	) => {

--- a/test/validator/body.test.ts
+++ b/test/validator/body.test.ts
@@ -286,6 +286,33 @@ describe('Body Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+  it('validate references', async () => {
+    const job = t.Object({
+      name : t.String()
+    }, { $id: "job" })
+
+    const person = t.Object({
+      name : t.String(),
+      job  : t.Ref(job)
+    })
+
+    const app = new Elysia()
+    .model({ job, person })
+    .post('/', ({ body: { name, job } }) => `${name} - ${job.name}`, {
+      body : person
+    })
+
+    const res = await app.handle(
+    post('/', {
+      name : 'sucrose',
+      job: { name: 'alchemist' }
+    })
+		)
+
+    expect(await res.text()).toBe('sucrose - alchemist')
+		expect(res.status).toBe(200)
+  })
+
 	it('validate optional primitive', async () => {
 		const app = new Elysia().post('/', ({ body }) => body ?? 'sucrose', {
 			body: t.Optional(t.String())

--- a/test/validator/body.test.ts
+++ b/test/validator/body.test.ts
@@ -286,32 +286,32 @@ describe('Body Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
-  it('validate references', async () => {
-    const job = t.Object({
-      name : t.String()
-    }, { $id: "job" })
+	it('validate references', async () => {
+		const job = t.Object({
+			name : t.String()
+		}, { $id: "job" })
 
-    const person = t.Object({
-      name : t.String(),
-      job  : t.Ref(job)
-    })
+		const person = t.Object({
+			name : t.String(),
+			job  : t.Ref(job)
+		})
 
-    const app = new Elysia()
-    .model({ job, person })
-    .post('/', ({ body: { name, job } }) => `${name} - ${job.name}`, {
-      body : person
-    })
+		const app = new Elysia()
+		.model({ job, person })
+		.post('/', ({ body: { name, job } }) => `${name} - ${job.name}`, {
+			body : person
+		})
 
-    const res = await app.handle(
-    post('/', {
-      name : 'sucrose',
-      job: { name: 'alchemist' }
-    })
+		const res = await app.handle(
+		post('/', {
+			name : 'sucrose',
+			job: { name: 'alchemist' }
+		})
 		)
 
-    expect(await res.text()).toBe('sucrose - alchemist')
+		expect(await res.text()).toBe('sucrose - alchemist')
 		expect(res.status).toBe(200)
-  })
+	})
 
 	it('validate optional primitive', async () => {
 		const app = new Elysia().post('/', ({ body }) => body ?? 'sucrose', {

--- a/test/validator/response.test.ts
+++ b/test/validator/response.test.ts
@@ -109,6 +109,29 @@ describe('Response Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+  it('validate nested references', async () => {
+    const job = t.Object({
+      name : t.String()
+    }, { $id: "job" })
+
+    const person = t.Object({
+      name : t.String(),
+      job  : t.Ref(job)
+    })
+
+    const app = new Elysia()
+    .model({ job, person })
+    .get('/', () => ({
+      name : 'sucrose',
+      job: { name: 'alchemist' }
+    }), {
+      response : person
+    })
+
+    const res = await app.handle(req('/'))
+		expect(res.status).toBe(200)
+  })
+
 	it('validate optional', async () => {
 		const app = new Elysia().get(
 			'/',

--- a/test/validator/response.test.ts
+++ b/test/validator/response.test.ts
@@ -109,28 +109,28 @@ describe('Response Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
-  it('validate nested references', async () => {
-    const job = t.Object({
-      name : t.String()
-    }, { $id: "job" })
+	it('validate nested references', async () => {
+		const job = t.Object({
+			name : t.String()
+		}, { $id: "job" })
 
-    const person = t.Object({
-      name : t.String(),
-      job  : t.Ref(job)
-    })
+		const person = t.Object({
+			name : t.String(),
+			job  : t.Ref(job)
+		})
 
-    const app = new Elysia()
-    .model({ job, person })
-    .get('/', () => ({
-      name : 'sucrose',
-      job: { name: 'alchemist' }
-    }), {
-      response : person
-    })
+		const app = new Elysia()
+		.model({ job, person })
+		.get('/', () => ({
+			name : 'sucrose',
+			job: { name: 'alchemist' }
+		}), {
+			response : person
+		})
 
-    const res = await app.handle(req('/'))
+		const res = await app.handle(req('/'))
 		expect(res.status).toBe(200)
-  })
+	})
 
 	it('validate optional', async () => {
 		const app = new Elysia().get(


### PR DESCRIPTION
`references` weren't being passed along to `Clean` when validating a response. So Typebox wasn't able to deref.

I've added the references in the cleaner, to be able to deref properly.

There is a new test case as an example also:

```typescript
  it('validate nested references', async () => {
    const job = t.Object({
      name : t.String()
    }, { $id: "job" })

    const person = t.Object({
      name : t.String(),
      job  : t.Ref(job)
    })

    const app = new Elysia()
    .model({ job, person })
    .get('/', () => ({
      name : 'sucrose',
      job: { name: 'alchemist' }
    }), {
      response : person
    })

    const res = await app.handle(req('/'))
    expect(res.status).toBe(200)
  })
```