### PR TITLE
fix: unwrap transform errors

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2343,9 +2343,10 @@ export const composeErrorHandler = (
 	}
 
 	fnLiteral += `if(error.constructor.name === "ValidationError" || error.constructor.name === "TransformDecodeError") {
-		set.status = error.status ?? 422
+	    const reportedError = error.error ?? error
+		set.status = reportedError.status ?? 422
 		return new Response(
-			error.message,
+			reportedError.message,
 			{
 				headers: Object.assign(
 					{ 'content-type': 'application/json'},

--- a/test/core/handle-error.test.ts
+++ b/test/core/handle-error.test.ts
@@ -204,4 +204,25 @@ describe('Handle Error', () => {
 			'APIError'
 		)
 	})
+
+	it('handle error in Transform', async () => {
+		const route = new Elysia().get('/', ({query: {aid}}) => aid, {
+			query: t.Object({
+				aid: t.Transform(t.String())
+					.Decode((value) => {
+						throw new NotFoundError('foo')
+					})
+					.Encode((value) => `1`)
+			})
+		})
+
+		let response = await (new Elysia({ aot: false })).use(route).handle(req('/?aid=a'))
+		expect(response.status).toEqual(404)
+		expect(await response.text()).toEqual('foo')
+
+		response = await (new Elysia({aot: true})).use(route).handle(req('/?aid=a'))
+		expect(response.status).toEqual(404)
+		expect(await response.text()).toEqual('foo')
+	})
+
 })


### PR DESCRIPTION
Errors thrown in transform decoding would not get picked up by `app.handleError` because Typobox wraps them in a `TransformDecodeError`.

This proposal unwraps the error, allowing e.g. `NotFoundError` thrown in transform decoding to result in HTTP 404.

Fixes #882