### PR TITLE
export adapter utils for use in building external adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
 			"import": "./dist/adapter/index.mjs",
 			"require": "./dist/cjs/adapter/index.js"
 		},
+		"./adapter/utils": {
+			"types": "./dist/adapter/utils.d.ts",
+			"import": "./dist/adapter/utils.mjs",
+			"require": "./dist/cjs/adapter/utils.js"
+		},
 		"./adapter/bun": {
 			"types": "./dist/adapter/bun/index.d.ts",
 			"import": "./dist/adapter/bun/index.mjs",


### PR DESCRIPTION
This PR will add the /adapter/utils file to the list of exports in package.json.

Currently the node adapter is [broken](https://github.com/elysiajs/elysia/issues/1212) on Elysia 1.3.  Some of us have attempted to fix it, but it seems that having access to import the adapter utils will be necessary to do so without copying or rebuilding a bunch of code.  Exporting the these utils in "package.json should allow the node adapter to access those utils and reuse the code that is used to build the built-in adapter.