### PR TITLE
ci: publish preview version of Elysia for testing on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,7 @@ jobs:
 
             - name: Test
               run: bun run test
+
+            - name: Publish Preview
+              if: github.event_name == 'pull_request'
+              run: bunx pkg-pr-new publish


### PR DESCRIPTION
Using the same strategy as Vite, this PR will publish a preview version of package that can be used to test the package without needing to publish manually by using [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new)

Noted that before pkg-pr-new bot can publish, and comment version to GitHub app needed to be installed first. ([As described in Setup step](https://github.com/stackblitz-labs/pkg.pr.new))

As a result, when testing with project locally from someone else PR's we can do something like this in `package.json`

```json
"dependencies": {
  "elysia": "npm:https://pkg.pr.new/elysiajs/elysia@1181"
}
```