### PR TITLE
fix: boolean-string converted to string

### DIFF
--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -397,11 +397,11 @@ export const ElysiaType = {
 			.Transform(
 				t.Union(
 					[
+						t.Boolean(property),
 						t.String({
 							format: 'boolean',
 							default: false
 						}),
-						t.Boolean(property)
 					],
 					property
 				)

--- a/test/type-system/boolean-string.test.ts
+++ b/test/type-system/boolean-string.test.ts
@@ -63,6 +63,11 @@ describe('TypeSystem - BooleanString', () => {
 		expect(() => Value.Decode(schema, null)).toThrow(error)
 	})
 
+	it('Convert', () => {
+		expect(Value.Convert(t.BooleanString(), 'true')).toBe(true)
+		expect(Value.Convert(t.BooleanString(), 'false')).toBe(false)
+	})
+
 	it('Integrate', async () => {
 		const app = new Elysia().get('/', ({ query }) => query, {
 			query: t.Object({


### PR DESCRIPTION
## Issue

The BooleanString converted value is a string instead of a boolean. This occurs because Typebox converts the value to the first matching schema, as shown here:

```typescript
function FromUnion(schema: TUnion, references: TSchema[], value: any): unknown {
  for (const subschema of schema.anyOf) {
    const converted = Visit(subschema, references, value)
    if (!Check(subschema, references, converted)) continue
    return converted
  }
  return value
}
```