### PR TITLE
fix(types): preserve type narrowing in getSchemaValidator

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -694,7 +694,7 @@ export const getSchemaValidator = <T extends TSchema | string | undefined>(
 		validators?: InputSchema['body'][]
 		sanitize?: () => ExactMirrorInstruction['sanitize']
 	} = {}
-): T extends TSchema ? ElysiaTypeCheck<TSchema> : undefined => {
+): T extends TSchema ? ElysiaTypeCheck<T> : undefined => {
 	validators = validators?.filter((x) => x)
 
 	if (!s) {


### PR DESCRIPTION
When I used `getSchemaValidator`, I expected `.Check()` to properly narrow types as a type guard.

However, I found that because the return type uses `ElysiaTypeCheck<TSchema>` instead of `ElysiaTypeCheck<T>`, the type narrowing does not work correctly—even though `T` extends `TSchema`.

Example:

```typescript
import { t, getSchemaValidator } from "elysia";

const schema = t.Object({
	key: t.String(),
});

const myData: Record<string, string> = {};

const validator = getSchemaValidator(schema);
const isValid = validator.Check(myData);

if (isValid) {
	myData; // is still inferred as Record<string, string>
}
```

After applying this fix, when `isValid` is `true`, `myData` is correctly narrowed to `{ key: string }` inside the `if` block.

```typescript
if (isValid) {
	myData; // is { key: string }
}
```