### PR TITLE
fix: preserve encoded '+' characters in URL query parameters

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -898,12 +898,12 @@ export const composeHandler = ({
 							`if(a${index}===undefined)` +
 							`a${index}=[]\n` +
 							`if(memory===-1){` +
-							`const temp=decodeURIComponent(url.slice(start)).replace(/\\+/g,' ')\n` +
+							`const temp=decodeURIComponent(url.slice(start))\n` +
 							`if(temp.includes(',')){a${index}=a${index}.concat(temp.split(','))}` +
-							`else{a${index}.push(decodeURIComponent(url.slice(start)).replace(/\\+/g,' '))}\n` +
+							`else{a${index}.push(decodeURIComponent(url.slice(start)))}\n` +
 							`break` +
 							`}else{` +
-							`const temp=decodeURIComponent(url.slice(start, memory)).replace(/\\+/g,' ')\n` +
+							`const temp=decodeURIComponent(url.slice(start, memory))\n` +
 							`if(temp.includes(',')){a${index}=a${index}.concat(temp.split(','))}` +
 							`else{a${index}.push(temp)}\n` +
 							`}` +

--- a/src/deuri.ts
+++ b/src/deuri.ts
@@ -154,7 +154,7 @@ export const decode = (url: string): string | null => {
 			start = percentPosition + 3
 
 			percentPosition = url.indexOf('%', start)
-			if (percentPosition === -1) {console.log("ccc", decoded + url.substring(start)); return decoded + url.substring(start)}
+			if (percentPosition === -1) return decoded + url.substring(start)
 
 			// Ensure percentPosition always has 2 chars after
 			if (percentPosition > end) return null

--- a/src/deuri.ts
+++ b/src/deuri.ts
@@ -115,6 +115,9 @@ export const decode = (url: string): string | null => {
 	let percentPosition = url.indexOf('%')
 	if (percentPosition === -1) return url
 
+	// Ensure that not encoded plus signs are replaced with spaces
+	url = url.replace(/\+/g, ' ')
+
 	// Ensure percentPosition always has 2 chars after
 	let end = url.length - 3
 	if (percentPosition > end) return null
@@ -151,7 +154,7 @@ export const decode = (url: string): string | null => {
 			start = percentPosition + 3
 
 			percentPosition = url.indexOf('%', start)
-			if (percentPosition === -1) return decoded + url.substring(start)
+			if (percentPosition === -1) {console.log("ccc", decoded + url.substring(start)); return decoded + url.substring(start)}
 
 			// Ensure percentPosition always has 2 chars after
 			if (percentPosition > end) return null


### PR DESCRIPTION
This is a fix for: #1162

## Problem
When processing URL query parameters containing '+' characters (like in dates or mathematical expressions), they were being incorrectly converted to spaces according to standard URL encoding rules. This caused issues with date parameters and other values where literal '+' characters are meaningful.

## Solution
Modified the query parameter handling to preserve encoded '+' and replace not encoded '+' by a space.

## Impact
- Date parameters with time zone indicators (e.g., "2023-04-05T12:30:00+01:00") now parse correctly
- Mathematical expressions containing '+' operators remain intact
- Any query parameter requiring literal '+' characters now works as expected