### PR TITLE
fix: typebox object schemas without properties key

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -79,6 +79,7 @@ export const hasAdditionalProperties = (
 		const properties = schema.properties as Record<string, TAnySchema>
 
 		if ('additionalProperties' in schema) return schema.additionalProperties
+		if ('patternProperties' in schema) return false
 
 		for (const key of Object.keys(properties)) {
 			const property = properties[key]

--- a/test/core/compose.test.ts
+++ b/test/core/compose.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+import { Type } from '@sinclair/typebox'
+import { hasAdditionalProperties } from '../../src/compose'
+
+describe('hasAdditionalProperties', () => {
+		it('should handle object schemas without properties key', () => {
+			const schema = Type.Intersect([
+				Type.Object({ a: Type.String() }),
+				// Record schemas does not have properties key, instead it has patternProperties
+				Type.Record(Type.Number(), Type.String())
+			])
+			expect(hasAdditionalProperties(schema)).toBe(false)
+	})
+})


### PR DESCRIPTION
This PR fixes a TypeError in `hasAdditionalProperties` when handling intersection types that include a TypeBox Record. The function fails when processing schemas that have `type: "object"` but no `properties` key.

## Issue
When using an intersection (`Type.Intersect`) with a Record type from TypeBox, the generated schema is a valid JSON Schema object using `allOf`, but lacks a `properties` key in some of its subschemas. This causes `hasAdditionalProperties` to throw a TypeError when attempting to access the `properties` field.

Example schema that triggers the bug:
```json
{
  "allOf": [
    {
      "type": "object",
      "properties": {
        "a": {
          "type": "string"
        }
      },
      "required": ["a"]
    },
    {
      "type": "object",
      "patternProperties": {
        "^(0|[1-9][0-9]*)$": {
          "type": "string"
        }
      }
    }
  ]
}
```

## Tests

Added test case for intersection of object + record types
Verified handling of schemas with missing properties key