### PR TITLE
feat(DX): shortcut to Array Schema Validator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5593,23 +5593,29 @@ export default class Elysia<
 
 	model(name: string | Record<string, TSchema> | Function, model?: TSchema) {
 		switch (typeof name) {
-			case 'object':
-				Object.entries(name).forEach(([key, value]) => {
-					if (!(key in this.definitions.type))
-						this.definitions.type[key] = value as TSchema
+			case 'object': {
+				Object.keys(name).forEach((key) => {
+					if (!(key in this.definitions.type)) {
+						const value = name[key]
+						value.$id ??= `#/components/schemas/${key}`
+						this.definitions.type[key] = value
+					}
 				})
-
 				return this
-
-			case 'function':
+			}
+			case 'function': {
 				this.definitions.type = name(this.definitions.type)
-
+				return this as any
+			}
+			case 'string': {
+				if (!model) return this
+				model.$id ??= `#/components/schemas/${name}`
+				this.definitions.type[name] = model
+				return this as any
+			}
+			default: 
 				return this as any
 		}
-
-		;(this.definitions.type as Record<string, TSchema>)[name] = model!
-
-		return this as any
 	}
 
 	mapDerive<

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,11 +337,15 @@ export type UnwrapSchema<
 		? Schema extends OptionalField
 			? Prettify<Partial<Static<Schema>>>
 			: StaticDecode<Schema>
-		: Schema extends string
-			? Definitions extends Record<Schema, infer NamedSchema>
-				? NamedSchema
+		: Schema extends `${infer Key}[]`
+			? Definitions extends Record<Key, infer NamedSchema>
+				? Array<NamedSchema>
 				: Definitions
-			: unknown
+			: Schema extends string
+				? Definitions extends Record<Schema, infer NamedSchema>
+					? NamedSchema
+					: Definitions
+				: unknown
 
 export type UnwrapBodySchema<
 	Schema extends TSchema | string | undefined,
@@ -352,11 +356,15 @@ export type UnwrapBodySchema<
 		? Schema extends OptionalField
 			? Prettify<Partial<Static<Schema>>> | null
 			: StaticDecode<Schema>
-		: Schema extends string
-			? Definitions extends Record<Schema, infer NamedSchema>
-				? NamedSchema
+		: Schema extends `${infer Key}[]`
+			? Definitions extends Record<Key, infer NamedSchema>
+				? Array<NamedSchema>
 				: Definitions
-			: unknown
+			: Schema extends string
+				? Definitions extends Record<Schema, infer NamedSchema>
+					? NamedSchema
+					: Definitions
+				: unknown
 
 export interface UnwrapRoute<
 	in out Schema extends InputSchema<any>,
@@ -510,7 +518,7 @@ export type HTTPMethod =
 	| 'ALL'
 
 export interface InputSchema<Name extends string = string> {
-	body?: TSchema | Name
+	body?: TSchema | Name | `${Name}[]`
 	headers?: TObject | TNull | TUndefined | Name
 	query?: TObject | TNull | TUndefined | Name
 	params?: TObject | TNull | TUndefined | Name
@@ -518,8 +526,8 @@ export interface InputSchema<Name extends string = string> {
 	response?:
 		| TSchema
 		| Record<number, TSchema>
-		| Name
-		| Record<number, Name | TSchema>
+		| `${Name}[]`| Name 
+		| Record<number, `${Name}[]` | Name | TSchema>
 }
 
 export interface MergeSchema<

--- a/test/extends/models.test.ts
+++ b/test/extends/models.test.ts
@@ -124,6 +124,10 @@ describe('Model', () => {
 					data: t.Number()
 				})
 			})
+			.post('/arr', ({ body }) => body, {
+				response: 'number[]',
+				body: 'number[]',
+			})
 
 		const correct = await app.handle(
 			new Request('http://localhost/', {
@@ -139,6 +143,19 @@ describe('Model', () => {
 
 		expect(correct.status).toBe(200)
 
+		const correctArr = await app.handle(
+			new Request('http://localhost/arr', {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json'
+				},
+				body: JSON.stringify([1, 2])
+			})
+		)
+
+		expect(correctArr.status).toBe(200)
+
+
 		const wrong = await app.handle(
 			new Request('http://localhost/', {
 				method: 'POST',
@@ -152,6 +169,20 @@ describe('Model', () => {
 		)
 
 		expect(wrong.status).toBe(422)
+
+		const wrongArr = await app.handle(
+			new Request('http://localhost/arr', {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json'
+				},
+				body: JSON.stringify({
+					data: true
+				})
+			})
+		)
+
+		expect(wrongArr.status).toBe(422)
 	})
 
 	it('remap', async () => {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -79,6 +79,28 @@ app.model({
 	}
 )
 
+app.model({
+	t: t.Object({
+		username: t.String(),
+		password: t.String()
+	})
+}).get(
+	'/',
+	({ body }) => {
+		// ? unwrap body type
+		expectTypeOf<{
+			username: string
+			password: string
+		}[]>().toEqualTypeOf<typeof body>()
+
+		return body
+	},
+	{
+		body: 't[]',
+		response: 't[]'
+	}
+)
+
 app.get('/id/:id', ({ params }) => {
 	// ? infer params name
 	expectTypeOf<{
@@ -183,6 +205,16 @@ app.model({
 				},
 				{
 					body: 'string'
+				}
+			)
+			.get(
+				'/',
+				({ body }) => {
+					expectTypeOf<typeof body>().not.toBeUnknown()
+					expectTypeOf<typeof body>().toEqualTypeOf<string[]>()
+				},
+				{
+					body: 'string[]'
 				}
 			)
 			.model({
@@ -404,6 +436,14 @@ const b = app
 		{
 			body: 'b'
 		}
+	).post(
+		'/',
+		({ body }) => {
+			expectTypeOf<typeof body>().toEqualTypeOf<'c'[]>()
+		},
+		{
+			body: 'c[]'
+		}
 	)
 
 // ? It derive void
@@ -485,6 +525,16 @@ app.use(plugin).get(
 	{
 		body: 'string'
 	}
+).get(
+	'/',
+	({ body, decorate, store: { state } }) => {
+		expectTypeOf<typeof decorate>().toBeString()
+		expectTypeOf<typeof state>().toBeString()
+		expectTypeOf<typeof body>().toEqualTypeOf<string[]>()
+	},
+	{
+		body: 'string[]'
+	}
 )
 
 export const asyncPlugin = async (app: Elysia) =>
@@ -502,6 +552,16 @@ app.use(asyncPlugin).get(
 	},
 	{
 		body: 'string'
+	}
+).get(
+	'/',
+	({ body, decorate, store: { state } }) => {
+		expectTypeOf<typeof decorate>().toBeString()
+		expectTypeOf<typeof state>().toBeString()
+		expectTypeOf<typeof body>().toEqualTypeOf<string[]>()
+	},
+	{
+		body: 'string[]'
 	}
 )
 


### PR DESCRIPTION
Hi 👋 

This is an initial attempt to address issues #402 and #921.

Changes Introduced:
 - Array Type Aliases: Appended `[]` to the body and response schema identifiers to represent an array type alias (à la arktype). This transformation converts the schema into `t.Array(t.Ref(MySchema))`.

- Prefilled `$id` Field: Automatically prefilled the `$id` field to allow seamless referencing within the API documentation.

Here's an example 
```ts
const app = new Elysia()
	.model({
		number: t.Number()
	})
	.post('/', ({ body }) => body, {
		response: 'number[]',
		body: 'number[]',
	})
``` 

Feel free to suggest or make any modifications as needed!

