### PR TITLE
fix: standalone validator - guard types, as(scoped|global) and hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2902,7 +2902,6 @@ export default class Elysia<
 			)
 			this.validator.local = null
 
-			console.log("BEFORE", this.standaloneValidator.local)
 			if (this.standaloneValidator.local !== null) {
 				this.standaloneValidator.scoped ||= []
 				this.standaloneValidator.scoped.push(
@@ -2910,7 +2909,6 @@ export default class Elysia<
 				)
 				this.standaloneValidator.local = null
 			}
-			console.log("AFTER", this.standaloneValidator.scoped)
 		} else if (type === 'global') {
 			this.validator.global = mergeSchemaValidator(
 				this.validator.global,


### PR DESCRIPTION
As of now, standalone validators do not correctly work with:
- `.as("scoped" | "global")` on the instance (standaloneValidators property doesn't get promoted to the proper level)
- hooks inside the guard like `beforeHandle` don't get set on the instance
- `.derive`, `.onBeforeHandle` and most other hooks (type information from standalone validators doesn't get to them)

This PR aims to fix this. Standalone validators are the best feature imho as it enables great composability in the framework, but they are a bit undercooked. Thanks for creating and maintaning elysia!