### PR TITLE
fix: websocket errors not catching

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -186,9 +186,9 @@ export const BunAdapter: ElysiaAdapter = {
 				let _id: string | undefined
 
 				const errorHandlers = [
-					...(Array.isArray(options.error)
+					...(options.error ? (Array.isArray(options.error)
 						? options.error
-						: [options.error]),
+						: [options.error]) : []),
 					...(app.event.error ?? []).map((x) =>
 						typeof x === 'function' ? x : x.fn
 					)
@@ -229,9 +229,9 @@ export const BunAdapter: ElysiaAdapter = {
 							pong(data?: unknown) {
 								options.pong?.(data)
 							},
-							open(ws: ServerWebSocket<any>) {
+							open: async (ws: ServerWebSocket<any>) => {
 								try {
-									handleResponse(
+									await handleResponse(
 										ws,
 										options.open?.(
 											new ElysiaWS(ws, context as any)
@@ -257,7 +257,7 @@ export const BunAdapter: ElysiaAdapter = {
 									)
 
 								try {
-									handleResponse(
+									await handleResponse(
 										ws,
 										options.message?.(
 											new ElysiaWS(
@@ -272,9 +272,9 @@ export const BunAdapter: ElysiaAdapter = {
 									handleErrors(ws, error)
 								}
 							},
-							drain(ws: ServerWebSocket<any>) {
+							drain: async (ws: ServerWebSocket<any>) => {
 								try {
-									handleResponse(
+									await handleResponse(
 										ws,
 										options.drain?.(
 											new ElysiaWS(ws, context as any)
@@ -284,13 +284,13 @@ export const BunAdapter: ElysiaAdapter = {
 									handleErrors(ws, error)
 								}
 							},
-							close(
+							close: async (
 								ws: ServerWebSocket<any>,
 								code: number,
 								reason: string
-							) {
+							) => {
 								try {
-									handleResponse(
+									await handleResponse(
 										ws,
 										options.close?.(
 											new ElysiaWS(ws, context as any),

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -487,4 +487,33 @@ describe('WebSocket message', () => {
 		await wsClosed(ws)
 		app.stop()
 	})
+
+	it('handle error with onError', async () => {
+		const app = new Elysia()
+			.onError(() => {
+				return 'caught'
+			})
+			.ws('/ws', {
+				message(ws, message) {
+					throw new Error('A')
+				}
+			})
+			.listen(0)
+
+		const ws = newWebsocket(app.server!)
+
+		await wsOpen(ws)
+
+		const message = wsMessage(ws)
+
+		ws.send('Hello!')
+
+		const { type, data } = await message
+
+		expect(type).toBe('message')
+		expect(data).toBe('caught')
+
+		await wsClosed(ws)
+		app.stop()
+	})
 })


### PR DESCRIPTION
This PR fixes a few issues related to catching websocket errors.

To reproduce, run `bun run example/websocket.ts` with the following code (an uncaught error occurs):

```typescript
import { Elysia } from "../src";

const app = new Elysia()
	.state("start", "here")
	.ws("/ws", {
		open(ws) {
			throw new Error("asdf");
			ws.subscribe("asdf");
			console.log("Open Connection:", ws.id);
		},
		close(ws) {
			console.log("Closed Connection:", ws.id);
		},
		message(ws, message) {
			ws.publish("asdf", message);
			ws.send("asdf", message);
		},
	})
	.get("/publish/:publish", ({ params: { publish: text } }) => {
		app.server!.publish("asdf", text);

		return text;
	})
	.listen(3000, (server) => {
		console.log(`http://${server.hostname}:${server.port}`);
	});

const ws = new WebSocket('ws://localhost:3000/ws')

ws.onopen = () => {
	console.log('Connected to websocket')
	ws.send('Hello from client!')
}

ws.onmessage = (event) => {
	console.log('Received:', event.data)
}

ws.onclose = () => {
	console.log('Disconnected from websocket')
}

ws.onerror = (error) => {
	console.error('WebSocket error:', error)
}
```

If you modify the the code to have an `onError` handler above the websocket it also doesn't catch.

While on this topic: right now if there aren't any error handlers the error fails silently. Should there be a default `ws` error handler that closes the connection?