### PR TITLE
fix: skip non-numeric status codes in response schema validation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -844,6 +844,10 @@ export const getResponseSchemaValidator = (
 	const record: Record<number, TypeCheck<any>> = {}
 
 	Object.keys(maybeSchemaOrRecord).forEach((status): TSchema | undefined => {
+		if (isNaN(+status)) {
+			return undefined;
+		}
+		
 		const maybeNameOrSchema = maybeSchemaOrRecord[+status]
 
 		if (typeof maybeNameOrSchema === 'string') {

--- a/test/validator/response.test.ts
+++ b/test/validator/response.test.ts
@@ -257,7 +257,8 @@ describe('Response Validator', () => {
 				}),
 				response: {
 					200: t.String(),
-					201: t.Number()
+					201: t.Number(),
+					default: t.String()
 				}
 			}
 		)


### PR DESCRIPTION
When defining response schemas with status codes, only numeric HTTP status codes (like 200, 404, etc.) should be processed. Previously, the validator would crash if non-numeric keys were present in the response schema definition.

Error
```
undefined is not an object (evaluating 'maybeNameOrSchema.type')
```

This change adds a validation check to safely ignore any non-numeric status codes, making the schema validator more robust against invalid inputs.

And one of the use case is that we can set a `default` status in response schema as allowed by [OpenAPI 3.0.4](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.4.md#responses-object) specification. 

```tsx
const app = new Elysia().get(
  '/health',
  () => {
    return {
      status: 200,
      response: 'Hello world',
    };
  },
  {
    response: {
      200: t.String(),
      default: t.String(),
    },
  },
);
```

This will be generate in Swagger UI like this:

<img width="670" alt="Screenshot 2025-04-16 at 3 27 44 PM" src="https://github.com/user-attachments/assets/06cb06cf-7a28-4c9e-a4da-defe1489f00d" />

 

Also, fixes #1164