### PR TITLE
fix: replace t.Number() for Type.Integer()

### DIFF
--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -376,7 +376,7 @@ export const ElysiaType = {
 							format: 'integer',
 							default: 0
 						}),
-						t.Number(property)
+						Type.Integer(property)
 					],
 					property
 				)

--- a/test/validator/body.test.ts
+++ b/test/validator/body.test.ts
@@ -194,6 +194,40 @@ describe('Body Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('rejects malformed integer from array object', async () => {
+		const app = new Elysia().post('/', ({ body }) => body, {
+			body: t.Array(
+				t.Object({
+					name: t.String(),
+					job: t.String(),
+					trait: t.Optional(t.String()),
+					age: t.Integer(),
+					rank: t.Integer()
+				})
+			)
+		})
+		const res = await app.handle(
+			post('/', [
+				{
+					name: 'sucrose',
+					job: 'alchemist',
+					age: 16.4,
+					rank: 4
+				}
+			])
+		)
+
+		expect(res.status).toBe(422)
+	})
+
+	it('rejects malformed integer directly in array', async () => {
+		const app = new Elysia().post('/', ({ body }) => body, {
+			body: t.Array(t.Integer())
+		})
+		const res = await app.handle(post('/', [1, 2, 3, 4.2]))
+
+		expect(res.status).toBe(422)
+	})
 	it('validate empty body', async () => {
 		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.Union([

--- a/test/validator/params.test.ts
+++ b/test/validator/params.test.ts
@@ -110,27 +110,40 @@ describe('Params Validator', () => {
 		})
 
 		const res = await app.handle(req('/id/617.1234'))
-		expect(await res.json()).toEqual({
+		expect(await res.json()).toMatchObject({
+			type: 'validation',
+			on: 'params',
+			summary: "Property 'id' should be one of: 'integer', 'integer'",
+			property: '/id',
+			message: 'Expected union value',
+			expected: {
+				id: 0
+			},
+			found: {
+				id: '617.1234'
+			},
 			errors: [
 				{
-					errors: [],
-					message: 'Expected integer',
-					path: '',
+					type: 62,
 					schema: {
-						type: 'integer'
+						anyOf: [
+							{
+								format: 'integer',
+								default: 0,
+								type: 'string'
+							},
+							{
+								type: 'integer'
+							}
+						]
 					},
-					summary: 'Expected integer',
-					type: 27,
-					value: 617.1234
+					path: '/id',
+					value: '617.1234',
+					message: 'Expected union value',
+					summary:
+						"Property 'id' should be one of: 'integer', 'integer'"
 				}
-			],
-			expected: 0,
-			found: 617.1234,
-			message: 'Expected integer',
-			on: 'property',
-			property: 'root',
-			summary: 'Expected integer',
-			type: 'validation'
+			]
 		})
 		expect(res.status).toBe(422)
 	})


### PR DESCRIPTION
Fixes #1011 

Tightens the schema used for Elysia's custom `t.Integer()` to reject numbers with any decimal content.

If there's some other considerations I'm missing feel free to let me know.