### PR TITLE
fix: undefined `route` context on `aot=false`

### DIFF
--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -62,6 +62,7 @@ export const createDynamicHandler = (app: AnyElysia) => {
 				set,
 				// @ts-expect-error
 				store: app.singleton.store,
+				route: app._route,
 				request,
 				path,
 				qi,

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ export default class Elysia<
 	private dependencies: Record<string, Checksum[]> = {}
 
 	_routes: Routes = {} as any
+	_route: string = ""
 
 	_types = {
 		Prefix: '' as BasePath,
@@ -680,7 +681,7 @@ export default class Elysia<
 				validator,
 				hooks,
 				content: localHook?.type as string,
-				handle
+				handle,
 			})
 
 			if (this.config.strictPath === false)
@@ -699,6 +700,7 @@ export default class Elysia<
 				hooks: hooks,
 				compile: handle
 			})
+			this._route = path
 
 			return
 		}

--- a/test/core/context.test.ts
+++ b/test/core/context.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from '../../src'
+import { req } from '../utils'
+
+describe('context', () => {
+	describe('return route', () => {
+		it('on aot=true', async () => {
+			const app = new Elysia().get('/hi/:id', ({ route }) => route)
+			const res = await app.handle(req('/hi/123')).then((x) => x.text())
+			expect(res).toBe('/hi/:id')
+		})
+
+		it('on aot=false', async () => {
+			const app = new Elysia({ aot: false }).get(
+				'/hi/:id',
+				({ route }) => route
+			)
+			const res = await app.handle(req('/hi/123')).then((x) => x.text())
+			expect(res).toBe('/hi/:id')
+		})
+	})
+
+	describe('early return on macros with route data', () => {
+		it('on aot=true', async () => {
+			const app = new Elysia()
+				.macro({
+					test: {
+						beforeHandle({ route }) {
+							return route
+						}
+					}
+				})
+				.get('/hi/:id', () => 'should not returned', {
+					test: true
+				})
+			const res = await app.handle(req('/hi/123')).then((x) => x.text())
+			expect(res).toBe('/hi/:id')
+		})
+
+		it('on aot=false', async () => {
+			const app = new Elysia({ aot: false })
+				.macro({
+					test: {
+						beforeHandle({ route }) {
+							return route
+						}
+					}
+				})
+				.get('/hi/:id', () => 'should not returned', {
+					test: true
+				})
+			const res = await app.handle(req('/hi/123')).then((x) => x.text())
+			expect(res).toBe('/hi/:id')
+		})
+	})
+})


### PR DESCRIPTION
It looks like the `route` context is returning `undefined` if the `aot=false`.

This commit try to fix it by passing the `route` to `createDynamicHandler`

Fix: [#898](https://github.com/elysiajs/elysia/issues/898)

---

Also added some test cases for it.