### PR TITLE
Typescript fixes & minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ trace
 *.tsbuildinfo
 .wrangler
 .elysia
+.vscode

--- a/example/cookie.ts
+++ b/example/cookie.ts
@@ -12,7 +12,7 @@ const app = new Elysia({
 			(council.value = [
 				{
 					name: 'Rin',
-					affilation: 'Administration'
+					affiliation: 'Administration'
 				}
 			]),
 		{
@@ -20,7 +20,7 @@ const app = new Elysia({
 				council: t.Array(
 					t.Object({
 						name: t.String(),
-						affilation: t.String()
+						affiliation: t.String()
 					})
 				)
 			})

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"test:imports": "bun run ./test/type-system/import.ts",
 		"test:types": "tsc --project tsconfig.test.json",
 		"test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js && bun dist/bun/index.js",
-		"pretest:node": "bun run build",
+		"pretest:node": "npm run build",
 		"dev": "bun run --watch example/a.ts",
 		"build": "rm -rf dist && bun build.ts",
 		"release": "npm run build && npm run test && npm publish"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
 		"test:imports": "bun run ./test/type-system/import.ts",
 		"test:types": "tsc --project tsconfig.test.json",
 		"test:node": "npm install --prefix ./test/node/cjs/ && npm install --prefix ./test/node/esm/ && node ./test/node/cjs/index.js && node ./test/node/esm/index.js && bun dist/bun/index.js",
+		"pretest:node": "bun run build",
 		"dev": "bun run --watch example/a.ts",
 		"build": "rm -rf dist && bun build.ts",
 		"release": "npm run build && npm run test && npm publish"

--- a/src/error.ts
+++ b/src/error.ts
@@ -269,8 +269,7 @@ export class ValidationError extends Error {
 	get all() {
 		return 'Errors' in this.validator
 			? [...this.validator.Errors(this.value)].map(mapValueError)
-			: // @ts-ignore
-				[...Value.Errors(this.validator, this.value)].map(mapValueError)
+			: [...Value.Errors(this.validator, this.value)].map(mapValueError)
 	}
 
 	static simplifyModel(validator: TSchema | TypeCheck<any>) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -6,7 +6,7 @@ import { StatusMap } from './utils'
 import { Cookie } from './cookies'
 
 import type { Context } from './context'
-import type { LocalHook } from './types'
+import type { HTTPHeaders, LocalHook } from './types'
 import { ElysiaCustomStatusResponse } from './error'
 
 const hasHeaderShorthand = 'toJSON' in new Headers()
@@ -112,14 +112,6 @@ export const serializeCookie = (cookies: Context['set']['cookie']) => {
 	return set
 }
 
-// const concatUint8Array = (a: Uint8Array, b: Uint8Array) => {
-// 	const arr = new Uint8Array(a.length + b.length)
-// 	arr.set(a, 0)
-// 	arr.set(b, a.length)
-
-// 	return arr
-// }
-
 const handleStream = async (
 	generator: Generator | AsyncGenerator,
 	set?: Context['set'],
@@ -196,8 +188,8 @@ const handleStream = async (
 				// Manually set transfer-encoding for direct response, eg. app.handle, eden
 				'transfer-encoding': 'chunked',
 				'content-type': 'text/event-stream; charset=utf-8',
-				...set?.headers
-			}
+				...((set?.headers || {}) as HTTPHeaders)
+			} as Record<string, string> | [string, string][] | Headers
 		}
 	)
 }

--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -6,16 +6,16 @@ import {
 	TArray,
 	TDate,
 	TUnsafe,
-	TypeRegistry
+	TypeRegistry,
+	type Static,
+	type TString,
+	type TTransform
 } from '@sinclair/typebox'
 import { TypeSystem } from '@sinclair/typebox/system'
 import {
 	Type,
 	type SchemaOptions,
-	// type TNull,
-	// type TUnion,
 	type TSchema,
-	// type TUndefined,
 	TProperties,
 	ObjectOptions,
 	TObject,
@@ -97,8 +97,6 @@ const t = Object.assign({}, Type)
 
 export namespace ElysiaTypeOptions {
 	export type Numeric = NumberOptions
-
-	export type FileUnit = number | `${number}${'k' | 'm'}`
 
 	export type StrictFileType =
 		| 'image'
@@ -186,6 +184,8 @@ export namespace ElysiaTypeOptions {
 		 */
 		sign?: Readonly<(keyof T | (string & {}))[]>
 	}
+
+	export type FileUnit = number | `${number}${'k' | 'm'}`
 }
 
 const parseFileUnit = (size: ElysiaTypeOptions.FileUnit) => {
@@ -318,8 +318,11 @@ type NonEmptyArray<T> = [T, ...T[]]
 
 export type TEnumValue = number | string | null
 
-export interface TUnionEnum<T extends NonEmptyArray<TEnumValue> | Readonly<NonEmptyArray<TEnumValue>> = [TEnumValue]>
-	extends TSchema {
+export interface TUnionEnum<
+	T extends
+		| NonEmptyArray<TEnumValue>
+		| Readonly<NonEmptyArray<TEnumValue>> = [TEnumValue]
+> extends TSchema {
 	type?: 'number' | 'string' | 'null'
 	[Kind]: 'UnionEnum'
 	static: T[number]
@@ -542,7 +545,7 @@ export const ElysiaType = {
 					throw new ValidationError('property', schema, value)
 
 				return JSON.stringify(value)
-			}) as any as TArray<T>
+			}) as any as TTransform<TString, Static<T>[]>
 	},
 	File,
 	Files: (options: ElysiaTypeOptions.Files = {}) =>
@@ -593,7 +596,11 @@ export const ElysiaType = {
 		return v
 	},
 	// based on https://github.com/elysiajs/elysia/issues/512#issuecomment-1980134955
-	UnionEnum: <const T extends NonEmptyArray<TEnumValue> | Readonly<NonEmptyArray<TEnumValue>>>(
+	UnionEnum: <
+		const T extends
+			| NonEmptyArray<TEnumValue>
+			| Readonly<NonEmptyArray<TEnumValue>>
+	>(
 		values: T,
 		options: SchemaOptions = {}
 	) => {
@@ -707,81 +714,3 @@ export {
 	TypeSystemDuplicateTypeKind
 } from '@sinclair/typebox/system'
 export { TypeCompiler, TypeCheck } from '@sinclair/typebox/compiler'
-
-// type Template =
-// 	| string
-// 	| number
-// 	| bigint
-// 	| boolean
-// 	| StringConstructor
-// 	| NumberConstructor
-// 	| undefined
-
-// type Join<A> = A extends Readonly<[infer First, ...infer Rest]>
-// 	? (
-// 			First extends Readonly<Template[]>
-// 				? First[number]
-// 				: First extends StringConstructor
-// 				? string
-// 				: First extends NumberConstructor
-// 				? `${number}`
-// 				: First
-// 	  ) extends infer A
-// 		? Rest extends []
-// 			? A extends undefined
-// 				? NonNullable<A> | ''
-// 				: A
-// 			: // @ts-ignore
-// 			A extends undefined
-// 			? `${NonNullable<A>}${Join<Rest>}` | ''
-// 			: // @ts-ignore
-// 			  `${A}${Join<Rest>}`
-// 		: ''
-// 	: ''
-
-// const template = <
-// 	const T extends Readonly<(Template | Readonly<Template[]>)[]>
-// >(
-// 	...p: T
-// ): Join<T> => {
-// 	return a as any
-// }
-
-// const create =
-// 	<const T extends string>(t: T): ((t: T) => void) =>
-// 	(t) =>
-// 		t
-
-// const optional = <
-// 	const T extends Readonly<(Template | Readonly<Template[]>)[]>
-// >(
-// 	...p: T
-// ): T | undefined => {
-// 	return undefined
-// }
-
-// template.optional = optional
-
-// const hi = create(
-// 	template(
-// 		['seminar', 'millennium'],
-// 		':',
-// 		['Rio', 'Yuuka', 'Noa', 'Koyuki'],
-// 		template.optional(template(',', ['Rio', 'Yuuka', 'Noa', 'Koyuki'])),
-// 		template.optional(template(',', ['Rio', 'Yuuka', 'Noa', 'Koyuki'])),
-// 		template.optional(template(',', ['Rio', 'Yuuka', 'Noa', 'Koyuki']))
-// 	)
-// )
-
-// hi(`seminar:Noa,Koyuki,Yuuka`)
-
-// const a = TypeCompiler.Compile(t.String())
-
-// console.log(v.Decode.toString())
-
-// const T = t.Transform(v.schema)
-// 	.Decode((value) => new Date(value)) // required: number to Date
-// 	.Encode((value) => value.getTime()) // required: Date to number
-
-// const decoded = Value.Decode(T, 0) // const decoded = Date(1970-01-01T00:00:00.000Z)
-// const encoded = Value.Encode(T, decoded)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1428,12 +1428,12 @@ type ElysiaFormData<T extends Record<string | number, unknown>> = FormData & {
 export const ELYSIA_REQUEST_ID = Symbol('ElysiaRequestId')
 export type ELYSIA_REQUEST_ID = typeof ELYSIA_REQUEST_ID
 
-export const form = <const T extends Record<string | number, unknown>>(
+export const form = <const T extends Record<string | number, string | Blob>>(
 	items: T
 ): ElysiaFormData<T> => {
 	const formData = new FormData()
 
-	for (const [key, value] of Object.entries(items)) {
+	for (const [key, value] of Object.entries<string | Blob>(items)) {
 		if (Array.isArray(value)) {
 			for (const v of value) {
 				if (value instanceof File)
@@ -1495,54 +1495,3 @@ export const promoteEvent = (
 
 	for (const event of events) if ('scope' in event) event.scope = 'global'
 }
-
-type PropertyKeys<T> = {
-	[K in keyof T]: T[K] extends (...args: any[]) => any ? never : K
-}[keyof T]
-
-type PropertiesOnly<T> = Pick<T, PropertyKeys<T>>
-
-// export const classToObject = <T>(
-// 	instance: T,
-// 	processed: WeakMap<object, object> = new WeakMap()
-// ): T extends object ? PropertiesOnly<T> : T => {
-// 	if (typeof instance !== 'object' || instance === null)
-// 		return instance as any
-
-// 	if (Array.isArray(instance))
-// 		return instance.map((x) => classToObject(x, processed)) as any
-
-// 	if (processed.has(instance)) return processed.get(instance) as any
-
-// 	const result: Partial<T> = {}
-
-// 	for (const key of Object.keys(instance) as Array<keyof T>) {
-// 		const value = instance[key]
-// 		if (typeof value === 'object' && value !== null)
-// 			result[key] = classToObject(value, processed) as T[keyof T]
-// 		else result[key] = value
-// 	}
-
-// 	const prototype = Object.getPrototypeOf(instance)
-// 	if (!prototype) return result as any
-
-// 	const properties = Object.getOwnPropertyNames(prototype)
-
-// 	for (const property of properties) {
-// 		const descriptor = Object.getOwnPropertyDescriptor(
-// 			Object.getPrototypeOf(instance),
-// 			property
-// 		)
-
-// 		if (descriptor && typeof descriptor.get === 'function') {
-// 			// ? Very important to prevent prototype pollution
-// 			if (property === '__proto__') continue
-
-// 			;(result as any)[property as keyof typeof instance] = classToObject(
-// 				instance[property as keyof typeof instance]
-// 			)
-// 		}
-// 	}
-
-// 	return result as any
-// }

--- a/test/aot/response.test.ts
+++ b/test/aot/response.test.ts
@@ -6,7 +6,6 @@ import { signCookie } from '../../src/utils'
 const secrets = 'We long for the seven wailings. We bear the koan of Jericho.'
 
 const getCookies = (response: Response) =>
-	// @ts-expect-error
 	response.headers.getAll('Set-Cookie').map((x) => {
 		return decodeURIComponent(x)
 	})
@@ -15,12 +14,12 @@ const app = new Elysia()
 	.get(
 		'/council',
 		({ cookie: { council } }) =>
-			(council.value = [
+			(council.value = JSON.stringify([
 				{
 					name: 'Rin',
-					affilation: 'Administration'
+					affiliation: 'Administration'
 				}
-			])
+			]))
 	)
 	.get('/create', ({ cookie: { name } }) => (name.value = 'Himari'))
 	.get('/multiple', ({ cookie: { name, president } }) => {
@@ -64,14 +63,17 @@ describe('Dynamic Cookie Response', () => {
 	it('set multiple cookie', async () => {
 		const response = await app.handle(req('/multiple'))
 
-		expect(getCookies(response)).toEqual(['name=Himari; Path=/', 'president=Rio; Path=/'])
+		expect(getCookies(response)).toEqual([
+			'name=Himari; Path=/',
+			'president=Rio; Path=/'
+		])
 	})
 
 	it('set JSON cookie', async () => {
 		const response = await app.handle(req('/council'))
 
 		expect(getCookies(response)).toEqual([
-			'council=[{"name":"Rin","affilation":"Administration"}]; Path=/'
+			'council=[{"name":"Rin","affiliation":"Administration"}]; Path=/'
 		])
 	})
 
@@ -85,16 +87,17 @@ describe('Dynamic Cookie Response', () => {
 							JSON.stringify([
 								{
 									name: 'Aoi',
-									affilation: 'Financial'
+									affiliation: 'Financial'
 								}
 							])
-						) + '; Path=/'
+						) +
+						'; Path=/'
 				}
 			})
 		)
 
 		expect(getCookies(response)).toEqual([
-			'council=[{"name":"Rin","affilation":"Administration"}]; Path=/'
+			'council=[{"name":"Rin","affiliation":"Administration"}]; Path=/'
 		])
 	})
 
@@ -108,7 +111,7 @@ describe('Dynamic Cookie Response', () => {
 							JSON.stringify([
 								{
 									name: 'Rin',
-									affilation: 'Administration'
+									affiliation: 'Administration'
 								}
 							])
 						)
@@ -201,10 +204,9 @@ describe('Dynamic Cookie Response', () => {
 		const response = await app.handle(
 			req('/update', {
 				headers: {
-					cookie: `name=${await signCookie(
-						'seminar: Himari',
-						secrets
-					)}` + '; Path=/'
+					cookie:
+						`name=${await signCookie('seminar: Himari', secrets)}` +
+						'; Path=/'
 				}
 			})
 		)

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -20,7 +20,7 @@ const app = new Elysia()
 			(council.value = [
 				{
 					name: 'Rin',
-					affilation: 'Administration'
+					affiliation: 'Administration'
 				}
 			]),
 		{
@@ -29,7 +29,7 @@ const app = new Elysia()
 					t.Array(
 						t.Object({
 							name: t.String(),
-							affilation: t.String()
+							affiliation: t.String()
 						})
 					)
 				)
@@ -99,7 +99,7 @@ describe('Cookie Response', () => {
 		const response = await app.handle(req('/council'))
 
 		expect(getCookies(response)).toEqual([
-			'council=[{"name":"Rin","affilation":"Administration"}]; Path=/'
+			'council=[{"name":"Rin","affiliation":"Administration"}]; Path=/'
 		])
 	})
 
@@ -113,7 +113,7 @@ describe('Cookie Response', () => {
 							JSON.stringify([
 								{
 									name: 'Aoi',
-									affilation: 'Financial'
+									affiliation: 'Financial'
 								}
 							])
 						)
@@ -122,7 +122,7 @@ describe('Cookie Response', () => {
 		)
 
 		expect(getCookies(response)).toEqual([
-			'council=[{"name":"Rin","affilation":"Administration"}]; Path=/'
+			'council=[{"name":"Rin","affiliation":"Administration"}]; Path=/'
 		])
 	})
 
@@ -136,7 +136,7 @@ describe('Cookie Response', () => {
 							JSON.stringify([
 								{
 									name: 'Rin',
-									affilation: 'Administration'
+									affiliation: 'Administration'
 								}
 							])
 						)
@@ -271,7 +271,7 @@ describe('Cookie Response', () => {
 				cookie: t.Cookie({
 					council: t.Object({
 						name: t.String(),
-						affilation: t.String()
+						affiliation: t.String()
 					})
 				})
 			}
@@ -279,7 +279,7 @@ describe('Cookie Response', () => {
 
 		const expected = {
 			name: 'Rin',
-			affilation: 'Administration'
+			affiliation: 'Administration'
 		}
 
 		const response = await app.handle(
@@ -306,7 +306,7 @@ describe('Cookie Response', () => {
 
 		const expected = {
 			name: 'Rin',
-			affilation: 'Administration'
+			affiliation: 'Administration'
 		}
 
 		const response = await app.handle(
@@ -355,7 +355,6 @@ describe('Cookie Response', () => {
 			return 'a'
 		})
 
-		// @ts-expect-error
 		const res = app.handle(req('/')).then((x) => x.headers.toJSON())
 
 		// @ts-expect-error
@@ -392,13 +391,14 @@ describe('Cookie Response', () => {
 			})
 			.get('/', () => 'Hello, world!')
 
-		const res = await app.handle(
-			new Request('http://localhost:3000/', {
-				headers: {
-					cookie: 'test=Hello, world!'
-				}
-			})
-		)
+		const res = await app
+			.handle(
+				new Request('http://localhost:3000/', {
+					headers: {
+						cookie: 'test=Hello, world!'
+					}
+				})
+			)
 			.then((x) => x.headers)
 
 		expect(res.getSetCookie()).toEqual([])

--- a/test/core/elysia.test.ts
+++ b/test/core/elysia.test.ts
@@ -125,7 +125,6 @@ describe('Edge Case', () => {
 
 		const response = await app
 			.handle(req('/'))
-			// @ts-expect-error
 			.then((x) => x.headers.toJSON())
 
 		expect(response['set-cookie']).toHaveLength(1)

--- a/test/core/handle-error.test.ts
+++ b/test/core/handle-error.test.ts
@@ -70,9 +70,7 @@ describe('Handle Error', () => {
 	})
 
 	it('inject headers to error', async () => {
-		const app = new Elysia({
-			forceErrorEncapsulation: true
-		})
+		const app = new Elysia()
 			.onRequest(({ set }) => {
 				set.headers['Access-Control-Allow-Origin'] = '*'
 			})

--- a/test/core/modules.test.ts
+++ b/test/core/modules.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Elysia } from '../../src'
 
 import { describe, expect, it } from 'bun:test'

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -53,10 +53,18 @@ describe('error', () => {
 				if (code === 'VALIDATION') {
 					set.status = 400
 
-					return error.all.map((i) => ({
-						filed: i.path.slice(1) || 'root',
-						reason: i.message
-					}))
+					return error.all.map((i) => {
+						if ('path' in i) {
+							return {
+								filed: i.path.slice(1) || 'root',
+								reason: i.message
+							}
+						}
+						return {
+							filed: 'root',
+							reason: i.summary
+						}
+					})
 				}
 			})
 			.post('/login', ({ body }) => body, {

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -1,12 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-	Elysia,
-	InternalServerError,
-	ParseError,
-	ValidationError,
-	error,
-	t
-} from '../../src'
+import { Elysia, InternalServerError, ParseError, t } from '../../src'
 import { describe, expect, it } from 'bun:test'
 import { post, req } from '../utils'
 

--- a/test/macro/macro.test.ts
+++ b/test/macro/macro.test.ts
@@ -484,7 +484,6 @@ describe('Macro', () => {
 		const called = <string[]>[]
 
 		const plugin = new Elysia().get('/hello', () => 'hello', {
-			// @ts-expect-error missing type reference
 			hello: 'nagisa'
 		})
 

--- a/test/response/redirect.test.ts
+++ b/test/response/redirect.test.ts
@@ -1,4 +1,4 @@
-import { Elysia } from '../../src'
+import { Elysia, t } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -10,7 +10,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi'
 		})
@@ -24,7 +23,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(301)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi'
 		})
@@ -40,7 +38,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi',
 			alias: 'Abyssal Hunter'
@@ -61,9 +58,9 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi',
+			// @ts-expect-error - Unsure where this comes from, set cookie can return an array. Maybe the type is expecting comma separated values?
 			'set-cookie': ['name=a; Path=/', 'name2=b; Path=/']
 		})
 	})

--- a/test/type-system/array-string.test.ts
+++ b/test/type-system/array-string.test.ts
@@ -1,15 +1,20 @@
 import Elysia, { t } from '../../src'
 import { describe, expect, it } from 'bun:test'
 import { Value } from '@sinclair/typebox/value'
-import { TBoolean, TString, TypeBoxError } from '@sinclair/typebox'
-import { req } from '../utils'
 
 describe('TypeSystem - ArrayString', () => {
 	it('Create', () => {
-		expect(Value.Create(t.ArrayString())).toBe('[]')
+		const value = Value.Create(t.ArrayString())
+		expect(value).toBe('[]')
 	})
 
-	it('Check', () => {
+	it('Check - String', () => {
+		const schema = t.ArrayString(t.Number())
+
+		expect(Value.Check(schema, '[1]')).toBe(true)
+	})
+
+	it('Check - Cast', () => {
 		const schema = t.ArrayString(t.Number())
 
 		expect(Value.Check(schema, [1])).toBe(true)
@@ -18,63 +23,55 @@ describe('TypeSystem - ArrayString', () => {
 	it('Encode', () => {
 		const schema = t.ArrayString(t.Number())
 
-		expect(
-			Value.Encode<typeof schema, string>(schema, [1])
-		).toBe(JSON.stringify([1]))
+		expect(Value.Encode<typeof schema>(schema, [1])).toBe(
+			JSON.stringify([1])
+		)
 
-		expect(
-			Value.Encode<typeof schema, string>(schema, [1])
-		).toBe(JSON.stringify([1]))
+		expect(Value.Encode<typeof schema>(schema, [1])).toBe(
+			JSON.stringify([1])
+		)
 	})
 
 	it('Decode', () => {
 		const schema = t.ArrayString(t.Number())
 
-		expect(
-			Value.Decode<typeof schema>(
-				schema,
-				'[1]'
-			)
-		).toEqual([1])
+		expect(Value.Decode<typeof schema>(schema, '[1]')).toEqual([1])
 
-		expect(() =>
-			Value.Decode<typeof schema>(
-				schema,
-				'1'
-			)
-		).toThrow()
+		expect(() => Value.Decode<typeof schema>(schema, '1')).toThrow()
 	})
 
 	it('Integrate', async () => {
-		const app = new Elysia().post(
-			'/',
-			({ body }) => body,
-			{
-				body: t.Object({
-					id: t.ArrayString(t.Number())
-				})
-			}
-		)
+		const app = new Elysia().post('/', ({ body }) => body, {
+			body: t.Object({
+				id: t.ArrayString(t.Number())
+			})
+		})
 
-		const res1 = await app.handle(new Request('http://localhost', {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ id: JSON.stringify([1, 2, 3]) })
-		}))
+		const res1 = await app.handle(
+			new Request('http://localhost', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id: JSON.stringify([1, 2, 3]) })
+			})
+		)
 		expect(res1.status).toBe(200)
 
-		const res2 = await app.handle(new Request('http://localhost', {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ id: [1, 2, 3] })
-		}))
+		const res2 = await app.handle(
+			new Request('http://localhost', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id: [1, 2, 3] })
+			})
+		)
 		expect(res2.status).toBe(200)
 
-		const res3 = await app.handle(new Request('http://localhost', {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ id: ['a', 2, 3] })
-		}))
+		const res3 = await app.handle(
+			new Request('http://localhost', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id: ['a', 2, 3] })
+			})
+		)
 		expect(res3.status).toBe(422)
 	})
 })

--- a/test/types/type-system.ts
+++ b/test/types/type-system.ts
@@ -3,7 +3,6 @@ import { expect } from 'bun:test'
 import { t, Elysia, RouteSchema, Cookie } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
-// ? ArrayString
 {
 	new Elysia().post(
 		'/',

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -281,7 +281,6 @@ describe('Query Validator', () => {
 					check() {
 						const { state } = ctx.query
 
-						// @ts-expect-error
 						if (!checker.check(ctx, name, state ?? ctx.query.state))
 							throw new Error('State mismatch')
 					}

--- a/test/ws/utils.ts
+++ b/test/ws/utils.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'bun'
 
 export const newWebsocket = (server: Server, path = '/ws') =>
-	new WebSocket(`ws://${server.hostname}:${server.port}${path}`, {})
+	new WebSocket(`ws://${server.hostname}:${server.port}${path}`)
 
 export const wsOpen = (ws: WebSocket) =>
 	new Promise((resolve) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 
     /* Language and Environment */
     "target": "ES2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ESNext"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ESNext", "DOM"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 
     /* Language and Environment */
     "target": "ES2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ESNext", "DOM"],                            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
- Fix spelling in example, 'aot' and 'cookie' tests
- Remove unneeded `@ts-ignore` and `@ts-expect-errors`
- Fix ArrayString type so that encode correctly returns `string` as the type. This also fixes the type errors in the tests.
- Replace ArrayStrings `Check` test with `Check - Cast` that checks the non encoded version
- Add to ArrayStrings `Check - String` test which checks the encoded version
- Replace form `unknown` with `string | Blob` to correctly fix the types
- Remove general commented out code, it's in git history
- Remove `forceErrorEncapsulation: true` from the `handle-error` test as this option is no longer valid
- In the `error` test check for the `path` in the error to narrow the type as ValidationError can return two very different types.
- I did have to add one `@ts-expect-error` in the `response` test. Unsure why, code looks spec correct.
- Added `DOM` and `DOM.Iterable` to the `tsconfig.json`. These are required for `headers.keys()` (DOM) and `headers.getAll()` (DOM.Iterable). Do note though that `headers.getAll()` has been removed from the spec and is deprecated. It doesn't exist in the node only types anymore.

Hope this helps, I wanted to try work on a few things I've needed but had to fix a few types in the process so thought I'd submit them separately first.