### PR TITLE
test: use `describe` instead of nested `it`

### DIFF
--- a/test/validator/params.test.ts
+++ b/test/validator/params.test.ts
@@ -233,7 +233,7 @@ describe('Params Validator', () => {
 		expect(value).toBe('boolean')
 	})
 
-	it('create default value on optional params', () => {
+	describe('create default value on optional params', () => {
 		it('parse multiple optional params', async () => {
 			const app = new Elysia().get(
 				'/name/:last?/:first?',


### PR DESCRIPTION
## What This PR Does

The Bun team is considering disallowing nested `it`/`test` blocks. Currently, tests run with canary builds of Bun will fail if nested `it` statements are found, but we may revert this change.

If we decide to move forward with it, this PR keeps your tests running. We run eslysia's tests in our CI, so this change also unblocks PRs on our end.