### PR TITLE
fix: WebSocket validation error handling in BunAdapter

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -13,25 +13,25 @@ import { serializeCookie } from '../../cookies'
 import { isProduction, ValidationError } from '../../error'
 import { getSchemaValidator } from '../../schema'
 import {
-	hasHeaderShorthand,
-	isNotEmpty,
-	isNumericString,
-	randomId,
-	supportPerMethodInlineHandler
+  hasHeaderShorthand,
+  isNotEmpty,
+  isNumericString,
+  randomId,
+  supportPerMethodInlineHandler
 } from '../../utils'
 
 import {
-	mapResponse,
-	mapEarlyResponse,
-	mapCompactResponse,
-	createStaticHandler
+  mapResponse,
+  mapEarlyResponse,
+  mapCompactResponse,
+  createStaticHandler
 } from './handler'
 
 import {
-	createHandleWSResponse,
-	createWSMessageParser,
-	ElysiaWS,
-	websocket
+  createHandleWSResponse,
+  createWSMessageParser,
+  ElysiaWS,
+  websocket
 } from '../../ws/index'
 import type { ServerWebSocket } from '../../ws/bun'
 import type { AnyElysia } from '../..'
@@ -503,7 +503,9 @@ export const BunAdapter: ElysiaAdapter = {
 					)
 				].filter((x) => x)
 
-				const handleErrors = !errorHandlers.length
+        const hasCustomErrorHandlers = errorHandlers.length > 0
+
+				const handleErrors = !hasCustomErrorHandlers
 					? () => {}
 					: async (ws: ServerWebSocket<any>, error: unknown) => {
 							for (const handleError of errorHandlers) {
@@ -556,14 +558,19 @@ export const BunAdapter: ElysiaAdapter = {
 							) => {
 								const message = await parseMessage(ws, _message)
 
-								if (validateMessage?.Check(message) === false)
-									return void ws.send(
-										new ValidationError(
-											'message',
-											validateMessage,
-											message
-										).message as string
-									)
+								if (validateMessage?.Check(message) === false) {
+                  const validationError = new ValidationError(
+                    'message',
+                    validateMessage,
+                    message
+                  )
+
+                  if (!hasCustomErrorHandlers) {
+                    return void ws.send(validationError.message as string)
+                  }
+
+                  return handleErrors(ws, validationError)
+                }
 
 								try {
 									await handleResponse(

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -13,25 +13,25 @@ import { serializeCookie } from '../../cookies'
 import { isProduction, ValidationError } from '../../error'
 import { getSchemaValidator } from '../../schema'
 import {
-  hasHeaderShorthand,
-  isNotEmpty,
-  isNumericString,
-  randomId,
-  supportPerMethodInlineHandler
+	hasHeaderShorthand,
+	isNotEmpty,
+	isNumericString,
+	randomId,
+	supportPerMethodInlineHandler
 } from '../../utils'
 
 import {
-  mapResponse,
-  mapEarlyResponse,
-  mapCompactResponse,
-  createStaticHandler
+	mapResponse,
+	mapEarlyResponse,
+	mapCompactResponse,
+	createStaticHandler
 } from './handler'
 
 import {
-  createHandleWSResponse,
-  createWSMessageParser,
-  ElysiaWS,
-  websocket
+	createHandleWSResponse,
+	createWSMessageParser,
+	ElysiaWS,
+	websocket
 } from '../../ws/index'
 import type { ServerWebSocket } from '../../ws/bun'
 import type { AnyElysia } from '../..'
@@ -503,7 +503,7 @@ export const BunAdapter: ElysiaAdapter = {
 					)
 				].filter((x) => x)
 
-        const hasCustomErrorHandlers = errorHandlers.length > 0
+                const hasCustomErrorHandlers = errorHandlers.length > 0
 
 				const handleErrors = !hasCustomErrorHandlers
 					? () => {}
@@ -559,18 +559,18 @@ export const BunAdapter: ElysiaAdapter = {
 								const message = await parseMessage(ws, _message)
 
 								if (validateMessage?.Check(message) === false) {
-                  const validationError = new ValidationError(
-                    'message',
-                    validateMessage,
-                    message
-                  )
+                                    const validationError = new ValidationError(
+                                        'message',
+                                        validateMessage,
+                                        message
+                                    )
 
-                  if (!hasCustomErrorHandlers) {
-                    return void ws.send(validationError.message as string)
-                  }
+                                    if (!hasCustomErrorHandlers) {
+                                        return void ws.send(validationError.message as string)
+                                    }
 
-                  return handleErrors(ws, validationError)
-                }
+                                    return handleErrors(ws, validationError)
+                                }
 
 								try {
 									await handleResponse(

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -517,37 +517,37 @@ describe('WebSocket message', () => {
 		app.stop()
 	})
 
-  it('handle validation error with onError', async () => {
-    const app = new Elysia()
-      .onError(() => {
-        return 'caught'
-      })
-      .ws('/ws', {
-        body: t.Object({
-          name: t.String()
-        }),
-        message(ws, message) {
-          return ws.send(message)
-        }
-      })
-      .listen(0)
+    it('handle validation error with onError', async () => {
+        const app = new Elysia()
+            .onError(() => {
+                return 'caught'
+            })
+            .ws('/ws', {
+                body: t.Object({
+                    name: t.String()
+                }),
+                message(ws, message) {
+                    return ws.send(message)
+                }
+            })
+            .listen(0)
 
-    const ws = newWebsocket(app.server!)
+        const ws = newWebsocket(app.server!)
 
-		await wsOpen(ws)
+        await wsOpen(ws)
 
-		const message = wsMessage(ws)
+        const message = wsMessage(ws)
 
-		ws.send(JSON.stringify({
-      name: 123, // expecting a string
-    }))
+        ws.send(JSON.stringify({
+            name: 123, // expecting a string
+        }))
 
-		const { type, data } = await message
+        const { type, data } = await message
 
-		expect(type).toBe('message')
-		expect(data).toBe('caught')
+        expect(type).toBe('message')
+        expect(data).toBe('caught')
 
-		await wsClosed(ws)
-		app.stop()
-  })
+        await wsClosed(ws)
+        app.stop()
+    })
 })

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -516,4 +516,38 @@ describe('WebSocket message', () => {
 		await wsClosed(ws)
 		app.stop()
 	})
+
+  it('handle validation error with onError', async () => {
+    const app = new Elysia()
+      .onError(() => {
+        return 'caught'
+      })
+      .ws('/ws', {
+        body: t.Object({
+          name: t.String()
+        }),
+        message(ws, message) {
+          return ws.send(message)
+        }
+      })
+      .listen(0)
+
+    const ws = newWebsocket(app.server!)
+
+		await wsOpen(ws)
+
+		const message = wsMessage(ws)
+
+		ws.send(JSON.stringify({
+      name: 123, // expecting a string
+    }))
+
+		const { type, data } = await message
+
+		expect(type).toBe('message')
+		expect(data).toBe('caught')
+
+		await wsClosed(ws)
+		app.stop()
+  })
 })


### PR DESCRIPTION
Ensure ``ValidationError``~s are passed to custom error handlers when available

Regarding to this issue #1256 