### PR TITLE
add support to return web API's File from handler

### DIFF
--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -341,6 +341,9 @@ export const mapResponse = (
 
 			case 'ElysiaFile':
 				return handleFile((response as ElysiaFile).value as File)
+			
+			case 'File':
+				return handleFile(response as File, set as any)
 
 			case 'Blob':
 				return handleFile(response as Blob, set as any)
@@ -542,6 +545,9 @@ export const mapEarlyResponse = (
 			case 'ElysiaFile':
 				return handleFile((response as ElysiaFile).value as File)
 
+			case 'File':
+				return handleFile(response as File, set as any)
+
 			case 'Blob':
 				return handleFile(response as File | Blob, set)
 
@@ -710,6 +716,9 @@ export const mapEarlyResponse = (
 			case 'ElysiaFile':
 				return handleFile((response as ElysiaFile).value as File)
 
+			case 'File':
+				return handleFile(response as File, set as any)
+
 			case 'Blob':
 				return handleFile(response as File | Blob, set)
 
@@ -857,6 +866,9 @@ export const mapCompactResponse = (
 
 		case 'ElysiaFile':
 			return handleFile((response as ElysiaFile).value as File)
+
+		case 'File':
+			return handleFile(response as File)
 
 		case 'Blob':
 			return handleFile(response as File | Blob)

--- a/test/adapter/web-standard/map-compact-response.test.ts
+++ b/test/adapter/web-standard/map-compact-response.test.ts
@@ -87,6 +87,16 @@ describe('Web Standard - Map Compact Response', () => {
 		expect(response.status).toBe(200)
 	})
 
+	it('map File', async () => {
+		const file = new File(['Hello'], 'hello.txt', { type: 'text/plain' })
+
+		const response = mapCompactResponse(file)
+
+		expect(response).toBeInstanceOf(Response)
+		expect(await response.text()).toEqual('Hello')
+		expect(response.status).toBe(200)
+	})
+
 	it('map Promise', async () => {
 		const body = {
 			name: 'Shiroko'

--- a/test/adapter/web-standard/map-early-response.test.ts
+++ b/test/adapter/web-standard/map-early-response.test.ts
@@ -86,6 +86,16 @@ describe('Web Standard - Map Early Response', () => {
 		expect(response?.status).toBe(200)
 	})
 
+	it('map File', async () => {
+		const file = new File(['Hello'], 'hello.txt', { type: 'text/plain' })
+
+		const response = mapEarlyResponse(file, defaultContext)
+
+		expect(response).toBeInstanceOf(Response)
+		expect(await response?.text()).toEqual('Hello')
+		expect(response?.status).toBe(200)
+	})
+
 	it('map Promise', async () => {
 		const body = {
 			name: 'Shiroko'

--- a/test/adapter/web-standard/map-response.test.ts
+++ b/test/adapter/web-standard/map-response.test.ts
@@ -105,6 +105,16 @@ describe('Web Standard - Map Response', () => {
 		expect(response.status).toBe(200)
 	})
 
+	it('map File', async () => {
+		const file = new File(['Hello'], 'hello.txt', { type: 'text/plain' })
+
+		const response = mapResponse(file, defaultContext)
+
+		expect(response).toBeInstanceOf(Response)
+		expect(await response.text()).toEqual('Hello')
+		expect(response.status).toBe(200)
+	})
+
 	it('map Promise', async () => {
 		const body = {
 			name: 'Shiroko'

--- a/test/path/path.test.ts
+++ b/test/path/path.test.ts
@@ -316,6 +316,10 @@ describe('Path', () => {
 
 		expect(res.headers.get('content-type')).toBe('text/plain;charset=utf-8')
 		expect(await res.text()).toBe('Hello')
+		expect(res.status).toBe(200)
+		expect(res.headers.get('accept-ranges')).toBe('bytes')
+		expect(res.headers.get('content-range')).toBe('bytes 0-4/5')
+
 	})
 
 	it('handle *', async () => {

--- a/test/path/path.test.ts
+++ b/test/path/path.test.ts
@@ -310,6 +310,14 @@ describe('Path', () => {
 		expect(res.headers.get('Server')).toBe('Elysia')
 	})
 
+	it('return web api\'s File', async () => {
+		const app = new Elysia().get('/', () => new File(['Hello'], 'hello.txt', { type: 'text/plain' }))
+		const res = await app.handle(req('/'))
+
+		expect(res.headers.get('content-type')).toBe('text/plain;charset=utf-8')
+		expect(await res.text()).toBe('Hello')
+	})
+
 	it('handle *', async () => {
 		const app = new Elysia().get('/*', () => 'Hi')
 		const get = await app.handle(req('/')).then((r) => r.text())


### PR DESCRIPTION
```ts
it('return web api\'s File', async () => {
		const app = new Elysia().get('/', () => new File(['Hello'], 'hello.txt', { type: 'text/plain' }))
		const res = await app.handle(req('/'))

		expect(res.headers.get('content-type')).toBe('text/plain;charset=utf-8')
		expect(await res.text()).toBe('Hello')
		expect(res.status).toBe(200)
		expect(res.headers.get('accept-ranges')).toBe('bytes')
		expect(res.headers.get('content-range')).toBe('bytes 0-4/5')
	})
```