### PR TITLE
fix: align mapResponse and onAfterHandle with unified return types an…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1951,7 +1951,7 @@ export default class Elysia<
 	>(
 		options: { as?: LifeCycleType },
 		handler: MaybeArray<
-			OptionalHandler<
+			AfterHandler<
 				MergeSchema<
 					Schema,
 					MergeSchema<

--- a/src/types.ts
+++ b/src/types.ts
@@ -922,7 +922,7 @@ export type MapResponse<
 		},
 		Path
 	>
-) => MaybePromise<Response | void>
+) => MaybePromise<{} extends Route['response'] ? unknown : Route['response'][keyof Route['response']] | void>
 
 // Handler<
 // 	Omit<Route, 'response'> & {},


### PR DESCRIPTION
### Changes

- Relaxed the return type of `mapResponse` to support primitive values (e.g. string, number), aligning its behavior with `AfterHandler`.
- Updated `onAfterHandle` to use `AfterHandler` instead of `OptionalHandler` for consistency and clarity in handler semantics.

### Motivation

This change improves the developer experience by making the behavior of response handlers more predictable and flexible. It also eliminates subtle inconsistencies between `mapResponse` and `onAfterHandle`.

No breaking changes expected for users following the current type contracts.