### PR TITLE
improve dev env steps and fix bun run dev experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,13 @@ The Elysia.js repo is using [bun](https://bun.sh). Make sure you have the [lates
 
 1. Clone this repository
 
-2. In the root of this project, run `bun install` to install all of the necessary dependencies
+2. In the root of this project, run `bun install` to install dependencies
 
-3. To run the development version, run `bun run dev`
+3. Run `bun test` to run unit tests
+
+4. (optional) Run `bun build` to locally build files and `bun run test` to run a full test
+
+5. Run `bun run dev` to start an example application :fox_face:
 
 ### Unit Testing
 

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,21 +1,24 @@
-import { Elysia, error, t } from '../src'
+import { Elysia, t } from '../src'
 import { req } from '../test/utils'
 
 const app = new Elysia().get(
 	'/',
 	() => {
 		return {
-			name: 'a',
-			a: 'b'
+			message: 'Hello World!'
 		}
 	},
 	{
 		response: t.Object({
-			name: t.String()
+			message: t.String()
 		})
 	}
 )
 
-app.handle(req('/'))
-	.then((x) => x.json())
+app.listen(3000, ({ hostname, port }) => {
+	console.log(`🦊 running at http://${hostname}:${port}`)
+})
+  // Trigger the request
+	.handle(req('/'))
+	.then((res) => res.json())
 	.then(console.log)


### PR DESCRIPTION
ref #1095 

starting `bun run test` in a fresh clone fails because it requires `bun run build`. Additionally, `examples/a.ts` had unused imports and didn't create a local server, so made sure to listen to :3000 as well