### PR TITLE
fix: array of plugin usage causes incorrect path aggregation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1727,7 +1727,7 @@ export type MergeElysiaInstances<
 			Routes &
 				(Prefix extends ``
 					? Current['~Routes']
-					: AddPrefix<Prefix, Current['~Routes']>)
+					: CreateEden<Prefix, Current['~Routes']>)
 		>
 	: Elysia<
 			Prefix,

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -962,9 +962,11 @@ app.group(
 // ? Inherits plugin instance prefix path
 {
 	const pluginPrefixApp = new Elysia({ prefix: '/app' }).get('/test', () => 'hello')
-	const appWithPrefix = new Elysia({ prefix: '/api' }).use([pluginPrefixApp])
 
-	expectTypeOf<typeof appWithPrefix['~Routes']>().toEqualTypeOf<{
+	const appWithArrayOfPlugin = new Elysia({ prefix: '/api' }).use([pluginPrefixApp])
+	const appWithPlugin = new Elysia({ prefix: '/api' }).use(pluginPrefixApp)
+	
+	expectTypeOf<typeof appWithArrayOfPlugin['~Routes']>().toEqualTypeOf<{
 		api: {
 			app: {
 				test: {
@@ -981,6 +983,7 @@ app.group(
 			},
 		}
 	}>()
+	expectTypeOf<typeof appWithArrayOfPlugin['~Routes']>().toEqualTypeOf<typeof appWithPlugin['~Routes']>()
 }
 
 // ? Inlining function callback don't repeat prefix

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -959,6 +959,30 @@ app.group(
 	}>()
 }
 
+// ? Inherits plugin instance prefix path
+{
+	const pluginPrefixApp = new Elysia({ prefix: '/app' }).get('/test', () => 'hello')
+	const appWithPrefix = new Elysia({ prefix: '/api' }).use([pluginPrefixApp])
+
+	expectTypeOf<typeof appWithPrefix['~Routes']>().toEqualTypeOf<{
+		api: {
+			app: {
+				test: {
+					get: {
+						body: unknown
+						headers: unknown
+						query: unknown
+						params: Record<never, string>
+						response: {
+							200: string
+						}
+					}
+				}
+			},
+		}
+	}>()
+}
+
 // ? Inlining function callback don't repeat prefix
 {
 	const test = (app: Elysia) =>


### PR DESCRIPTION
This PR should fix type inference when Elysia instance uses array of plugins with prefix, it also should infer same route type as single plugin usage

Type tests are available in https://github.com/miello/elysia/blob/53678c8083b5c7b3f24896440347b07f5698af86/test/types/index.ts#L962

----

### Before

<img width="1133" height="287" alt="image" src="https://github.com/user-attachments/assets/e49f92d4-2ce7-4e24-baa4-21e06ca00a1d" />

### After

<img width="1105" height="310" alt="image" src="https://github.com/user-attachments/assets/f2d8d97f-da36-466a-a8e3-54681c6bf600" />


