### PR TITLE
fix: onRequest not firing

### DIFF
--- a/src/adapter/bun/compose.ts
+++ b/src/adapter/bun/compose.ts
@@ -127,7 +127,7 @@ export const createBunRouteHandler = (app: AnyElysia, route: InternalRoute) => {
 	const needsQuery = inference.query || !!route.hooks.query || !!route.standaloneValidators?.find((x) => x.query)
 
 	// inference.query require declaring const 'qi'
-	if (hasTrace || needsQuery) {
+	if (hasTrace || needsQuery || app.event.request?.length) {
 		fnLiteral += createContext(app, route, inference)
 		fnLiteral += createOnRequestHandler(app)
 


### PR DESCRIPTION
This fixes an issue where `onRequest` handlers would not fire, breaking plugins such as `@elysiajs/cors`.

I believe this was caused by not including `createOnRequestHandler()` in the compose phase, even if some `request` handlers should be registered.

Fixes #1308