### PR TITLE
Optional `BooleanString` decoding issue

### DIFF
--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -409,7 +409,7 @@ export const ElysiaType = {
 			.Decode((value) => {
 				if (typeof value === 'string') return value === 'true'
 
-				if (property && !Value.Check(schema, value))
+				if (value !== undefined && !Value.Check(schema, value))
 					throw new ValidationError('property', schema, value)
 
 				return value

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -200,6 +200,34 @@ describe('Query Validator', () => {
 		expect(await res.json()).toEqual({ param1: true })
 	})
 
+	it('parse optional boolean string with second parameter', async () => {
+		const schema = t.Object({
+			registered: t.Optional(t.Boolean()),
+			other: t.String(),
+		})
+		const app = new Elysia().get('/', ({ query }) => query, {
+			query: schema
+		})
+		const res = await app.handle(req('/?other=sucrose'))
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ other: 'sucrose' })
+	})
+
+	it('parse optional boolean string with default value', async () => {
+		const schema = t.Object({
+			registered: t.Optional(t.Boolean({default: true})),
+			other: t.String(),
+		})
+		const app = new Elysia().get('/', ({ query }) => query, {
+			query: schema
+		})
+		const res = await app.handle(req('/?other=sucrose'))
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ other: 'sucrose', registered: true })
+	})
+
 	it('validate optional object', async () => {
 		const app = new Elysia().get(
 			'/',


### PR DESCRIPTION
Possible fix for #872:

Using the following schema, the query string `?other=foo` is rejected with _422 expected boolean_.

```ts
t.Object({
    registered: t.Optional(t.Boolean()),
    other: t.String(),
})
```

The validation error is thrown in `BooleanString.Decode`.

@bogeychan please correct me if I'm wrong — I assume the intention in `Decode` is to check if `value` is present, not `property`?
