### PR TITLE
Ensure WebSockets get routed properly without AoT compilation

### DIFF
--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -88,8 +88,15 @@ export const createDynamicHandler = (app: AnyElysia) => {
 					if (response) return (context.response = response)
 				}
 
+			const isWS =
+				request.method === 'GET' &&
+				request.headers.get('upgrade')?.toLowerCase() === 'websocket'
+
+			const methodKey = isWS ? 'WS' : request.method
+
 			const handler =
 				app.router.dynamic.find(request.method, path) ??
+				app.router.dynamic.find(methodKey, path) ??
 				app.router.dynamic.find('ALL', path)
 
 			if (!handler) throw new NotFoundError()

--- a/test/ws/aot.test.ts
+++ b/test/ws/aot.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'bun:test'
+import { Elysia } from '../../src'
+import { newWebsocket, wsOpen, wsClosed } from './utils'
+
+describe('WebSocket with AoT disabled', () => {
+	it('should connect and close', async () => {
+		const app = new Elysia({ aot: false })
+			.ws('/ws', {
+				message() {}
+			})
+			.listen(0)
+
+		// @ts-expect-error some properties are missing
+		const ws = newWebsocket(app.server!)
+
+		await wsOpen(ws)
+		await wsClosed(ws)
+
+		await app.stop()
+	})
+})


### PR DESCRIPTION
This intends to fix https://github.com/elysiajs/elysia/issues/1215 where trying to connect to a WS would 404 without AOT. I've added a basic test case for it.