### PR TITLE
fix(#1238): bun adapter add qi to routes that need query from guard

### DIFF
--- a/test/adapter/bun/index.test.ts
+++ b/test/adapter/bun/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'bun:test'
+import { Elysia, t } from '../../../src'
+
+describe('Bun adapter', () => {
+    it('handle query guard', async () => {
+        const app = new Elysia()
+            .guard(({
+                query: t.Object({ a: t.String() }),
+            }))
+            .get("/works-with", ({ query }) => "Works" + query.a)
+            .get("/works-without", () => "Works without")
+            .listen(0)
+
+        const query = await fetch(
+                `http://localhost:${app.server!.port}/works-with?a=with`
+        ).then((x) => x.text())
+
+        expect(query).toEqual("Workswith")
+
+        const query2 = await fetch(
+            `http://localhost:${app.server!.port}/works-without?a=1`
+        ).then((x) => x.text())
+
+        expect(query2).toEqual("Works without")
+    })
+
+    it('handle standalone query guard', async () => {
+        const app = new Elysia()
+            .guard(({
+                query: t.Object({ a: t.String() }),
+                schema: "standalone"
+            }))
+            .get("/works-with", ({ query }) => "Works" + query.a)
+            .get("/works-without", () => "Works without")
+            .listen(0)
+
+        const query = await fetch(
+                `http://localhost:${app.server!.port}/works-with?a=with`
+        ).then((x) => x.text())
+
+        expect(query).toEqual("Workswith")
+
+        const query2 = await fetch(
+            `http://localhost:${app.server!.port}/works-without?a=1`
+        ).then((x) => x.text())
+
+        expect(query2).toEqual("Works without")
+    })
+})


### PR DESCRIPTION
fixes #1238 
`src/adapter/bun/compose.ts` didn't account for routes that have a guard that requires query, thus leading to a bug. This PR adds a straightforward check for it, bypassing `sucrose` calls
While this works, I think(?) that it would be better to handle route validators (including standalone validators) inside `sucrose` if I understand the purpose of this function right, but as of now I can't think of a way to do it properly
Would love to hear SaltyAoms thought on it. Also there is a test included for this specific case