### PR TITLE
Fix HTML imported pages in compiled apps

### DIFF
--- a/src/adapter/bun/handler-native.ts
+++ b/src/adapter/bun/handler-native.ts
@@ -1,3 +1,4 @@
+import { isHTMLBundle } from '.'
 import type { Context } from '../../context'
 import type { AnyLocalHook, MaybePromise } from '../../types'
 
@@ -10,11 +11,9 @@ export const createNativeStaticHandler = (
 ): (() => MaybePromise<Response>) | undefined => {
 	if (typeof handle === 'function' || handle instanceof Blob) return
 
-	if (
-		typeof handle === 'object' &&
-		handle?.toString() === '[object HTMLBundle]'
-	)
+	if (isHTMLBundle(handle)) {
 		return () => handle as any
+	}
 
 	const response = mapResponse(handle, {
 		headers: setHeaders

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -64,6 +64,15 @@ const getPossibleParams = (path: string) => {
 	return routes
 }
 
+export const isHTMLBundle = (handle: any) => {
+	return (
+		typeof handle === 'object' &&
+		handle !== null &&
+		(handle.toString() === '[object HTMLBundle]' ||
+			typeof handle.index === 'string')
+	)
+}
+
 const supportedMethods = {
 	GET: true,
 	HEAD: true,
@@ -260,11 +269,7 @@ export const BunAdapter: ElysiaAdapter = {
 												staticRoutes[path][method] =
 													awaited
 
-											if (
-												typeof awaited === 'object' &&
-												awaited?.toString() ===
-													'[object HTMLBundle]'
-											)
+											if (isHTMLBundle(awaited))
 												// @ts-ignore
 												staticRoutes[path][method] =
 													awaited
@@ -277,10 +282,7 @@ export const BunAdapter: ElysiaAdapter = {
 
 							if (
 								!(value instanceof Response) &&
-								!(
-									typeof value === 'object' &&
-									value?.toString() === '[object HTMLBundle]'
-								)
+								!isHTMLBundle(value)
 							)
 								continue
 


### PR DESCRIPTION
This PR aims to fix the issue with serving imported HTML as described in: https://github.com/elysiajs/elysia/issues/1297

I am not sure if this is the best way to solve that problem, I've noticed that when we run app in dev then the import returns HTMLBundle instance, in compiled apps(built with `--compile`) we are getting plain object. Based on https://github.com/oven-sh/bun/blob/fa1ad5425730c2f8d0c6046d6d49bb635e5d7383/packages/bun-types/bun.d.ts#L6086 HTMLBundle interface I changed the way how we check if given object is a bundle. 

I don't know how to emulate `--compile` in the tests  so there is no test for that particular scenario, I've tested it manually. If anyone knows how to do that I would appreciate guidance/tips how to write such test. 