### PR TITLE
fix: t.NoValidate

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -246,8 +246,10 @@ const composeValidationFactory = ({
 
 			if (!noValidate && value.schema?.$ref && value.schema?.$defs) {
 				const refKey = value.schema.$ref
-
-				const referencedDef = value.schema.$defs[refKey]
+				const defKey = typeof refKey === 'string' && refKey.includes('/')
+										? refKey.split('/').pop()!
+										: refKey
+				const referencedDef = value.schema.$defs[defKey as keyof typeof value.schema.$defs]
 				
 				if (referencedDef?.noValidate === true) {
 					noValidate = true

--- a/test/validator/novalidate.test.ts
+++ b/test/validator/novalidate.test.ts
@@ -208,26 +208,25 @@ describe('ElysiaType.NoValidate', () => {
 	})
 
 	it('should work with NoValidate on nested object properties', async () => {
-		const app = new Elysia()
-			.get(
-				'/',
-				// @ts-expect-error
-				() => ({
-					user: { age: '123', name: true },
-					timestamp: '2025-01-01T00:00:00Z'
-				}),
-				{
-					response: t.NoValidate(
-						t.Object({
-							user: t.Object({
-								name: t.String(),
-								age: t.Number()
-							}),
-							timestamp: t.Date()
-						})
-					)
-				}
-			)
+		const app = new Elysia().get(
+			'/',
+			// @ts-expect-error
+			() => ({
+				user: { age: '123', name: true },
+				timestamp: '2025-01-01T00:00:00Z'
+			}),
+			{
+				response: t.NoValidate(
+					t.Object({
+						user: t.Object({
+							name: t.String(),
+							age: t.Number()
+						}),
+						timestamp: t.Date()
+					})
+				)
+			}
+		)
 
 		const res = await app.handle(req('/'))
 
@@ -308,5 +307,29 @@ describe('ElysiaType.NoValidate', () => {
 
 		expect(res.status).toBe(200)
 		expect(await res.text()).toBe('test')
+	})
+
+	it('bypasses Encode when encodeSchema=true (Date)', async () => {
+		const app = new Elysia({ encodeSchema: true }).get(
+			'/',
+			// @ts-expect-error
+			() => 'Hello Elysia',
+			{ response: t.NoValidate(t.Date()) }
+		)
+		const res = await app.handle(req('/'))
+		expect(res.status).toBe(200)
+		expect(await res.text()).toBe('Hello Elysia')
+	})
+
+	it('bypasses Encode with NoValidate(t.Ref(Date)) when encodeSchema=true', async () => {
+		const app = new Elysia({ encodeSchema: true })
+			.model({ createdAt: t.Date() })
+			// @ts-expect-error
+			.get('/', () => 'Hello', {
+				response: t.NoValidate(t.Ref('createdAt'))
+			})
+		const res = await app.handle(req('/'))
+		expect(res.status).toBe(200)
+		expect(await res.text()).toBe('Hello')
 	})
 })


### PR DESCRIPTION
 ## Summary

Fix `t.NoValidate` not working with referenced models and schema transformations

## Test Coverage

  Added comprehensive test case in `test/validator/novalidate.test.ts` covering:
  - Referenced models with `t.NoValidate`
  - Various schema types (`t.Date`, `t.Number`, etc.)
  - Both inline and referenced schema scenarios

## Closes

  - Fixes #1361 - `t.NoValidate` doesn't work with "reference model"
  - Fixes #1386 - `t.NoValidate` doesn't work with `t.Date`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - NoValidate is now recognized when using referenced schema definitions, including per-status response schemas; supports nested, union, and complex structures.
- Bug Fixes
  - Prevents encoding/transformation when NoValidate is active so raw payloads are returned as intended.
- Tests
  - Added comprehensive tests for NoValidate across types (string, number, boolean, object, array, union, date), refs, strict objects, empty bodies, nested structures, and per-status responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->