### PR TITLE
chore: remove unused WSLocalHook import from types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ import type {
 	ValidationError
 } from './error'
 
-import type { AnyWSLocalHook, WSLocalHook } from './ws/types'
+import type { AnyWSLocalHook } from './ws/types'
 import type { WebSocketHandler } from './ws/bun'
 import type { Instruction as ExactMirrorInstruction } from 'exact-mirror'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal type to simplify type imports and reduce maintenance overhead.
  * No functional changes or public API modifications; behavior remains unchanged.
  * No action required for users; existing workflows continue to operate as before.
  * Improves developer experience and clarity in type declarations.
  * Part of ongoing housekeeping to keep the codebase tidy and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->