### PR TITLE
fix: Websocket `beforeLoad` not being executed

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -323,6 +323,14 @@ export const BunAdapter: ElysiaAdapter = {
 			normalize: app.config.normalize
 		})
 
+		const validateUpgradeData = getSchemaValidator(options.upgradeData, {
+			// @ts-expect-error private property
+			modules: app.definitions.typebox,
+			// @ts-expect-error private property
+			models: app.definitions.type as Record<string, TSchema>,
+			normalize: app.config.normalize
+		})
+
 		app.route(
 			'WS',
 			path as any,
@@ -367,6 +375,12 @@ export const BunAdapter: ElysiaAdapter = {
 				const parseMessage = createWSMessageParser(parse)
 
 				let _id: string | undefined
+
+				let _beforeHandleData: any
+				if (typeof options.beforeHandle === 'function') {
+					const result = options.beforeHandle(context)
+					_beforeHandleData = result instanceof Promise ? await result : result
+				}
 
 				const errorHandlers = [
 					...(Array.isArray(options.error)
@@ -413,11 +427,22 @@ export const BunAdapter: ElysiaAdapter = {
 								options.pong?.(data)
 							},
 							open(ws: ServerWebSocket<any>) {
+								if (validateUpgradeData?.Check(_beforeHandleData) === false) {
+									return void ws.send(
+										new ValidationError(
+											'upgradeData',
+											validateUpgradeData,
+											_beforeHandleData
+										).message as string
+									)
+								}
+
 								try {
 									handleResponse(
 										ws,
 										options.open?.(
-											new ElysiaWS(ws, context as any)
+											new ElysiaWS(ws, context as any),
+											_beforeHandleData as any
 										)
 									)
 								} catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5384,7 +5384,8 @@ export default class Elysia<
 				MergeSchema<Ephemeral['schema'], Metadata['schema']>
 			>
 		>,
-		const Macro extends Metadata['macro']
+		const Macro extends Metadata['macro'],
+		const UpgradeDataSchema extends TSchema,
 	>(
 		path: Path,
 		options: WSLocalHook<
@@ -5396,7 +5397,8 @@ export default class Elysia<
 					Volatile['resolve'] &
 					MacroToContext<Metadata['macroFn'], Macro>
 			},
-			Macro
+			Macro,
+			UpgradeDataSchema
 		>
 	): Elysia<
 		BasePath,

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -487,4 +487,38 @@ describe('WebSocket message', () => {
 		await wsClosed(ws)
 		app.stop()
 	})
+
+	it('should call beforeHandle hook', async () => {
+		const app = new Elysia()
+			.ws('/ws', {
+				upgradeData: t.Object({
+					hello: t.String()
+				}),
+				beforeHandle() {
+					return {
+						hello: 'world'
+					}
+				},
+				open(ws, data) {
+					ws.send(data.hello)
+				}
+			})
+			.listen(0)
+
+		const ws = newWebsocket(app.server!)
+
+		await wsOpen(ws)
+
+		const message = wsMessage(ws)
+
+		ws.send('Hello!')
+
+		const { data } = await message
+		
+		expect(data).toBe('world')
+
+		await wsClosed(ws)
+
+		app.stop()
+	})
 })


### PR DESCRIPTION
- [x] Fixes `beforeHandle` hook before upgrading not being executed;
- [x] Support for validating upgrade data with TypeBox schemas (typesafe) (maybe a better name then `upgradeData`?).

Fixes #1169 