### PR TITLE
:wrench: fix: handle `error()` in resolve with `aot: false`

### DIFF
--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -294,6 +294,10 @@ export const createDynamicHandler =
 				let response = hook.fn(context)
 
 				if (hook.subType === 'resolve') {
+					if (response instanceof ElysiaCustomStatusResponse) {
+						const result = mapEarlyResponse(response, context.set)
+						if (result) return (context.response = result)
+					}
 					if (response instanceof Promise)
 						Object.assign(context, await response)
 					else Object.assign(context, response)

--- a/test/lifecycle/resolve.test.ts
+++ b/test/lifecycle/resolve.test.ts
@@ -210,14 +210,19 @@ describe('resolve', () => {
 	})
 
 	it('handle error', async () => {
-		const app = new Elysia()
+		const route = new Elysia()
 			.resolve(() => {
 				return error(418)
 			})
 			.get('/', () => '')
 
-		const res = await app.handle(req('/')).then((x) => x.text())
+		const res = await (new Elysia({aot: true})).use(route).handle(req('/'))
+		expect(await res.status).toEqual(418)
+		expect(await res.text()).toEqual("I'm a teapot")
 
-		expect(res).toEqual("I'm a teapot")
+		const res2 = await (new Elysia({aot: false})).use(route).handle(req('/'))
+		expect(await res2.status).toEqual(418)
+		expect(await res2.text()).toEqual("I'm a teapot")
+
 	})
 })


### PR DESCRIPTION
Fixes #888

@SaltyAom — it seems a little inconsistent to sprinkle cases with `{ aot: false }` over the tests. Perhaps you have a more exhaustive approach for full test coverage both with and without AOT?