### PR TITLE
fix: Correctly set `t.Date()` defaults

### DIFF
--- a/src/type-system.ts
+++ b/src/type-system.ts
@@ -393,7 +393,9 @@ export const ElysiaType = {
 	},
 	Date: (property?: DateOptions) => {
 		const schema = Type.Date(property)
-
+		const _default = property?.default ?
+			new Date(property.default) : // in case the default is an ISO string or milliseconds from epoch
+			undefined;
 		return t
 			.Transform(
 				t.Union(
@@ -401,13 +403,13 @@ export const ElysiaType = {
 						Type.Date(property),
 						t.String({
 							format: 'date',
-							default: new Date().toISOString()
+							default: _default?.toISOString()
 						}),
 						t.String({
 							format: 'date-time',
-							default: new Date().toISOString()
+							default: _default?.toISOString()
 						}),
-						t.Number()
+						t.Number({ default: _default?.getTime() })
 					],
 					property
 				)

--- a/test/type-system/date.test.ts
+++ b/test/type-system/date.test.ts
@@ -1,12 +1,33 @@
 import Elysia, { t } from '../../src'
 import { describe, expect, it } from 'bun:test'
 import { Value } from '@sinclair/typebox/value'
-import { TBoolean, TDate, TypeBoxError } from '@sinclair/typebox'
+import { TBoolean, TDate, TUnion, TypeBoxError } from '@sinclair/typebox'
 import { post } from '../utils'
 
 describe('TypeSystem - Date', () => {
 	it('Create', () => {
 		expect(Value.Create(t.Date())).toBeInstanceOf(Date)
+	})
+
+	it('No default date provided', () => {
+		const schema = t.Date()
+		expect(schema.default).toBeUndefined();
+
+		const unionSchema = schema as unknown as TUnion
+		for (const type of unionSchema.anyOf) {
+			expect(type.default).toBeUndefined();
+		}
+	})
+
+	it('Default date provided', () => {
+		const given = new Date("2025-01-01T00:00:00.000Z")
+		const schema = t.Date({ default: given })
+		expect(schema.default).toEqual(given);
+
+		const unionSchema = schema as unknown as TUnion
+		for (const type of unionSchema.anyOf) {
+			expect(new Date(type.default)).toEqual(given);
+		}
 	})
 
 	it('Check', () => {


### PR DESCRIPTION
Currently we hardcode the default for the `t.String` with date and date-time formats to the current time. We should be respecting the defaults that are being provided as part of the DateOptions.

In this PR, we use the default passed in via DateOptions to set the defaults for `t.String` with date and date-time formats, as well as `t.Number`.

I've added a test case in the first commit to demonstrate the bug I'm describing