### PR TITLE
supplement missing types of tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,8 @@ import type {
 	ResolveResolutions,
 	UnwrapTypeModule,
 	MacroToContext,
-	MergeTypeModule
+	MergeTypeModule,
+	NoInfer
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ import type { WebSocketHandler } from './ws/bun'
 type PartialServe = Partial<Serve>
 
 export type IsNever<T> = [T] extends [never] ? true : false
+export type NoInfer<T> = T extends infer U ? U : never;
 
 export type ElysiaConfig<Prefix extends string | undefined> = {
 	/**


### PR DESCRIPTION
I found that I cannot get the correct type prompt for the third parameter of the request method, perhaps because the type tool is missing #995 