### PR TITLE
Standard Schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,11 @@
     "": {
       "name": "elysia",
       "dependencies": {
+        "arktype": "^2.1.20",
         "cookie": "^1.0.2",
         "exact-mirror": "0.1.6",
         "fast-decode-uri-component": "^1.0.1",
+        "valibot": "^1.1.0",
       },
       "devDependencies": {
         "@types/bun": "^1.2.16",
@@ -28,17 +30,24 @@
       "optionalDependencies": {
         "@sinclair/typebox": "^0.34.33",
         "openapi-types": "^12.1.3",
+        "zod": "4.1.1",
       },
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0",
+        "@standard-schema/spec": "^1.0.0",
         "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",
+        "zod": ">= 4.0.0",
       },
     },
   },
   "packages": {
+    "@ark/schema": ["@ark/schema@0.46.0", "", { "dependencies": { "@ark/util": "0.46.0" } }, "sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ=="],
+
+    "@ark/util": ["@ark/util@0.46.0", "", {}, "sha512-JPy/NGWn/lvf1WmGCPw2VGpBg5utZraE84I7wli18EDF3p3zc/e9WolT35tINeZO3l7C77SjqRJeAUoT0CvMRg=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.4", "", { "os": "android", "cpu": "arm" }, "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="],
@@ -179,6 +188,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -226,6 +237,8 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "arktype": ["arktype@2.1.20", "", { "dependencies": { "@ark/schema": "0.46.0", "@ark/util": "0.46.0" } }, "sha512-IZCEEXaJ8g+Ijd59WtSYwtjnqXiwM8sWQ5EjGamcto7+HVN9eK0C4p0zDlCuAwWhpqr6fIBkxPuYDl4/Mcj/+Q=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -793,6 +806,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "valibot": ["valibot@1.1.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
@@ -819,7 +834,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+    "zod": ["zod@4.1.1", "", {}, "sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
@@ -827,7 +842,11 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "prettier": "^3.5.3",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
+        "zod": "^4.1.5",
       },
       "optionalDependencies": {
         "@sinclair/typebox": "^0.34.33",
@@ -829,7 +830,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+    "zod": ["zod@4.1.5", "", {}, "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
@@ -837,7 +838,11 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,16 +30,13 @@
       "optionalDependencies": {
         "@sinclair/typebox": "^0.34.33",
         "openapi-types": "^12.1.3",
-        "zod": "4.1.1",
       },
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0",
-        "@standard-schema/spec": "^1.0.0",
         "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",
-        "zod": ">= 4.0.0",
       },
     },
   },
@@ -187,8 +184,6 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.2", "", { "os": "win32", "cpu": "x64" }, "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
@@ -834,7 +829,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.1.1", "", {}, "sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA=="],
+    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
@@ -842,11 +837,7 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
-    "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
-
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,28 +1,29 @@
 import { Elysia, t } from '../src'
 import { z } from 'zod'
 import * as v from 'valibot'
-import { req } from '../test/utils'
+import { type } from 'arktype'
 
-const app = new Elysia()
+new Elysia()
 	.guard({
 		schema: 'standalone',
 		body: z.object({
-			age: z.number()
+			age: z.coerce.number()
 		})
 	})
 	.guard({
 		schema: 'standalone',
 		body: v.object({
-			a: v.number()
+			vali: v.literal('vali')
 		})
 	})
 	.guard({
 		schema: 'standalone',
-		body: v.object({
-			b: v.number()
+		body: type({
+			'+': 'delete',
+			ark: '"type"'
 		})
 	})
-	.post('/', ({ body }) => ({ body }), {
+	.post('/', ({ body }) => body, {
 		body: t.Object({
 			name: t.String()
 		})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,23 +1,13 @@
 import { Elysia, t } from '../src'
+import { req } from '../test/utils'
 
-new Elysia()
-	.macro({
-		a: {
-			resolve: () => ({
-				query: {
-					age: 17
-				}
-			})
-		}
+const app = new Elysia()
+	.get('/', function* () {
+		for (let i = 0; i <= 100_000; i++) yield { hello: 'world' }
 	})
-	.get(
-		'/',
-		({ query }) => {
-			query
-		},
-		{
-			query: t.Object({
-				name: t.String()
-			})
-		}
-	)
+	.listen(3000)
+
+const q = app
+	.handle(req('/'))
+	.then((x) => x.text())
+	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,23 +1,14 @@
-import { Elysia, t } from 'elysia'
+import { Elysia, t, validateFileExtension } from '../src'
 import { z } from 'zod'
-import { type } from 'arktype'
-import * as v from 'valibot'
 
-new Elysia().get(
-	'/name/:name',
-	({ status }) => Math.random() > 0.5
-		? status(200, 'ok')
-		: status(201, 'aight'),
-	{
-		params: type({
-			name: '"Standard Schema"'
-		}),
-		query: z.object({
-			id: z.coerce.number()
-		}),
-		response: {
-			200: t.Literal('ok'),
-			201: v.literal('aight')
-		}
+const app = new Elysia()
+	.post('', ({ body: { file } }) => file, {
+		body: z.object({
+			file: z
+				.file()
+				.refine((file) => validateFileExtension(file, 'image/jpeg'))
+		})
 	})
 	.listen(3000)
+
+console.log(app.routes[0].compile().toString())

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,14 +1,28 @@
-import { Elysia, t, validateFileExtension } from '../src'
-import { z } from 'zod'
+import { Elysia, t } from '../src'
+import { req } from '../test/utils'
 
 const app = new Elysia()
-	.post('', ({ body: { file } }) => file, {
-		body: z.object({
-			file: z
-				.file()
-				.refine((file) => validateFileExtension(file, 'image/jpeg'))
+	.onError(({ error, code }) => {
+		if (code === 'VALIDATION') return error.detail(error.message)
+	})
+	.post('/', () => 'Hello World!', {
+		body: t.Object({
+			x: t.Number({
+				error: 'x must be a number'
+			})
 		})
 	})
-	.listen(3000)
 
-console.log(app.routes[0].compile().toString())
+const response = await app
+	.handle(
+		new Request('http://localhost', {
+			method: 'POST',
+			body: JSON.stringify({ x: 'hi!' }),
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		})
+	)
+	.then((x) => x.text())
+
+console.log(response)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,10 +1,23 @@
 import { Elysia, t } from '../src'
-import { z } from 'zod'
 
-const app = new Elysia()
-	.get('/', ({ query }) => query, {
-		query: z.object({
-			x: z.array(z.string())
-		})
+new Elysia()
+	.macro({
+		a: {
+			resolve: () => ({
+				query: {
+					age: 17
+				}
+			})
+		}
 	})
-	.listen(3000)
+	.get(
+		'/',
+		({ query }) => {
+			query
+		},
+		{
+			query: t.Object({
+				name: t.String()
+			})
+		}
+	)

--- a/example/a.ts
+++ b/example/a.ts
@@ -2,6 +2,8 @@ import { Elysia, t } from '../src'
 import { z } from 'zod'
 import { req } from '../test/utils'
 
+import type { StandardSchemaV1Like } from '../src/types'
+
 const app = new Elysia()
 	.guard({
 		schema: 'standalone',

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,13 +1,24 @@
 import { Elysia, t } from '../src'
+import { z } from 'zod'
 import { req } from '../test/utils'
 
 const app = new Elysia()
-	.get('/', function* () {
-		for (let i = 0; i <= 100_000; i++) yield { hello: 'world' }
+	.guard({
+		schema: 'standalone',
+		body: z
+			.object({
+				age: z.number()
+			})
+			.loose()
+	})
+	.post('/', ({ body }) => ({ body }), {
+		body: z.object({
+			age: z.number()
+		})
 	})
 	.listen(3000)
 
-const q = app
-	.handle(req('/'))
-	.then((x) => x.text())
-	.then(console.log)
+// const q = app
+// 	.handle(req('/'))
+// 	.then((x) => x.text())
+// 	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,19 +1,23 @@
-import { Elysia, sse, t } from '../src'
-import { req } from '../test/utils'
+import { Elysia, t } from '../src'
+import { z } from 'zod'
+import { type } from 'arktype'
+import * as v from 'valibot'
 
-const app = new Elysia().get('/', ({ query }) => query, {
-	query: t.Object(
-		{
-			name: t.String()
-		},
-		{ additionalProperties: true }
-	)
-})
-
-const response = await app
-	.handle(req('/?name=nagisa&hifumi=daisuki'))
-	.then((x) => x.json())
-
-console.log(response)
-
-console.log(app.routes[0].hooks)
+new Elysia().get(
+	'/name/:name',
+	({ status }) => Math.random() > 0.5
+		? status(200, 'ok')
+		: status(201, 'aight'),
+	{
+		params: type({
+			name: '"hi saltyaom"'
+		}),
+		query: z.object({
+			id: z.coerce.number()
+		}),
+		response: {
+			200: t.Literal('ok'),
+			201: v.literal('aight')
+		}
+	})
+	.listen(3000)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from '../src'
+import { Elysia, t } from 'elysia'
 import { z } from 'zod'
 import { type } from 'arktype'
 import * as v from 'valibot'
@@ -10,7 +10,7 @@ new Elysia().get(
 		: status(201, 'aight'),
 	{
 		params: type({
-			name: '"hi saltyaom"'
+			name: '"Standard Schema"'
 		}),
 		query: z.object({
 			id: z.coerce.number()

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,28 +1,10 @@
 import { Elysia, t } from '../src'
-import { req } from '../test/utils'
+import { z } from 'zod'
 
 const app = new Elysia()
-	.onError(({ error, code }) => {
-		if (code === 'VALIDATION') return error.detail(error.message)
-	})
-	.post('/', () => 'Hello World!', {
-		body: t.Object({
-			x: t.Number({
-				error: 'x must be a number'
-			})
+	.get('/', ({ query }) => query, {
+		query: z.object({
+			x: z.array(z.string())
 		})
 	})
-
-const response = await app
-	.handle(
-		new Request('http://localhost', {
-			method: 'POST',
-			body: JSON.stringify({ x: 'hi!' }),
-			headers: {
-				'Content-Type': 'application/json'
-			}
-		})
-	)
-	.then((x) => x.text())
-
-console.log(response)
+	.listen(3000)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,26 +1,30 @@
 import { Elysia, t } from '../src'
 import { z } from 'zod'
+import * as v from 'valibot'
 import { req } from '../test/utils'
-
-import type { StandardSchemaV1Like } from '../src/types'
 
 const app = new Elysia()
 	.guard({
 		schema: 'standalone',
-		body: z
-			.object({
-				age: z.number()
-			})
-			.loose()
-	})
-	.post('/', ({ body }) => ({ body }), {
 		body: z.object({
 			age: z.number()
 		})
 	})
+	.guard({
+		schema: 'standalone',
+		body: v.object({
+			a: v.number()
+		})
+	})
+	.guard({
+		schema: 'standalone',
+		body: v.object({
+			b: v.number()
+		})
+	})
+	.post('/', ({ body }) => ({ body }), {
+		body: t.Object({
+			name: t.String()
+		})
+	})
 	.listen(3000)
-
-// const q = app
-// 	.handle(req('/'))
-// 	.then((x) => x.text())
-// 	.then(console.log)

--- a/example/custom-response.ts
+++ b/example/custom-response.ts
@@ -5,7 +5,7 @@ const prettyJson = new Elysia()
 		if (response instanceof Object)
 			return new Response(JSON.stringify(response, null, 4))
 	})
-	.as('plugin')
+	.as('scoped')
 
 new Elysia()
 	.use(prettyJson)

--- a/example/websocket.ts
+++ b/example/websocket.ts
@@ -12,7 +12,7 @@ const app = new Elysia()
 		},
 		message(ws, message) {
 			ws.publish('asdf', message)
-			ws.send('asdf', message)
+			ws.send(message)
 		}
 	})
 	.get('/publish/:publish', ({ params: { publish: text } }) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.1",
+	"version": "1.4.0-exp.2",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.2",
+	"version": "1.4.0-exp.3",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -183,9 +183,11 @@
 		"release": "npm run build && npm run test && npm publish"
 	},
 	"dependencies": {
+		"arktype": "^2.1.20",
 		"cookie": "^1.0.2",
 		"exact-mirror": "0.1.6",
-		"fast-decode-uri-component": "^1.0.1"
+		"fast-decode-uri-component": "^1.0.1",
+		"valibot": "^1.1.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.16",
@@ -206,13 +208,16 @@
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": ">= 0.34.0",
+		"@standard-schema/spec": "^1.0.0",
 		"exact-mirror": ">= 0.0.9",
 		"file-type": ">= 20.0.0",
 		"openapi-types": ">= 12.0.0",
-		"typescript": ">= 5.0.0"
+		"typescript": ">= 5.0.0",
+		"zod": ">= 4.0.0"
 	},
 	"optionalDependencies": {
 		"@sinclair/typebox": "^0.34.33",
-		"openapi-types": "^12.1.3"
+		"openapi-types": "^12.1.3",
+		"zod": "4.1.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.3.20",
+	"version": "1.4.0-exp.1",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -208,16 +208,13 @@
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": ">= 0.34.0",
-		"@standard-schema/spec": "^1.0.0",
 		"exact-mirror": ">= 0.0.9",
 		"file-type": ">= 20.0.0",
 		"openapi-types": ">= 12.0.0",
-		"typescript": ">= 5.0.0",
-		"zod": ">= 4.0.0"
+		"typescript": ">= 5.0.0"
 	},
 	"optionalDependencies": {
 		"@sinclair/typebox": "^0.34.33",
-		"openapi-types": "^12.1.3",
-		"zod": "4.1.1"
+		"openapi-types": "^12.1.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-<<<<<<< HEAD
 	"version": "1.4.0-exp.2",
-=======
-	"version": "1.3.21",
->>>>>>> weirs
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -208,7 +204,8 @@
 		"mitata": "^1.0.34",
 		"prettier": "^3.5.3",
 		"tsup": "^8.4.0",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"zod": "^4.1.5"
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": ">= 0.34.0",

--- a/src/adapter/bun/compose.ts
+++ b/src/adapter/bun/compose.ts
@@ -65,7 +65,6 @@ const createContext = (
 			hasTrace || inference.url || needsQuery
 		) +
 		`redirect,` +
-		`error:status,` +
 		`status,` +
 		`set:{headers:` +
 		(isNotEmpty(defaultHeaders)

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -483,7 +483,7 @@ export const BunAdapter: ElysiaAdapter = {
 					) as any
 
 				const handleResponse = createHandleWSResponse(validateResponse)
-				const parseMessage = createWSMessageParser(parse)
+				const parseMessage = createWSMessageParser(parse as any)
 
 				let _id: string | undefined
 

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -262,9 +262,9 @@ export const createStreamHandler =
 
 							// Wait for the next event loop
 							// Otherwise the data will be mixed up
-							await new Promise<void>((resolve) =>
-								setTimeout(() => resolve(), 0)
-							)
+							// await new Promise<void>((resolve) =>
+							// 	setTimeout(() => resolve(), 0)
+							// )
 						}
 					} catch (error) {
 						console.warn(error)

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -107,7 +107,6 @@ export const WebStandardAdapter: ElysiaAdapter = {
 				`path:p,` +
 				`url:u,` +
 				`redirect,` +
-				`error:status,` +
 				`status,` +
 				`set:{headers:`
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -206,34 +206,6 @@ export type Context<
 					response: T
 					// @ts-ignore trust me bro
 				) => ElysiaCustomStatusResponse<Code, T>
-
-		/**
-		* @deprecated use `status` instead
-		*/
-		error: {} extends Route['response']
-			? typeof status
-			: <
-					const Code extends
-						| keyof Route['response']
-						| InvertedStatusMap[Extract<
-								InvertedStatusMapKey,
-								keyof Route['response']
-						  >],
-					const T extends Code extends keyof Route['response']
-						? Route['response'][Code]
-						: Code extends keyof StatusMap
-							? // @ts-ignore StatusMap[Code] always valid because Code generic check
-								Route['response'][StatusMap[Code]]
-							: never
-				>(
-					code: Code,
-					response: T
-					// @ts-ignore trust me bro
-				) => ElysiaCustomStatusResponse<Code, T>
-
-		// response?: IsNever<keyof Route['response']> extends true
-		// 	? unknown
-		// 	: Route['response'][keyof Route['response']]
 	} & Singleton['decorator'] &
 		Singleton['derive'] &
 		Singleton['resolve']
@@ -261,10 +233,6 @@ export type PreContext<
 			redirect?: string
 		}
 
-		/**
-		 * @deprecated use `status` instead
-		 */
-		error: typeof status
 		status: typeof status
 	} & Singleton['decorator']
 >

--- a/src/context.ts
+++ b/src/context.ts
@@ -136,8 +136,8 @@ export type Context<
 			? Record<string, string | undefined>
 			: PrettifyIfObject<Route['headers']>
 		cookie: undefined extends Route['cookie']
-			? Record<string, Cookie<string | undefined>>
-			: Record<string, Cookie<string | undefined>> & {
+			? Record<string, Cookie<unknown>>
+			: Record<string, Cookie<unknown>> & {
 					[key in keyof Route['cookie']]-?: Cookie<
 						Route['cookie'][key]
 					>

--- a/src/error.ts
+++ b/src/error.ts
@@ -268,8 +268,11 @@ export class ValidationError extends Error {
 		let expected
 		let customError
 
-		// @ts-ignore
-		if ('~standard' in validator || '~standard' in validator.schema) {
+		if (
+			'~standard' in validator ||
+			// @ts-ignore
+			(validator.schema && '~standard' in validator.schema)
+		) {
 			const standard = // @ts-ignore
 				('~standard' in validator ? validator : validator.schema)[
 					'~standard'
@@ -300,6 +303,8 @@ export class ValidationError extends Error {
 					null,
 					2
 				)
+
+			customError = error?.message
 		} else {
 			if (
 				value &&
@@ -332,7 +337,7 @@ export class ValidationError extends Error {
 				}
 			}
 
-			const customError =
+			customError =
 				error?.schema?.message || error?.schema?.error !== undefined
 					? typeof error.schema.error === 'function'
 						? error.schema.error(

--- a/src/error.ts
+++ b/src/error.ts
@@ -264,6 +264,8 @@ export class ValidationError extends Error {
 		let customError
 
 		if (
+			// @ts-ignore
+			validator?.provider === 'standard' ||
 			'~standard' in validator ||
 			// @ts-ignore
 			(validator.schema && '~standard' in validator.schema)
@@ -273,9 +275,9 @@ export class ValidationError extends Error {
 					'~standard'
 				]
 
-			const errors = standard.validate(value).issues
+			const _errors = errors ?? standard.validate(value).issues
 
-			error = errors?.[0]
+			error = _errors?.[0]
 
 			if (isProduction)
 				message = JSON.stringify({

--- a/src/error.ts
+++ b/src/error.ts
@@ -8,7 +8,7 @@ import type {
 
 import { StatusMap, InvertedStatusMap } from './utils'
 import type { ElysiaTypeCheck } from './schema'
-import { StandardSchemaV1 } from '@standard-schema/spec'
+import { StandardSchemaV1Like } from './types'
 
 // ? Cloudflare worker support
 const env =
@@ -259,7 +259,7 @@ export class ValidationError extends Error {
 			| TSchema
 			| TypeCheck<any>
 			| ElysiaTypeCheck<any>
-			| StandardSchemaV1,
+			| StandardSchemaV1Like,
 		public value: unknown,
 		errors?: ValueErrorIterator
 	) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -79,11 +79,6 @@ export const status = <
 	response?: T
 ) => new ElysiaCustomStatusResponse<Code, T>(code, response as any)
 
-/**
- * @deprecated use `Elysia.status` instead
- */
-export const error = status
-
 export class InternalServerError extends Error {
 	code = 'INTERNAL_SERVER_ERROR'
 	status = 500

--- a/src/error.ts
+++ b/src/error.ts
@@ -436,6 +436,8 @@ export class ValidationError extends Error {
 	}
 
 	get model() {
+		if ('~standard' in this.validator) return this.validator
+
 		return ValidationError.simplifyModel(this.validator)
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -883,7 +883,6 @@ export default class Elysia<
 								headers: Object.assign({}, this.setHeaders)
 							},
 							status,
-							error: status,
 							store: this.store
 						}
 
@@ -4382,7 +4381,8 @@ export default class Elysia<
 				derive: Partial<Ephemeral['derive'] & Volatile['derive']>
 				resolve: Partial<Ephemeral['resolve'] & Volatile['resolve']>
 			},
-			Definitions['error']
+			Definitions['error'],
+			keyof Definitions['typebox'] & string
 		>
 	>(
 		macro: NewMacro
@@ -4620,7 +4620,8 @@ export default class Elysia<
 				Volatile['resolve'] &
 				MacroToContext<
 					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
+					Omit<Input, NonResolvableMacroKey>,
+					Definitions['typebox']
 				>
 		},
 		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4623,9 +4623,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4707,11 +4705,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			NoInfer<Decorator>,
-			JoinPath<BasePath, Path>
-		>
+		const Handle extends InlineHandler<NoInfer<Schema>, NoInfer<Decorator>>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4793,9 +4787,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4877,9 +4869,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4961,9 +4951,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5045,9 +5033,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5129,9 +5115,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5213,9 +5197,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5297,9 +5279,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5382,9 +5362,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		method: Method,
 		path: Path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,9 @@ import type {
 	MergeStandaloneSchema,
 	IsNever,
 	DocumentDecoration,
-	AfterHandler
+	AfterHandler,
+	AnyBaseHookLifeCycle,
+	NonResolvableMacroKey
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>
@@ -3037,7 +3039,8 @@ export default class Elysia<
 	group<
 		const Prefix extends string,
 		const NewElysia extends AnyElysia,
-		const Input extends InputSchema<keyof Definitions['typebox'] & string>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
 				Input,
@@ -3066,7 +3069,6 @@ export default class Elysia<
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
 			},
 			Definitions['error'],
-			Metadata['macro'],
 			keyof Metadata['parser']
 		>,
 		run: (
@@ -3216,17 +3218,15 @@ export default class Elysia<
 	}
 
 	guard<
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
-			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>,
 		const GuardType extends GuardSchemaType,
 		const AsType extends LifeCycleType
@@ -3242,14 +3242,13 @@ export default class Elysia<
 			 */
 			schema?: GuardType
 		} & LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
 			},
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Or<
@@ -3272,10 +3271,7 @@ export default class Elysia<
 						resolve: Prettify<Volatile['resolve'] & MacroContext>
 						schema: Prettify<
 							MergeSchema<
-								UnwrapRoute<
-									LocalSchema,
-									Definitions['typebox']
-								>,
+								UnwrapRoute<Input, Definitions['typebox']>,
 								Metadata['schema']
 							>
 						>
@@ -3298,7 +3294,7 @@ export default class Elysia<
 							schema: Prettify<
 								MergeSchema<
 									UnwrapRoute<
-										LocalSchema,
+										Input,
 										Definitions['typebox'],
 										BasePath
 									>,
@@ -3327,10 +3323,7 @@ export default class Elysia<
 							>
 							schema: Prettify<
 								MergeSchema<
-									UnwrapRoute<
-										LocalSchema,
-										Definitions['typebox']
-									>,
+									UnwrapRoute<Input, Definitions['typebox']>,
 									Metadata['schema'] & Ephemeral['schema']
 								>
 							>
@@ -3354,7 +3347,7 @@ export default class Elysia<
 						resolve: Prettify<Volatile['resolve'] & MacroContext>
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema'] &
-							UnwrapRoute<LocalSchema, Definitions['typebox']>
+							UnwrapRoute<Input, Definitions['typebox']>
 					}
 				>
 			: AsType extends 'global'
@@ -3372,7 +3365,7 @@ export default class Elysia<
 						{
 							schema: Metadata['schema']
 							standaloneSchema: UnwrapRoute<
-								LocalSchema,
+								Input,
 								Definitions['typebox'],
 								BasePath
 							> &
@@ -3398,27 +3391,25 @@ export default class Elysia<
 							>
 							schema: Ephemeral['schema']
 							standaloneSchema: Ephemeral['standaloneSchema'] &
-								UnwrapRoute<LocalSchema, Definitions['typebox']>
+								UnwrapRoute<Input, Definitions['typebox']>
 						},
 						Volatile
 					>
 
 	guard<
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
-			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>
 	>(
 		hook: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
@@ -3427,7 +3418,6 @@ export default class Elysia<
 					MacroContext
 			},
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -3442,7 +3432,7 @@ export default class Elysia<
 			resolve: Prettify<Volatile['resolve'] & MacroContext>
 			schema: Prettify<
 				MergeSchema<
-					UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+					UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 					MergeSchema<
 						Volatile['schema'],
 						MergeSchema<Ephemeral['schema'], Metadata['schema']>
@@ -3462,10 +3452,10 @@ export default class Elysia<
 			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
+		const Input extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>
 	>(
 		run: (
@@ -3501,29 +3491,26 @@ export default class Elysia<
 	>
 
 	guard<
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const NewElysia extends AnyElysia,
 		const Schema extends MergeSchema<
-			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>
 	>(
 		schema: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
 			},
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>,
 		run: (
@@ -4611,12 +4598,11 @@ export default class Elysia<
 	 */
 	get<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4628,27 +4614,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4697,12 +4682,11 @@ export default class Elysia<
 	 */
 	post<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4714,27 +4698,28 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
+			NoInfer<Decorator>,
 			JoinPath<BasePath, Path>
 		>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4783,12 +4768,11 @@ export default class Elysia<
 	 */
 	put<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4800,27 +4784,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4869,12 +4852,11 @@ export default class Elysia<
 	 */
 	patch<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4886,27 +4868,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4955,12 +4936,11 @@ export default class Elysia<
 	 */
 	delete<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4972,27 +4952,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5041,12 +5020,11 @@ export default class Elysia<
 	 */
 	options<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5058,27 +5036,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5127,12 +5104,11 @@ export default class Elysia<
 	 */
 	all<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5144,27 +5120,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5213,12 +5188,11 @@ export default class Elysia<
 	 */
 	head<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5230,27 +5204,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5299,12 +5272,11 @@ export default class Elysia<
 	 */
 	connect<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5316,27 +5288,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5386,12 +5357,11 @@ export default class Elysia<
 	route<
 		const Method extends HTTPMethod,
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5403,28 +5373,27 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		method: Method,
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		> & {
 			config?: {
@@ -5479,12 +5448,11 @@ export default class Elysia<
 	 */
 	ws<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5492,20 +5460,21 @@ export default class Elysia<
 				Volatile['schema'],
 				MergeSchema<Ephemeral['schema'], Metadata['schema']>
 			>
-		>,
-		const Macro extends Metadata['macro']
+		>
 	>(
 		path: Path,
 		options: WSLocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] &
 					Volatile['resolve'] &
-					MacroToContext<Metadata['macroFn'], Macro>
-			},
-			Macro
+					MacroToContext<
+						Metadata['macroFn'],
+						Omit<Input, NonResolvableMacroKey>
+					>
+			}
 		>
 	): Elysia<
 		BasePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6800,7 +6800,11 @@ export default class Elysia<
 export { Elysia }
 
 export { t } from './type-system'
-export { validationDetail } from './type-system/utils'
+export {
+	validationDetail,
+	validateFile,
+	validateFileExtension
+} from './type-system/utils'
 export type {
 	ElysiaTypeCustomError,
 	ElysiaTypeCustomErrorCallback

--- a/src/index.ts
+++ b/src/index.ts
@@ -669,7 +669,7 @@ export default class Elysia<
 							models,
 							normalize,
 							validators: standaloneValidators.map(
-								(x) => x.response
+								(x) => x.response as any
 							),
 							sanitize
 						})
@@ -769,7 +769,7 @@ export default class Elysia<
 									models,
 									normalize,
 									validators: standaloneValidators.map(
-										(x) => x.response
+										(x) => x.response as any
 									),
 									sanitize
 								}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6793,7 +6793,6 @@ export {
 
 export {
 	status,
-	error,
 	mapValueError,
 	ParseError,
 	NotFoundError,

--- a/src/parse-query.ts
+++ b/src/parse-query.ts
@@ -118,6 +118,130 @@ export function parseQueryFromURL(
  * @callback parse
  * @param {string} input
  */
+export function parseQueryStandardSchema(
+	input: string,
+	startIndex: number = 0
+) {
+	const result = Object.create(null) as Record<string, string | string[]>
+
+	let flags = 0
+
+	const inputLength = input.length
+	let startingIndex = startIndex - 1
+	let equalityIndex = startingIndex
+
+	for (let i = 0; i < inputLength; i++)
+		switch (input.charCodeAt(i)) {
+			// '&'
+			case 38:
+				processKeyValuePair(input, i)
+
+				// Reset state variables
+				startingIndex = i
+				equalityIndex = i
+				flags = 0
+
+				break
+
+			// '='
+			case 61:
+				if (equalityIndex <= startingIndex) equalityIndex = i
+				// If '=' character occurs again, we should decode the input
+				else flags |= VALUE_NEEDS_DECODE
+
+				break
+
+			// '+'
+			case 43:
+				if (equalityIndex > startingIndex) flags |= VALUE_HAS_PLUS
+				else flags |= KEY_HAS_PLUS
+
+				break
+
+			// '%'
+			case 37:
+				if (equalityIndex > startingIndex) flags |= VALUE_NEEDS_DECODE
+				else flags |= KEY_NEEDS_DECODE
+
+				break
+		}
+
+	// Process the last pair if needed
+	if (startingIndex < inputLength) processKeyValuePair(input, inputLength)
+
+	return result
+
+	function processKeyValuePair(input: string, endIndex: number) {
+		const hasBothKeyValuePair = equalityIndex > startingIndex
+		const effectiveEqualityIndex = hasBothKeyValuePair
+			? equalityIndex
+			: endIndex
+
+		const keySlice = input.slice(startingIndex + 1, effectiveEqualityIndex)
+
+		// Skip processing if key is empty
+		if (!hasBothKeyValuePair && keySlice.length === 0) return
+
+		let finalKey = keySlice
+		if (flags & KEY_HAS_PLUS) finalKey = finalKey.replace(/\+/g, ' ')
+		if (flags & KEY_NEEDS_DECODE) finalKey = decode(finalKey) || finalKey
+
+		let finalValue = ''
+		if (hasBothKeyValuePair) {
+			let valueSlice = input.slice(equalityIndex + 1, endIndex)
+			if (flags & VALUE_HAS_PLUS)
+				valueSlice = valueSlice.replace(/\+/g, ' ')
+			if (flags & VALUE_NEEDS_DECODE)
+				valueSlice = decode(valueSlice) || valueSlice
+			finalValue = valueSlice
+		}
+
+		const currentValue = result[finalKey]
+
+		if (
+			finalValue.charCodeAt(0) === 91 &&
+			finalValue.charCodeAt(finalValue.length - 1) === 93
+		) {
+			try {
+				// @ts-ignore
+				finalValue = JSON.parse(finalValue)
+			} catch {
+				// If JSON parsing fails, treat it as a regular string
+			}
+
+			if (currentValue === undefined) result[finalKey] = finalValue
+			else if (Array.isArray(currentValue)) currentValue.push(finalValue)
+			else result[finalKey] = [currentValue, finalValue]
+		} else if (
+			finalValue.charCodeAt(0) === 123 &&
+			finalValue.charCodeAt(finalValue.length - 1) === 125
+		) {
+			try {
+				// @ts-ignore
+				finalValue = JSON.parse(finalValue)
+			} catch {
+				// If JSON parsing fails, treat it as a regular string
+			}
+
+			if (currentValue === undefined) result[finalKey] = finalValue
+			else if (Array.isArray(currentValue)) currentValue.push(finalValue)
+			else result[finalKey] = [currentValue, finalValue]
+		} else {
+			if (finalValue.includes(','))
+				// @ts-ignore
+				finalValue = finalValue.split(',')
+
+			if (currentValue === undefined) result[finalKey] = finalValue
+			else if (Array.isArray(currentValue)) currentValue.push(finalValue)
+			else result[finalKey] = [currentValue, finalValue]
+		}
+	}
+}
+
+/**
+ * @callback parse
+ * @param {string} input
+ */
 export function parseQuery(input: string) {
 	const result = Object.create(null) as Record<string, string | string[]>
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -753,6 +753,7 @@ export const getSchemaValidator = <
 		modules,
 		normalize = false,
 		additionalProperties = false,
+		forceAdditionalProperties = false,
 		coerce = false,
 		additionalCoerce = [],
 		validators,
@@ -761,6 +762,7 @@ export const getSchemaValidator = <
 		models?: Record<string, TSchema>
 		modules?: TModule<any, any>
 		additionalProperties?: boolean
+		forceAdditionalProperties?: boolean
 		dynamic?: boolean
 		normalize?: ElysiaConfig<''>['normalize']
 		coerce?: boolean
@@ -891,6 +893,7 @@ export const getSchemaValidator = <
 				dynamic,
 				normalize,
 				additionalProperties: true,
+				forceAdditionalProperties: true,
 				coerce,
 				additionalCoerce
 			})!
@@ -900,10 +903,11 @@ export const getSchemaValidator = <
 
 			// @ts-ignore
 			return (v) => {
-				if (vali.Check(v))
+				if (vali.Check(v)) {
 					return {
 						value: vali.Decode(v)
 					}
+				}
 				else
 					return {
 						issues: [...vali.Errors(v)]
@@ -1054,7 +1058,8 @@ export const getSchemaValidator = <
 	} else {
 		if (
 			schema.type === 'object' &&
-			'additionalProperties' in schema === false
+			('additionalProperties' in schema === false ||
+				forceAdditionalProperties)
 		)
 			schema.additionalProperties = additionalProperties
 		else

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -28,8 +28,8 @@ import type {
 	MaybeArray,
 	StandaloneInputSchema
 } from './types'
-import { StandardSchemaV1 } from '@standard-schema/spec'
-import { fa } from 'zod/locales'
+
+import type { StandardSchemaV1Like } from './types'
 
 type MapValueError = ReturnType<typeof mapValueError>
 
@@ -743,7 +743,7 @@ const createCleaner = (schema: TAnySchema) => (value: unknown) => {
 // const caches = <Record<string, ElysiaTypeCheck<any>>>{}
 
 export const getSchemaValidator = <
-	T extends TSchema | StandardSchemaV1 | string | undefined
+	T extends TSchema | StandardSchemaV1Like | string | undefined
 >(
 	s: T,
 	{
@@ -801,10 +801,10 @@ export const getSchemaValidator = <
 	}
 
 	const mapSchema = (
-		s: string | TSchema | StandardSchemaV1 | undefined
-	): TSchema | StandardSchemaV1 => {
+		s: string | TSchema | StandardSchemaV1Like | undefined
+	): TSchema | StandardSchemaV1Like => {
 		if (s && typeof s !== 'string' && '~standard' in s)
-			return s as StandardSchemaV1
+			return s as StandardSchemaV1Like
 
 		let schema: TSchema
 
@@ -1053,6 +1053,7 @@ export const getSchemaValidator = <
 				Code: () => '',
 				// @ts-ignore
 				Decode(value) {
+					// @ts-ignore
 					const response = schema['~standard'].validate(value)
 
 					if (response instanceof Promise)
@@ -1141,6 +1142,7 @@ export const getSchemaValidator = <
 			schema,
 			references: '',
 			checkFunc(value: unknown) {
+				// @ts-ignore
 				const response = schema['~standard'].validate(value)
 
 				if (response instanceof Promise)
@@ -1168,6 +1170,7 @@ export const getSchemaValidator = <
 			Code: () => '',
 			// @ts-ignore
 			Decode(value) {
+				// @ts-ignore
 				const response = schema['~standard'].validate(value)
 
 				if (response instanceof Promise)
@@ -1358,9 +1361,10 @@ export const getResponseSchemaValidator = (
 
 	let maybeSchemaOrRecord:
 		| TSchema
-		| StandardSchemaV1
-		| Record<number, string | TSchema | StandardSchemaV1>
+		| StandardSchemaV1Like
+		| Record<number, string | TSchema | StandardSchemaV1Like>
 
+	// @ts-ignore
 	if (typeof s !== 'string') maybeSchemaOrRecord = s!
 	else {
 		const isArray = s.endsWith('[]')
@@ -1378,7 +1382,7 @@ export const getResponseSchemaValidator = (
 	if (Kind in maybeSchemaOrRecord || '~standard' in maybeSchemaOrRecord)
 		return {
 			200: getSchemaValidator(
-				maybeSchemaOrRecord as TSchema | StandardSchemaV1,
+				maybeSchemaOrRecord as TSchema | StandardSchemaV1Like,
 				{
 					modules,
 					models,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -930,17 +930,47 @@ export const getSchemaValidator = <
 	if (dynamic) {
 		if (Kind in schema) {
 			const validator: ElysiaTypeCheck<any> = {
+				provider: 'standard',
 				schema,
 				references: '',
-				checkFunc: () => {},
+				checkFunc(value: unknown) {
+					const response = schema['~standard']['validate'](value)
+
+					if (response instanceof Promise)
+						throw Error(
+							'Async validation is not supported in non-dynamic schema'
+						)
+
+					return response
+				},
 				code: '',
-				// @ts-expect-error
-				Check: (value: unknown) => Value.Check(schema, value),
-				Errors: (value: unknown) => Value.Errors(schema, value),
+				Check: schema['~standard']['validate'],
+				// @ts-ignore
+				Errors(value: unknown) {
+					// @ts-ignore
+					const response = schema['~standard']['validate'](value)
+
+					if (response instanceof Promise)
+						throw Error(
+							'Async validation is not supported in non-dynamic schema'
+						)
+
+					return response.issues
+				},
 				Code: () => '',
-				Clean: createCleaner(schema),
-				Decode: (value: unknown) => Value.Decode(schema, value),
-				Encode: (value: unknown) => Value.Encode(schema, value),
+				// @ts-ignore
+				Decode(value) {
+					const response = schema['~standard']['validate'](value)
+
+					if (response instanceof Promise)
+						throw Error(
+							'Async validation is not supported in non-dynamic schema'
+						)
+
+					return response
+				},
+				// @ts-ignore
+				Encode: (value: unknown) => value,
 				get hasAdditionalProperties() {
 					if ('~hasAdditionalProperties' in this)
 						return this['~hasAdditionalProperties'] as boolean
@@ -1036,16 +1066,7 @@ export const getSchemaValidator = <
 				checkFunc: () => {},
 				code: '',
 				// @ts-ignore
-				Check(value) {
-					const response = schema['~standard']['validate'](value)
-
-					if (response instanceof Promise)
-						throw Error(
-							'Async validation is not supported in non-dynamic schema'
-						)
-
-					return response
-				},
+				Check: schema['~standard']['validate'],
 				// @ts-ignore
 				Errors(value: unknown) {
 					// @ts-ignore
@@ -1122,10 +1143,7 @@ export const getSchemaValidator = <
 			provider: 'standard',
 			schema,
 			references: '',
-			checkFunc: () => {},
-			code: '',
-			// @ts-ignore
-			Check(value) {
+			checkFunc(value: unknown) {
 				const response = schema['~standard']['validate'](value)
 
 				if (response instanceof Promise)
@@ -1135,6 +1153,9 @@ export const getSchemaValidator = <
 
 				return response
 			},
+			code: '',
+			// @ts-ignore
+			Check: schema['~standard']['validate'],
 			// @ts-ignore
 			Errors(value: unknown) {
 				// @ts-ignore

--- a/src/type-system/utils.ts
+++ b/src/type-system/utils.ts
@@ -13,7 +13,8 @@ import { InvalidFileType, ValidationError } from '../error'
 import type {
 	ElysiaTypeCustomErrorCallback,
 	FileOptions,
-	FileUnit
+	FileUnit,
+	FileType
 } from './types'
 import type { MaybeArray } from '../types'
 
@@ -126,7 +127,7 @@ export const fileTypeFromBlob = (file: Blob | File) => {
 
 export const validateFileExtension = async (
 	file: MaybeArray<Blob | File | undefined>,
-	extension: string | string[],
+	extension: FileType | FileType[],
 	// @ts-ignore
 	name = file?.name ?? ''
 ): Promise<boolean> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,9 @@ import type {
 
 import type { AnyWSLocalHook } from './ws/types'
 import type { WebSocketHandler } from './ws/bun'
+
 import type { Instruction as ExactMirrorInstruction } from 'exact-mirror'
-import { Static } from '@sinclair/typebox/parser'
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 
 type PartialServe = Partial<Serve>
 
@@ -43,11 +44,14 @@ export type IsNever<T> = [T] extends [never] ? true : false
 // Standard Schema reduce to bare minimum to save inference time
 export interface StandardSchemaV1Like<
 	in out Input = unknown,
-	in out Output = unknown
+	in out Output = Input
 > {
 	readonly '~standard': {
-		readonly types:
-			| any
+		readonly types?:
+			| {
+					readonly input: Input
+					readonly output: Output
+			  }
 			| undefined
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,12 +206,12 @@ export interface ValidatorLayer {
 }
 
 export interface StandaloneInputSchema<Name extends string = string> {
-	body?: TSchema | Name | `${Name}[]`
-	headers?: TSchema | Name | `${Name}[]`
-	query?: TSchema | Name | `${Name}[]`
-	params?: TSchema | Name | `${Name}[]`
-	cookie?: TSchema | Name | `${Name}[]`
-	response?: { [status in number]: `${Name}[]` | Name | TSchema }
+	body?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	headers?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	query?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	params?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	cookie?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	response?: { [status in number]: `${Name}[]` | Name | TSchema | StandardSchemaV1 }
 }
 
 export interface StandaloneValidator {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,12 @@ export interface StandardSchemaV1Like<
 	}
 }
 
+export type StandardSchemaV1LikeValidate = <T>(
+	v: T
+) => MaybePromise<
+	{ value: T; issues?: never } | { value?: never; issues: unknown[] }
+>
+
 export interface ElysiaConfig<Prefix extends string | undefined> {
 	/**
 	 * @default BunAdapter

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,9 @@ export interface StandardSchemaV1Like<
 	in out Input = unknown,
 	in out Output = unknown
 > {
-	'~standard': {
-		types:
-			| {
-					input: Input
-					output: Output
-			  }
+	readonly '~standard': {
+		readonly types:
+			| any
 			| undefined
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -696,12 +696,11 @@ export const createMacroManager =
 			}
 
 		// @ts-expect-error this is available in macro v2
-		if (stackName === 'resolve') {
+		if (stackName === 'resolve')
 			type = {
 				...type,
 				subType: 'resolve'
 			}
-		}
 
 		if (!localHook[stackName]) localHook[stackName] = []
 		if (typeof localHook[stackName] === 'function')

--- a/src/ws/types.ts
+++ b/src/ws/types.ts
@@ -121,48 +121,46 @@ export type WSParseHandler<Route extends RouteSchema, Context = {}> = (
 	message: unknown
 ) => MaybePromise<Route['body'] | void | undefined>
 
-export type AnyWSLocalHook = WSLocalHook<any, any, any, any>
+export type AnyWSLocalHook = WSLocalHook<any, any, any>
 
 export type WSLocalHook<
-	LocalSchema extends InputSchema,
+	Input extends BaseMacro,
 	Schema extends RouteSchema,
 	Singleton extends SingletonBase,
-	Macro extends MetadataBase['macro']
-> = Prettify<Macro> &
-	(LocalSchema extends any ? LocalSchema : Prettify<LocalSchema>) & {
-		detail?: DocumentDecoration
-		/**
-		 * Headers to register to websocket before `upgrade`
-		 */
-		upgrade?: Record<string, unknown> | ((context: Context) => unknown)
-		parse?: MaybeArray<WSParseHandler<Schema>>
+> = Prettify<Input> & {
+	detail?: DocumentDecoration
+	/**
+	 * Headers to register to websocket before `upgrade`
+	 */
+	upgrade?: Record<string, unknown> | ((context: Context) => unknown)
+	parse?: MaybeArray<WSParseHandler<Schema>>
 
-		/**
-		 * Transform context's value
-		 */
-		transform?: MaybeArray<TransformHandler<Schema, Singleton>>
-		/**
-		 * Execute before main handler
-		 */
-		beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
-		/**
-		 * Execute after main handler
-		 */
-		afterHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
-		/**
-		 * Execute after main handler
-		 */
-		mapResponse?: MaybeArray<MapResponse<Schema, Singleton>>
-		/**
-		 * Execute after response is sent
-		 */
-		afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton>>
-		/**
-		 * Catch error
-		 */
-		error?: MaybeArray<ErrorHandler<{}, Schema, Singleton>>
-		tags?: DocumentDecoration['tags']
-	} & TypedWebSocketHandler<
+	/**
+	 * Transform context's value
+	 */
+	transform?: MaybeArray<TransformHandler<Schema, Singleton>>
+	/**
+	 * Execute before main handler
+	 */
+	beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
+	/**
+	 * Execute after main handler
+	 */
+	afterHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
+	/**
+	 * Execute after main handler
+	 */
+	mapResponse?: MaybeArray<MapResponse<Schema, Singleton>>
+	/**
+	 * Execute after response is sent
+	 */
+	afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton>>
+	/**
+	 * Catch error
+	 */
+	error?: MaybeArray<ErrorHandler<{}, Schema, Singleton>>
+	tags?: DocumentDecoration['tags']
+} & TypedWebSocketHandler<
 		Omit<Context<Schema, Singleton>, 'body'> & {
 			body: never
 		},

--- a/test/adapter/web-standard/map-early-response.test.ts
+++ b/test/adapter/web-standard/map-early-response.test.ts
@@ -235,6 +235,7 @@ describe('Web Standard - Map Early Response', () => {
 
 		expect(response).toBeInstanceOf(Response)
 		expect(await response?.text()).toEqual('Shiroko')
+		// @ts-ignore
 		expect(response?.headers.toJSON()).toEqual({
 			...headers,
 			name: 'Himari'

--- a/test/adapter/web-standard/map-response.test.ts
+++ b/test/adapter/web-standard/map-response.test.ts
@@ -276,6 +276,7 @@ describe('Web Standard - Map Response', () => {
 
 		expect(response).toBeInstanceOf(Response)
 		expect(await response.text()).toEqual('Shiroko')
+		// @ts-ignore
 		expect(response.headers.toJSON()).toEqual({
 			...headers,
 			name: 'Himari'

--- a/test/aot/analysis.test.ts
+++ b/test/aot/analysis.test.ts
@@ -102,7 +102,7 @@ describe('Static code analysis', () => {
 		}
 
 		const app = new Elysia().post('/json', (c) => c.body, {
-			type: 'json'
+			parse: 'json'
 		})
 
 		const res = await app.handle(post('/json', body)).then((x) => x.json())

--- a/test/aot/response.test.ts
+++ b/test/aot/response.test.ts
@@ -6,7 +6,6 @@ import { signCookie } from '../../src/utils'
 const secrets = 'We long for the seven wailings. We bear the koan of Jericho.'
 
 const getCookies = (response: Response) =>
-	// @ts-expect-error
 	response.headers.getAll('Set-Cookie').map((x) => {
 		return decodeURIComponent(x)
 	})

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -297,7 +297,7 @@ describe('Cookie Response', () => {
 	})
 
 	it("don't parse cookie type unless specified", async () => {
-		let value: string | undefined
+		let value: unknown
 
 		const app = new Elysia().get(
 			'/council',
@@ -355,7 +355,6 @@ describe('Cookie Response', () => {
 			return 'a'
 		})
 
-		// @ts-expect-error
 		const res = app.handle(req('/')).then((x) => x.headers.toJSON())
 
 		// @ts-expect-error

--- a/test/core/elysia.test.ts
+++ b/test/core/elysia.test.ts
@@ -123,7 +123,6 @@ describe('Edge Case', () => {
 
 		const response = await app
 			.handle(req('/'))
-			// @ts-expect-error
 			.then((x) => x.headers.toJSON())
 
 		expect(response['set-cookie']).toHaveLength(1)

--- a/test/core/handle-error.test.ts
+++ b/test/core/handle-error.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, InternalServerError, NotFoundError, error, t } from '../../src'
+import { Elysia, InternalServerError, NotFoundError, status, t } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -142,8 +142,8 @@ describe('Handle Error', () => {
 	})
 
 	it('handle thrown error function', async () => {
-		const app = new Elysia().get('/', () => {
-			throw error(404, 'Not Found :(')
+		const app = new Elysia().get('/', ({ status }) => {
+			throw status(404, 'Not Found :(')
 		})
 
 		const response = await app.handle(req('/'))
@@ -153,8 +153,8 @@ describe('Handle Error', () => {
 	})
 
 	it('handle thrown Response', async () => {
-		const app = new Elysia().get('/', () => {
-			throw error(404, 'Not Found :(')
+		const app = new Elysia().get('/', ({ status }) => {
+			throw status(404, 'Not Found :(')
 		})
 
 		const response = await app.handle(req('/'))
@@ -253,8 +253,8 @@ describe('Handle Error', () => {
 
 		const response: Response = await new Elysia()
 			.get('/', () => 'Hello', {
-				beforeHandle({ error }) {
-					throw error("I'm a teapot", { message: 'meow!' })
+				beforeHandle({ status }) {
+					throw status("I'm a teapot", { message: 'meow!' })
 				}
 			})
 			// @ts-expect-error private property
@@ -265,7 +265,7 @@ describe('Handle Error', () => {
 						headers: {}
 					}
 				},
-				error(422, value) as any
+				status(422, value) as any
 			)
 
 		expect(await response.json()).toEqual(value)
@@ -288,8 +288,8 @@ describe('Handle Error', () => {
 					})
 			})
 			.get('/', () => 'Hello', {
-				beforeHandle({ error }) {
-					throw error("I'm a teapot", { message: 'meow!' })
+				beforeHandle({ status }) {
+					throw status("I'm a teapot", { message: 'meow!' })
 				}
 			})
 			// @ts-expect-error private property
@@ -300,7 +300,7 @@ describe('Handle Error', () => {
 						headers: {}
 					}
 				},
-				error(422, value) as any
+				status(422, value) as any
 			)
 
 		expect(await response.text()).toBe('Don Quixote')

--- a/test/core/mount.test.ts
+++ b/test/core/mount.test.ts
@@ -119,7 +119,6 @@ describe('Mount', () => {
 
 	it('preserve headers', async () => {
 		const app = new Elysia().mount((request) => {
-			// @ts-expect-error Bun has toJSON
 			return Response.json(request.headers.toJSON())
 		})
 

--- a/test/core/native-static.test.ts
+++ b/test/core/native-static.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Elysia } from '../../src'
 import { describe, expect, it } from 'bun:test'
 

--- a/test/core/normalize.test.ts
+++ b/test/core/normalize.test.ts
@@ -100,7 +100,7 @@ describe('Normalize', () => {
 			normalize: false
 		}).get(
 			'/',
-			({ error }) => error(418, { name: 'Nagisa', hifumi: 'daisuki' }),
+			({ status }) => status(418, { name: 'Nagisa', hifumi: 'daisuki' }),
 			{
 				response: {
 					200: t.Object({

--- a/test/core/normalize.test.ts
+++ b/test/core/normalize.test.ts
@@ -75,7 +75,8 @@ describe('Normalize', () => {
 	it('normalize multiple response', async () => {
 		const app = new Elysia().get(
 			'/',
-			({ error }) => error(418, { name: 'Nagisa', hifumi: 'daisuki' }),
+			// @ts-ignore
+			({ status }) => status(418, { name: 'Nagisa', hifumi: 'daisuki' }),
 			{
 				response: {
 					200: t.Object({
@@ -100,6 +101,7 @@ describe('Normalize', () => {
 			normalize: false
 		}).get(
 			'/',
+			// @ts-ignore
 			({ status }) => status(418, { name: 'Nagisa', hifumi: 'daisuki' }),
 			{
 				response: {

--- a/test/extends/models.test.ts
+++ b/test/extends/models.test.ts
@@ -332,14 +332,14 @@ describe('Model', () => {
 					400: 'res'
 				}
 			})
-			.get('/400', ({ error }) => error(400, 'ok'), {
+			.get('/400', ({ status }) => status(400, 'ok'), {
 				response: {
 					200: 'res',
 					400: 'res'
 				}
 			})
 			// @ts-expect-error
-			.get('/error', ({ error }) => error(400, 1), {
+			.get('/error', ({ status }) => status(400, 1), {
 				response: {
 					200: 'res',
 					400: 'res'

--- a/test/lifecycle/derive.test.ts
+++ b/test/lifecycle/derive.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, error } from '../../src'
+import { Elysia } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -182,9 +182,7 @@ describe('derive', () => {
 
 	it('handle error', async () => {
 		const app = new Elysia()
-			.derive(() => {
-				return error(418)
-			})
+			.derive(({ status }) => status(418))
 			.get('/', () => '')
 
 		const res = await app.handle(req('/')).then((x) => x.text())

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -4,7 +4,6 @@ import {
 	InternalServerError,
 	ParseError,
 	ValidationError,
-	error,
 	t,
 	validationDetail
 } from '../../src'
@@ -127,8 +126,8 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct number status on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) =>
-				error(418, 'I am a teapot')
+			const app = new Elysia({ aot }).get('/', ({ status }) =>
+				status(418, 'I am a teapot')
 			)
 
 			const response = await app.handle(req('/'))
@@ -140,8 +139,8 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct named status on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) =>
-				error("I'm a teapot", 'I am a teapot')
+			const app = new Elysia({ aot }).get('/', ({ status }) =>
+				status("I'm a teapot", 'I am a teapot')
 			)
 
 			const response = await app.handle(req('/'))
@@ -153,7 +152,7 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct number status without value on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) => error(418))
+			const app = new Elysia({ aot }).get('/', ({ status }) => status(418))
 
 			const response = await app.handle(req('/'))
 
@@ -165,8 +164,8 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct named status without value on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) =>
-				error("I'm a teapot")
+			const app = new Elysia({ aot }).get('/', ({ status }) =>
+				status("I'm a teapot")
 			)
 
 			const response = await app.handle(req('/'))

--- a/test/lifecycle/hook-types.test.ts
+++ b/test/lifecycle/hook-types.test.ts
@@ -13,19 +13,19 @@ describe('Hook Types', () => {
 			}
 		)
 
-		expect(plugin.event.transform[0].scope).toBe('scoped')
+		expect(plugin.event.transform?.[0].scope).toBe('scoped')
 
 		const a = new Elysia().use(plugin).get('/foo', ({ id }) => {
 			return { id, name: 'foo' }
 		})
 
-		expect(plugin.event.transform[0].scope).toBe('scoped')
+		expect(plugin.event.transform?.[0].scope).toBe('scoped')
 
 		const b = new Elysia().use(plugin).get('/bar', ({ id }) => {
 			return { id, name: 'bar' }
 		})
 
-		expect(plugin.event.transform[0].scope).toBe('scoped')
+		expect(plugin.event.transform?.[0].scope).toBe('scoped')
 
 		const [res1, res2] = await Promise.all([
 			a.handle(req('/foo')).then((x) => x.json()),

--- a/test/lifecycle/map-response.test.ts
+++ b/test/lifecycle/map-response.test.ts
@@ -243,7 +243,7 @@ describe('Map Response', () => {
 		const app = new Elysia()
 			.onAfterHandle(() => {})
 			.mapResponse((context) => {
-				return context.response
+				return new Response(context.response + '')
 			})
 			.get('/', async () => 'aru')
 

--- a/test/lifecycle/parser.test.ts
+++ b/test/lifecycle/parser.test.ts
@@ -428,6 +428,7 @@ describe('Parser', () => {
 
 		const app = new Elysia()
 			.onError((ctx) => {
+				// @ts-ignore
 				code = ctx.code
 			})
 			.post('/', () => '', {

--- a/test/lifecycle/resolve.test.ts
+++ b/test/lifecycle/resolve.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, error } from '../../src'
+import { Elysia } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -211,8 +211,8 @@ describe('resolve', () => {
 
 	it('handle error', async () => {
 		const route = new Elysia()
-			.resolve(() => {
-				return error(418)
+			.resolve(({ status }) => {
+				return status(418)
 			})
 			.get('/', () => '')
 

--- a/test/lifecycle/transform.test.ts
+++ b/test/lifecycle/transform.test.ts
@@ -41,17 +41,13 @@ describe('Transform', () => {
 
 	it('group transform', async () => {
 		const app = new Elysia()
-			.group('/scoped', (app) =>
+			.group('/scoped/id/:id', (app) =>
 				app
-					.onTransform<{
-						params: {
-							id: number
-						} | null
-					}>((request) => {
-						if (request.params?.id)
-							request.params.id = +request.params.id
+					.onTransform(({ params }) => {
+						// @ts-ignore
+						if (params.id) params.id = +params.id
 					})
-					.get('/id/:id', ({ params: { id } }) => typeof id)
+					.get('', ({ params: { id } }) => typeof id)
 			)
 			.get('/id/:id', ({ params: { id } }) => typeof id)
 
@@ -71,6 +67,7 @@ describe('Transform', () => {
 			},
 			'global'
 		>({ as: 'global' }, (request) => {
+			// @ts-ignore
 			if (request.params?.id) request.params.id = +request.params.id
 		})
 

--- a/test/macro/macro.test.ts
+++ b/test/macro/macro.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, it, expect } from 'bun:test'
-import Elysia, { error, t } from '../../src'
+import Elysia, { t } from '../../src'
 import { req } from '../utils'
+import { status } from '../../dist/cjs'
 
 describe('Macro', () => {
 	it('work', async () => {
@@ -362,7 +363,7 @@ describe('Macro', () => {
 			requiredUser(value: boolean) {
 				onBeforeHandle(async () => {
 					if (value)
-						return error(401, {
+						return status(401, {
 							code: 'S000002',
 							message: 'Unauthorized'
 						})
@@ -416,8 +417,8 @@ describe('Macro', () => {
 		const authGuard = new Elysia().macro(({ onBeforeHandle }) => ({
 			isAuth(shouldAuth: boolean) {
 				if (shouldAuth) {
-					onBeforeHandle(({ cookie: { session }, error }) => {
-						if (!session.value) return error(418)
+					onBeforeHandle(({ cookie: { session }, status }) => {
+						if (!session.value) return status(418)
 					})
 				}
 			}
@@ -438,8 +439,8 @@ describe('Macro', () => {
 		const authGuard = new Elysia().macro(({ onBeforeHandle }) => ({
 			isAuth(shouldAuth: boolean) {
 				if (shouldAuth) {
-					onBeforeHandle(({ cookie: { session }, error }) => {
-						if (!session.value) return error(418)
+					onBeforeHandle(({ cookie: { session }, status }) => {
+						if (!session.value) return status(418)
 					})
 				}
 			}
@@ -456,12 +457,12 @@ describe('Macro', () => {
 		expect(status).toBe(418)
 	})
 
-	it('inherits macro in group', async () => {
+	it('inherits macro from plugin', async () => {
 		const authGuard = new Elysia().macro(({ onBeforeHandle }) => ({
 			isAuth(shouldAuth: boolean) {
 				if (shouldAuth) {
-					onBeforeHandle(({ cookie: { session }, error }) => {
-						if (!session.value) return error(418)
+					onBeforeHandle(({ cookie: { session }, status }) => {
+						if (!session.value) return status(418)
 					})
 				}
 			}
@@ -482,6 +483,7 @@ describe('Macro', () => {
 		const called = <string[]>[]
 
 		const plugin = new Elysia().get('/hello', () => 'hello', {
+			// @ts-ignore
 			hello: 'nagisa'
 		})
 
@@ -581,7 +583,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -615,7 +617,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -650,7 +652,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -685,7 +687,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -720,8 +722,8 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => {
-						if (Math.random() > 2) return error(401)
+					resolve: () => {
+						if (Math.random() > 2) return status(401)
 
 						return {
 							account: 'A'
@@ -758,8 +760,8 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: async ({ error }) => {
-						if (Math.random() > 2) return error(401)
+					resolve: async () => {
+						if (Math.random() > 2) return status(401)
 
 						return {
 							account: 'A'
@@ -809,8 +811,8 @@ describe('Macro', () => {
 			})
 			.get(
 				'/',
-				({ user, error }) => {
-					if (!user) return error(401)
+				({ user, status }) => {
+					if (!user) return status(401)
 
 					return { hello: 'hanabi' }
 				},
@@ -903,6 +905,7 @@ describe('Macro', () => {
 					// @ts-expect-error Property `a` does not exist
 					a,
 					b,
+					// @ts-expect-error Property `c` does not exist
 					c
 				}) => ({ a, b, c }),
 				{

--- a/test/plugins/checksum.test.ts
+++ b/test/plugins/checksum.test.ts
@@ -304,7 +304,7 @@ describe('Checksum', () => {
 		let i = 0
 
 		const plugin = new Elysia().use(
-			new Elysia({ prefix: '/call', scoped: true })
+			new Elysia({ prefix: '/call' })
 				.derive(() => {
 					i++ // <-- should not be called, when requesting /asdf
 					return { test: 'test' }

--- a/test/response/redirect.test.ts
+++ b/test/response/redirect.test.ts
@@ -10,7 +10,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi'
 		})
@@ -24,7 +23,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(301)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi'
 		})
@@ -40,7 +38,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi',
 			alias: 'Abyssal Hunter'

--- a/test/sucrose/infer-body-reference.test.ts
+++ b/test/sucrose/infer-body-reference.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { inferBodyReference } from '../../src/sucrose'
+import { inferBodyReference, Sucrose } from '../../src/sucrose'
 
 describe('infer body reference', () => {
 	it('infer dot notation', () => {
@@ -11,12 +11,15 @@ describe('infer body reference', () => {
 			body: false,
 			cookie: false,
 			set: false,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
-		expect(inference.body).toBe(true)
+		expect(inference.body as boolean).toBe(true)
 	})
 
 	it('infer property access', () => {
@@ -28,12 +31,15 @@ describe('infer body reference', () => {
 			body: false,
 			cookie: false,
 			set: false,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
-		expect(inference.body).toBe(true)
+		expect(inference.body as boolean).toBe(true)
 	})
 
 	it('infer multiple query', () => {
@@ -52,8 +58,11 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
@@ -63,7 +72,10 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
+			server: false,
+			path: false,
+			route: false,
+			url: false
 		})
 	})
 
@@ -141,8 +153,11 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
@@ -152,7 +167,10 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
+			server: false,
+			path: false,
+			route: false,
+			url: false
 		})
 	})
 
@@ -167,11 +185,14 @@ describe('infer body reference', () => {
 			body: false,
 			cookie: false,
 			set: false,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
-		expect(inference.server).toBe(true)
+		expect(inference.server as boolean).toBe(true)
 	})
 })

--- a/test/tracer/trace.test.ts
+++ b/test/tracer/trace.test.ts
@@ -31,7 +31,7 @@ describe('trace', () => {
 			clearTimeout(timeout)
 		})
 
-		const b = new Elysia({ scoped: true }).get('/scoped', () => 'hi')
+		const b = new Elysia().get('/scoped', () => 'hi')
 
 		const app = new Elysia()
 			.use(a)

--- a/test/type-system/uint8array.test.ts
+++ b/test/type-system/uint8array.test.ts
@@ -63,11 +63,7 @@ describe('TypeSystem - Uint8Array', () => {
 	// })
 
 	it('Integrate', async () => {
-		const app = new Elysia().post('/', ({ body }) => {
-			console.log(body)
-
-			return body
-		}, {
+		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.Uint8Array(),
 			response: t.Uint8Array()
 		})

--- a/test/type-system/union-enum.test.ts
+++ b/test/type-system/union-enum.test.ts
@@ -14,11 +14,10 @@ describe('TypeSystem - UnionEnum', () => {
 	})
 
 	it('Check', () => {
-		const schema = t.UnionEnum(['some', 'data', null])
+		const schema = t.UnionEnum(['some', 'data'])
 
 		expect(Value.Check(schema, 'some')).toBe(true)
 		expect(Value.Check(schema, 'data')).toBe(true)
-		expect(Value.Check(schema, null)).toBe(true)
 
 		expect(Value.Check(schema, { deep: 2 })).toBe(false)
 		expect(Value.Check(schema, 'yay')).toBe(false)
@@ -26,6 +25,7 @@ describe('TypeSystem - UnionEnum', () => {
 		expect(Value.Check(schema, {})).toBe(false)
 		expect(Value.Check(schema, undefined)).toBe(false)
 	})
+
 	it('JSON schema', () => {
 		expect(t.UnionEnum(['some', 'data'])).toMatchObject({
 			type: 'string',
@@ -36,27 +36,21 @@ describe('TypeSystem - UnionEnum', () => {
 			type: 'number',
 			enum: [2, 1]
 		})
-		expect(t.UnionEnum([null])).toMatchObject({
-			type: 'null',
-			enum: [null]
-		})
 	})
+
 	it('Integrate', async () => {
 		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.Object({
-				value: t.UnionEnum(['some', 1, null])
+				value: t.UnionEnum(['some', 1])
 			})
 		})
 		const res1 = await app.handle(post('/', { value: 1 }))
 		expect(res1.status).toBe(200)
 
-		const res2 = await app.handle(post('/', { value: null }))
+		const res2 = await app.handle(post('/', { value: 'some' }))
 		expect(res2.status).toBe(200)
 
-		const res3 = await app.handle(post('/', { value: 'some' }))
-		expect(res3.status).toBe(200)
-
-		const res4 = await app.handle(post('/', { value: 'data' }))
-		expect(res4.status).toBe(422)
+		const res3 = await app.handle(post('/', { value: 'data' }))
+		expect(res3.status).toBe(422)
 	})
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -4,10 +4,10 @@ import {
 	Elysia,
 	RouteSchema,
 	Cookie,
-	error,
 	file,
 	sse,
-	SSEPayload
+	SSEPayload,
+    status
 } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
@@ -67,7 +67,7 @@ app.model({
 
 		// ? unwrap cookie
 		expectTypeOf<
-			Record<string, Cookie<string | undefined>> & {
+			Record<string, Cookie<unknown>> & {
 				username: Cookie<string>
 				password: Cookie<string>
 			}
@@ -1255,14 +1255,13 @@ const a = app
 // ? Handle error status
 {
 	const a = new Elysia()
-		.get('/', ({ error }) => error(418, 'a'), {
+		.get('/', ({ status }) => status(418, 'a'), {
 			response: {
 				200: t.String(),
 				418: t.Literal('a')
 			}
 		})
-		// @ts-expect-error
-		.get('/', ({ error }) => error(418, 'b'), {
+		.get('/', ({ status }) => status(418, 'b' as any), {
 			response: {
 				200: t.String(),
 				418: t.Literal('a')
@@ -1277,18 +1276,18 @@ const a = app
 		.get('/true', () => true)
 		.post('', () => 'a', { response: { 201: t.String() } })
 		.post('/true', () => true, { response: { 202: t.Boolean() } })
-		.get('/error', ({ error }) => error("I'm a teapot", 'a'))
+		.get('/error', ({ status }) => status("I'm a teapot", 'a'))
 		.post('/mirror', ({ body }) => body)
 		.get('/immutable', '1')
-		.get('/immutable-error', ({ error }) => error("I'm a teapot", 'a'))
-		.get('/async', async ({ error }) => {
-			if (Math.random() > 0.5) return error("I'm a teapot", 'Nagisa')
+		.get('/immutable-error', ({ status }) => status("I'm a teapot", 'a'))
+		.get('/async', async ({ status }) => {
+			if (Math.random() > 0.5) return status("I'm a teapot", 'Nagisa')
 
 			return 'Hifumi'
 		})
-		.get('/default-error-code', ({ error }) => {
-			if (Math.random() > 0.5) return error(418, 'Nagisa')
-			if (Math.random() > 0.5) return error(401)
+		.get('/default-error-code', ({ status }) => {
+			if (Math.random() > 0.5) return status(418, 'Nagisa')
+			if (Math.random() > 0.5) return status(401)
 
 			return 'Hifumi'
 		})
@@ -1643,9 +1642,9 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', ({ error }) => {
-				error('Payment Required', 20)
-				return error(401, true)
+			.get('/plugin', ({ status }) => {
+				status('Payment Required', 20)
+				return status(401, true)
 			})
 
 		const app = new Elysia().use(plugin).get('/', () => 'ok')
@@ -1670,7 +1669,7 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', error(401, true))
+			.get('/plugin', status(401, true))
 
 		const app = new Elysia().use(plugin).get('/', 'ok')
 	}
@@ -1905,9 +1904,9 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', ({ error }) => {
-				error('Payment Required', 20)
-				return error(401, true)
+			.get('/plugin', ({ status }) => {
+				status('Payment Required', 20)
+				return status(401, true)
 			})
 
 		const app = new Elysia().use(plugin).get('/', () => 'ok')
@@ -1932,7 +1931,7 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', error(401, true))
+			.get('/plugin', status(401, true))
 
 		const app = new Elysia().use(plugin).get('/', 'ok')
 	}
@@ -2287,12 +2286,12 @@ type a = keyof {}
 
 				return {
 					beforeHandle({
-						error,
+						status,
 						cookie: { token },
 						store: { session }
 					}) {
 						if (!token.value)
-							return error(401, {
+							return status(401, {
 								success: false,
 								message: 'Unauthorized'
 							})
@@ -2305,7 +2304,7 @@ type a = keyof {}
 							session[token.value as unknown as number]
 
 						if (!username)
-							return error(401, {
+							return status(401, {
 								success: false,
 								message: 'Unauthorized'
 							})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1301,7 +1301,7 @@ const a = app
 
 	expectTypeOf<app['post']['response']>().toEqualTypeOf<{
 		200: string
-		readonly 201: string
+		201: string
 		422: {
 			type: 'validation'
 			on: string
@@ -1319,7 +1319,7 @@ const a = app
 
 	expectTypeOf<app['true']['post']['response']>().toEqualTypeOf<{
 		200: boolean
-		readonly 202: boolean
+		202: boolean
 		422: {
 			type: 'validation'
 			on: string
@@ -2014,32 +2014,46 @@ type a = keyof {}
 {
 	new Elysia()
 		.onParse(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.derive(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 
 			return {}
 		})
 		.resolve(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<never>()
 
 			return {}
 		})
 		.onTransform(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.onBeforeHandle(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.onAfterHandle(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.mapResponse(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.onAfterResponse(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 }
 
@@ -2442,8 +2456,8 @@ type a = keyof {}
 				expectTypeOf<typeof a>().toEqualTypeOf<string>()
 			},
 			{
-				a: true,
-				beforeHandle: (c) => {}
+				a: true
+				// beforeHandle: (c) => {}
 			}
 		)
 		.ws('/', {
@@ -2567,7 +2581,7 @@ type a = keyof {}
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
 	>().toEqualTypeOf<
-		AsyncGenerator<
+		Generator<
 			| {
 					readonly data: 'a'
 			  }
@@ -2595,7 +2609,7 @@ type a = keyof {}
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
 	>().toEqualTypeOf<
-		AsyncGenerator<
+		Generator<
 			| {
 					readonly data: 'a'
 			  }
@@ -2649,13 +2663,9 @@ type a = keyof {}
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
 	>().toEqualTypeOf<
-		AsyncGenerator<
-			{
-				readonly data: 'a'
-			},
-			void,
-			unknown
-		>
+		ReadableStream<{
+			readonly data: 'a'
+		}>
 	>()
 }
 
@@ -2669,5 +2679,5 @@ type a = keyof {}
 
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
-	>().toEqualTypeOf<AsyncGenerator<'a', void, unknown>>()
+	>().toEqualTypeOf<ReadableStream<'a'>>()
 }

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -6,7 +6,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -32,7 +32,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -60,7 +60,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -89,7 +89,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -116,8 +116,8 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => {
-					if (Math.random() > 0.5) return error(401)
+				resolve: ({ status }) => {
+					if (Math.random() > 0.5) return status(401)
 
 					return {
 						account: 'A'
@@ -146,8 +146,8 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: async ({ error }) => {
-					if (Math.random() > 0.5) return error(401)
+				resolve: async ({ status }) => {
+					if (Math.random() > 0.5) return status(401)
 
 					return {
 						account: 'A'

--- a/test/types/schema-standalone.ts
+++ b/test/types/schema-standalone.ts
@@ -869,7 +869,7 @@ import { expectTypeOf } from 'expect-type'
 					}>()
 
 					expectTypeOf<typeof cookie>().toEqualTypeOf<
-						Record<string, Cookie<string | undefined>> & {
+						Record<string, Cookie<unknown>> & {
 							family: Cookie<string>
 							name: Cookie<string>
 						}
@@ -907,7 +907,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						name: Cookie<string>
 					}
 				>()
@@ -944,7 +944,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						name: Cookie<string>
 					}
 				>()
@@ -1002,7 +1002,7 @@ import { expectTypeOf } from 'expect-type'
 					}>()
 
 					expectTypeOf<typeof cookie>().toEqualTypeOf<
-						Record<string, Cookie<string | undefined>> & {
+						Record<string, Cookie<unknown>> & {
 							family: Cookie<string>
 							name: Cookie<string>
 						}
@@ -1044,7 +1044,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						family: Cookie<string>
 						name: Cookie<string>
 					}
@@ -1082,7 +1082,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						name: Cookie<string>
 					}
 				>()
@@ -1140,7 +1140,7 @@ import { expectTypeOf } from 'expect-type'
 					}>()
 
 					expectTypeOf<typeof cookie>().toEqualTypeOf<
-						Record<string, Cookie<string | undefined>> & {
+						Record<string, Cookie<unknown>> & {
 							family: Cookie<string>
 							name: Cookie<string>
 						}
@@ -1182,7 +1182,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						family: Cookie<string>
 						name: Cookie<string>
 					}
@@ -1224,7 +1224,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						family: Cookie<string>
 						name: Cookie<string>
 					}

--- a/test/validator/encode.test.ts
+++ b/test/validator/encode.test.ts
@@ -34,8 +34,8 @@ describe('Encode response', () => {
 			encodeSchema: true
 		}).get(
 			'/:id',
-			({ error, params: { id } }) =>
-				error(id as any, {
+			({ status, params: { id } }) =>
+				status(id as any, {
 					id: 'hello world'
 				}),
 			{

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -968,19 +968,17 @@ describe('Query Validator', () => {
 	it('handle coerce TransformDecodeError', async () => {
 		let err: Error | undefined
 
-		const app = new Elysia()
-			.get('/', ({ query }) => query, {
-				query: t.Object({
-					year: t.Numeric({ minimum: 1900, maximum: 2160 })
-				}),
-				error({ code, error }) {
-					switch (code) {
-						case 'VALIDATION':
-							err = error
-					}
+		const app = new Elysia().get('/', ({ query }) => query, {
+			query: t.Object({
+				year: t.Numeric({ minimum: 1900, maximum: 2160 })
+			}),
+			error({ code, error }) {
+				switch (code) {
+					case 'VALIDATION':
+						err = error
 				}
-			})
-			.listen(0)
+			}
+		})
 
 		await app.handle(req('?year=3000'))
 

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -330,7 +330,6 @@ describe('Query Validator', () => {
 					check() {
 						const { state } = ctx.query
 
-						// @ts-expect-error
 						if (!checker.check(ctx, name, state ?? ctx.query.state))
 							throw new Error('State mismatch')
 					}

--- a/test/validator/response.test.ts
+++ b/test/validator/response.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, error, t } from '../../src'
+import { Elysia, t } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { post, req, upload } from '../utils'
@@ -295,18 +295,22 @@ describe('Response Validator', () => {
 	})
 
 	it('validate response per status with error()', async () => {
-		const app = new Elysia().get('/', () => error(418, 'I am a teapot'), {
-			response: {
-				200: t.String(),
-				418: t.String()
+		const app = new Elysia().get(
+			'/',
+			({ status }) => status(418, 'I am a teapot'),
+			{
+				response: {
+					200: t.String(),
+					418: t.String()
+				}
 			}
-		})
+		)
 	})
 
 	it('use inline error from handler', async () => {
 		const app = new Elysia().get(
 			'/',
-			({ error }) => error(418, 'I am a teapot'),
+			({ status }) => status(418, 'I am a teapot'),
 			{
 				response: {
 					200: t.String(),
@@ -379,7 +383,7 @@ describe('Response Validator', () => {
 
 	it('return error response with validator', async () => {
 		const app = new Elysia()
-			.get('/ok', ({ error }) => 'ok', {
+			.get('/ok', () => 'ok', {
 				response: {
 					200: t.String(),
 					418: t.Literal('Kirifuji Nagisa'),
@@ -388,7 +392,7 @@ describe('Response Validator', () => {
 			})
 			.get(
 				'/error',
-				({ error }) => error("I'm a teapot", 'Kirifuji Nagisa'),
+				({ status }) => status("I'm a teapot", 'Kirifuji Nagisa'),
 				{
 					response: {
 						200: t.String(),
@@ -399,8 +403,8 @@ describe('Response Validator', () => {
 			)
 			.get(
 				'/validate-error',
-				// @ts-expect-error
-				({ error }) => error("I'm a teapot", 'Nagisa'),
+				// @ts-ignore
+				({ status }) => status("I'm a teapot", 'Nagisa'),
 				{
 					response: {
 						200: t.String(),

--- a/test/ws/aot.test.ts
+++ b/test/ws/aot.test.ts
@@ -10,7 +10,6 @@ describe('WebSocket with AoT disabled', () => {
 			})
 			.listen(0)
 
-		// @ts-expect-error some properties are missing
 		const ws = newWebsocket(app.server!)
 
 		await wsOpen(ws)


### PR DESCRIPTION
Addressing #20 by adding support for Standard Schema

<img src=https://github.com/user-attachments/assets/d0c962e8-5c74-47c4-80aa-675b6d9d34e0 alt=nihamazing height=160 />

- [x] validate successfully
- [x] it infers type correctly
- [x] work with treaty (only proper type inference is required)
- [x] work as a standalone schema
- [ ] work as reference schema (string name)
- [ ] has test cases
- [x] work with dynamic mode (it's likely to work now, but not test yet)
- [ ] support OpenAPI by library's native API annotation (planned, likely will use [xs schema])(https://www.npmjs.com/package/xsschema)
- [x] support with OpenAPI for a library with no support for OpenAPI somehow. Solved with [Elysia OpenAPI Type Gen](https://elysiajs.com/blog/openapi-type-gen.html)
- [x] type inference is fast enough that it doesn't have a significant slowdown
- [x] support multiple schemas from multiple libraries interchangeably
- [x] it normalizes when using multiple standalone schema⁽¹⁾

1. Works by creating a parsed snapshot value of each validator, then merging them together. See https://github.com/elysiajs/elysia/commit/a43a60790a7e19000d28b9418b6c9d6c5146decd.