### PR TITLE
fix: check if the `plugin.constructor` exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4004,7 +4004,7 @@ export default class Elysia<
 						if (plugin instanceof Elysia)
 							return this._use(plugin).compile()
 
-						if (plugin.constructor.name === 'Elysia')
+						if (plugin.constructor?.name === 'Elysia')
 							return this._use(
 								plugin as unknown as Elysia
 							).compile()
@@ -4015,10 +4015,10 @@ export default class Elysia<
 						if (plugin.default instanceof Elysia)
 							return this._use(plugin.default)
 
-						if (plugin.constructor.name === 'Elysia')
+						if (plugin.constructor?.name === 'Elysia')
 							return this._use(plugin.default)
 
-						if (plugin.constructor.name === '_Elysia')
+						if (plugin.constructor?.name === '_Elysia')
 							return this._use(plugin.default)
 
 						try {


### PR DESCRIPTION
Context: https://github.com/oven-sh/bun/issues/22213

Starting from Bun 1.2.21, namespace objects no longer inherit from `Object.prototype` (https://github.com/oven-sh/bun/pull/21984). This change was made to comply with the ECMAScript specification.

This caused `plugin.constructor` to become `undefined` when executing `app.use(import("plugin"))`, resulting in a `TypeError` being thrown when accessing `plugin.constructor.name`.

This PR fixes the issue by using optional chaining to check that `plugin.constructor` exists.

This change is verified by four existing tests, so no additional tests are included (running the following tests with Bun 1.2.21 will fail):

* Modules > inline import 
* Modules > import
* Modules > inline import non default
* Modules > handle deferred import


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of plugin handling in Elysia.use to prevent rare runtime errors when a plugin lacks expected constructor metadata.
  * Safely detects plugin types even when certain internal properties are undefined, reducing edge-case crashes.

* **Chores**
  * No changes to public APIs or exported signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->