### PR TITLE
fix: allow overriding websocket handler with listen options

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -341,7 +341,9 @@ export const BunAdapter: ElysiaAdapter = {
 							),
 							websocket: {
 								...(app.config.websocket || {}),
-								...(websocket || {})
+								...(websocket || {}),
+								// @ts-expect-error not available in this variant of options type
+								...(options.websocket || {})
 							},
 							fetch: app.fetch
 						} as Serve)


### PR DESCRIPTION
Many people have asked for Socket.io integration at #260 and #162 and it's finally here. Socket.io added support for Bun. It can be seen in [this post](https://github.com/oven-sh/bun/discussions/2111#discussioncomment-14186172).

But to make integration easier with Elysia, the websocket handler must be configurable. This PR makes a small tweak to the `listen` function to allow that.

After this, it will be possible to add Socket.io to Elysia like this:

```ts
import { Elysia } from 'elysia';
import { Server as Engine } from '@socket.io/bun-engine';
import { Server } from 'socket.io';

const io = new Server();
const engine = new Engine({ path: '/socket.io/' });
io.bind(engine);

const app = new Elysia()
  .all('/socket.io/', ({ request, server }) => engine.handleRequest(request, server!))
  .listen({
    idleTimeout: 30,
    websocket: engine.handler().websocket as unknown as Bun.WebSocketHandler,
  });
```

Note that adding socket.io like this will disable Elysia's websocket features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now pass websocket configuration via the options object when starting the Bun server, enabling customization of WebSocket behavior (e.g., timeouts, compression, limits).
- Refactor
  - Improved merging of WebSocket options to prioritize user-specified settings provided in the options object.
- Chores
  - No changes to public API signatures; existing setups continue to work without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->