### PR TITLE
Release 1.4: Weirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 1.4.0 - 13 Sep 2025
+Feature:
+- standard validator
+- macro schema, macro extension, macro detail
+- lifecycle type soundness
+- type inference reduced by ~11%
+- [#861](https://github.com/elysiajs/elysia/issues/861) missing HEAD method when register route with GET
+
+Improvement
+- [#861](https://github.com/elysiajs/elysia/issues/861) automatically add HEAD method when defining GET route
+
+Change
+- ObjectString/ArrayString no longer produce default value by default due to security reasons
+- Cookie now dynamically parse when format is likely JSON
+- export `fileType` for external file type validation for accurate response
+- ObjectString/ArrayString no longer produce default value by default due to security reasons
+- Cookie now dynamically parse when format is likely JSON
+
+Breaking Change
+- remove macro v1 due to non type soundness
+- remove `error` function, use `status` instead
+- deprecation notice for `response` in `mapResponse`, `afterResponse`, use `responseValue` instead
+
 # 1.3.22 - 6 Sep 2025
 Bug fix:
 - safely unwrap t.Record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # 1.3.12 - 19 Aug 2025
 Bug fix:
-- [#1348](https://github.com/elysiajs/elysia/issues/1348) onAfterResponse runs twice if NotFoundError thrown and onError provided 
+- [#1348](https://github.com/elysiajs/elysia/issues/1348) onAfterResponse runs twice if NotFoundError thrown and onError provided
 
 # 1.3.11 - 18 Aug 2025
 Bug fix:
-- [#1346](https://github.com/elysiajs/elysia/issues/1346) cannot declare 'mep' twice 
+- [#1346](https://github.com/elysiajs/elysia/issues/1346) cannot declare 'mep' twice
 
 # 1.3.10 - 18 Aug 2025
 Bug fix:

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,8 @@
     "": {
       "name": "elysia",
       "dependencies": {
-        "arktype": "^2.1.22",
         "cookie": "^1.0.2",
-        "exact-mirror": "0.1.6",
+        "exact-mirror": "0.2.2",
         "fast-decode-uri-component": "^1.0.1",
       },
       "devDependencies": {
@@ -15,6 +14,7 @@
         "@types/fast-decode-uri-component": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
         "@typescript-eslint/parser": "^8.30.1",
+        "arktype": "^2.1.22",
         "eslint": "^9.24.0",
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-sonarjs": "^3.0.2",
@@ -371,7 +371,7 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.1", "", {}, "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA=="],
 
-    "exact-mirror": ["exact-mirror@0.1.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-EXGDixoDotCGrXCce63zmGHDA+3Id6PPkIwshBHuB10dwVc4YV4gfaYLuysHOxyURmwyt4UL186ann0oYa2CFQ=="],
+    "exact-mirror": ["exact-mirror@0.2.2", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-CrGe+4QzHZlnrXZVlo/WbUZ4qQZq8C0uATQVGVgXIrNXgHDBBNFD1VRfssRA2C9t3RYvh3MadZSdg2Wy7HBoQA=="],
 
     "expect-type": ["expect-type@1.2.1", "", {}, "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,11 @@
     "": {
       "name": "elysia",
       "dependencies": {
+        "arktype": "^2.1.20",
         "cookie": "^1.0.2",
         "exact-mirror": "0.1.6",
         "fast-decode-uri-component": "^1.0.1",
+        "valibot": "^1.1.0",
       },
       "devDependencies": {
         "@types/bun": "^1.2.16",
@@ -28,17 +30,24 @@
       "optionalDependencies": {
         "@sinclair/typebox": "^0.34.33",
         "openapi-types": "^12.1.3",
+        "zod": "4.1.1",
       },
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0",
+        "@standard-schema/spec": "^1.0.0",
         "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",
+        "zod": ">= 4.0.0",
       },
     },
   },
   "packages": {
+    "@ark/schema": ["@ark/schema@0.46.0", "", { "dependencies": { "@ark/util": "0.46.0" } }, "sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ=="],
+
+    "@ark/util": ["@ark/util@0.46.0", "", {}, "sha512-JPy/NGWn/lvf1WmGCPw2VGpBg5utZraE84I7wli18EDF3p3zc/e9WolT35tINeZO3l7C77SjqRJeAUoT0CvMRg=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.4", "", { "os": "android", "cpu": "arm" }, "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="],
@@ -179,6 +188,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -226,6 +237,8 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "arktype": ["arktype@2.1.20", "", { "dependencies": { "@ark/schema": "0.46.0", "@ark/util": "0.46.0" } }, "sha512-IZCEEXaJ8g+Ijd59WtSYwtjnqXiwM8sWQ5EjGamcto7+HVN9eK0C4p0zDlCuAwWhpqr6fIBkxPuYDl4/Mcj/+Q=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -793,6 +806,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "valibot": ["valibot@1.1.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
@@ -819,7 +834,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+    "zod": ["zod@4.1.1", "", {}, "sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
@@ -827,7 +842,11 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "fast-decode-uri-component": "^1.0.1",
       },
       "devDependencies": {
+        "@elysiajs/openapi": "^1.3.11",
         "@types/bun": "^1.2.16",
         "@types/cookie": "^1.0.0",
         "@types/fast-decode-uri-component": "^1.0.0",
@@ -44,6 +45,8 @@
     "@ark/schema": ["@ark/schema@0.49.0", "", { "dependencies": { "@ark/util": "0.49.0" } }, "sha512-GphZBLpW72iS0v4YkeUtV3YIno35Gimd7+ezbPO9GwEi9kzdUrPVjvf6aXSBAfHikaFc/9pqZOpv3pOXnC71tw=="],
 
     "@ark/util": ["@ark/util@0.49.0", "", {}, "sha512-/BtnX7oCjNkxi2vi6y1399b+9xd1jnCrDYhZ61f0a+3X8x8DxlK52VgEEzyuC2UQMPACIfYrmHkhD3lGt2GaMA=="],
+
+    "@elysiajs/openapi": ["@elysiajs/openapi@1.3.11", "", { "dependencies": { "@sinclair/typemap": "^0.10.1", "openapi-types": "^12.1.3" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-+jwAEIDbIGmSKjl/kePwdDaHFgsIX/cEpw01sSjzm7SosjwZuQjJDVgDCab2p68lIO+VUOsvkKuP+5Sm5ehCvQ=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
@@ -185,6 +188,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 
+    "@sinclair/typemap": ["@sinclair/typemap@0.10.1", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.30", "valibot": "^1.0.0", "zod": "^3.24.1" } }, "sha512-UXR0fhu/n3c9B6lB+SLI5t1eVpt9i9CdDrp2TajRe3LbKiUhCTZN2kSfJhjPnpc3I59jMRIhgew7+0HlMi08mg=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -320,6 +325,8 @@
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "elysia": ["elysia@1.3.21", "", { "dependencies": { "cookie": "^1.0.2", "exact-mirror": "0.1.6", "fast-decode-uri-component": "^1.0.1" }, "optionalDependencies": { "@sinclair/typebox": "^0.34.33", "openapi-types": "^12.1.3" }, "peerDependencies": { "file-type": ">= 20.0.0", "typescript": ">= 5.0.0" } }, "sha512-LLfDSoVA5fBoqKQfMJyzmHLkya8zMbEYwd7DS7v2iQB706mgzWg0gufXl58cFALErcvSayplrkDvjkmlYTkIZQ=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -838,6 +845,8 @@
     "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "elysia/exact-mirror": ["exact-mirror@0.1.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-EXGDixoDotCGrXCce63zmGHDA+3Id6PPkIwshBHuB10dwVc4YV4gfaYLuysHOxyURmwyt4UL186ann0oYa2CFQ=="],
 
     "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "prettier": "^3.5.3",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
+        "zod": "^4.1.5",
       },
       "optionalDependencies": {
         "@sinclair/typebox": "^0.34.33",
@@ -829,7 +830,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+    "zod": ["zod@4.1.5", "", {}, "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
@@ -837,7 +838,11 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,16 +30,13 @@
       "optionalDependencies": {
         "@sinclair/typebox": "^0.34.33",
         "openapi-types": "^12.1.3",
-        "zod": "4.1.1",
       },
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0",
-        "@standard-schema/spec": "^1.0.0",
         "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",
-        "zod": ">= 4.0.0",
       },
     },
   },
@@ -187,8 +184,6 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.2", "", { "os": "win32", "cpu": "x64" }, "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
@@ -834,7 +829,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.1.1", "", {}, "sha512-SgMZK/h8Tigt9nnKkfJMvB/mKjiJXaX26xegP4sa+0wHIFVFWVlsQGdhklDmuargBD3Hsi3rsQRIzwJIhTPJHA=="],
+    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
@@ -842,11 +837,7 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
-    "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
-
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-sonarjs/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,10 @@
     "": {
       "name": "elysia",
       "dependencies": {
-        "arktype": "^2.1.20",
+        "arktype": "^2.1.22",
         "cookie": "^1.0.2",
         "exact-mirror": "0.1.6",
         "fast-decode-uri-component": "^1.0.1",
-        "valibot": "^1.1.0",
       },
       "devDependencies": {
         "@types/bun": "^1.2.16",
@@ -22,10 +21,10 @@
         "expect-type": "^1.2.1",
         "file-type": "^20.4.1",
         "memoirist": "^0.4.0",
-        "mitata": "^1.0.34",
         "prettier": "^3.5.3",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
+        "valibot": "^1.1.0",
         "zod": "^4.1.5",
       },
       "optionalDependencies": {
@@ -42,9 +41,9 @@
     },
   },
   "packages": {
-    "@ark/schema": ["@ark/schema@0.46.0", "", { "dependencies": { "@ark/util": "0.46.0" } }, "sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ=="],
+    "@ark/schema": ["@ark/schema@0.49.0", "", { "dependencies": { "@ark/util": "0.49.0" } }, "sha512-GphZBLpW72iS0v4YkeUtV3YIno35Gimd7+ezbPO9GwEi9kzdUrPVjvf6aXSBAfHikaFc/9pqZOpv3pOXnC71tw=="],
 
-    "@ark/util": ["@ark/util@0.46.0", "", {}, "sha512-JPy/NGWn/lvf1WmGCPw2VGpBg5utZraE84I7wli18EDF3p3zc/e9WolT35tINeZO3l7C77SjqRJeAUoT0CvMRg=="],
+    "@ark/util": ["@ark/util@0.49.0", "", {}, "sha512-/BtnX7oCjNkxi2vi6y1399b+9xd1jnCrDYhZ61f0a+3X8x8DxlK52VgEEzyuC2UQMPACIfYrmHkhD3lGt2GaMA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
@@ -234,7 +233,7 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "arktype": ["arktype@2.1.20", "", { "dependencies": { "@ark/schema": "0.46.0", "@ark/util": "0.46.0" } }, "sha512-IZCEEXaJ8g+Ijd59WtSYwtjnqXiwM8sWQ5EjGamcto7+HVN9eK0C4p0zDlCuAwWhpqr6fIBkxPuYDl4/Mcj/+Q=="],
+    "arktype": ["arktype@2.1.22", "", { "dependencies": { "@ark/schema": "0.49.0", "@ark/util": "0.49.0" } }, "sha512-xdzl6WcAhrdahvRRnXaNwsipCgHuNoLobRqhiP8RjnfL9Gp947abGlo68GAIyLtxbD+MLzNyH2YR4kEqioMmYQ=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -585,8 +584,6 @@
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -29,11 +29,11 @@
         "zod": "^4.1.5",
       },
       "optionalDependencies": {
-        "@sinclair/typebox": "^0.34.33",
-        "openapi-types": "^12.1.3",
+        "@sinclair/typebox": ">= 0.34.0 < 1",
+        "openapi-types": ">= 12.0.0",
       },
       "peerDependencies": {
-        "@sinclair/typebox": ">= 0.34.0",
+        "@sinclair/typebox": ">= 0.34.0 < 1",
         "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
@@ -186,7 +186,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.2", "", { "os": "win32", "cpu": "x64" }, "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
 
     "@sinclair/typemap": ["@sinclair/typemap@0.10.1", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.30", "valibot": "^1.0.0", "zod": "^3.24.1" } }, "sha512-UXR0fhu/n3c9B6lB+SLI5t1eVpt9i9CdDrp2TajRe3LbKiUhCTZN2kSfJhjPnpc3I59jMRIhgew7+0HlMi08mg=="],
 
@@ -845,6 +845,8 @@
     "@modelcontextprotocol/sdk/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "elysia/@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
 
     "elysia/exact-mirror": ["exact-mirror@0.1.6", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-EXGDixoDotCGrXCce63zmGHDA+3Id6PPkIwshBHuB10dwVc4YV4gfaYLuysHOxyURmwyt4UL186ann0oYa2CFQ=="],
 

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,14 +1,16 @@
 import { Elysia, t } from 'elysia'
 
-new Elysia()
-	.macro('auth', {
-		headers: t.Object({ authorization: t.String() }),
-		resolve: ({ status }) =>
-			Math.random() > 0.5 ? { role: 'user' } : status(400)
-	})
-	.post('/', ({ role }) => `Hello ${role}`, {
-		auth: true,
-		beforeHandle({ role, status }) {
-			if (role !== 'admin') return status(401)
-		}
-	})
+new Elysia().group(
+	'/id/:id',
+	{
+		params: t.Object({
+			id: t.Number()
+		})
+	},
+	(app) =>
+		app.get('/:name', ({ params }) => params, {
+			params: t.Object({
+				name: t.String()
+			})
+		})
+)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,24 +1,12 @@
 import { Elysia, t, UnwrapSchema } from '../src'
-import z from 'zod'
 import { req } from '../test/utils'
 
-const app = new Elysia().get(
-	'/:name',
-	({ route }) => {
-		return {
-			id: 'a'
-		}
-	},
-	{
-		response: z.object({
-			id: z.number()
-		})
-	}
+const app = new Elysia().get('/', () => 'hello world')
+
+app.handle(
+	new Request('http://localhost', {
+		method: 'HEAD'
+	})
 )
-
-const lilith = await app.handle(req('/lilith')).then((x) => x.json())
-const fouco = await app.handle(req('/fouco')).then((x) => x.json())
-
-// console.log(app.routes[0].compile().toString())
-
-console.log(lilith)
+	.then((x) => x.headers.toJSON())
+	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,28 +1,29 @@
 import { Elysia, t } from '../src'
 import { z } from 'zod'
 import * as v from 'valibot'
-import { req } from '../test/utils'
+import { type } from 'arktype'
 
-const app = new Elysia()
+new Elysia()
 	.guard({
 		schema: 'standalone',
 		body: z.object({
-			age: z.number()
+			age: z.coerce.number()
 		})
 	})
 	.guard({
 		schema: 'standalone',
 		body: v.object({
-			a: v.number()
+			vali: v.literal('vali')
 		})
 	})
 	.guard({
 		schema: 'standalone',
-		body: v.object({
-			b: v.number()
+		body: type({
+			'+': 'delete',
+			ark: '"type"'
 		})
 	})
-	.post('/', ({ body }) => ({ body }), {
+	.post('/', ({ body }) => body, {
 		body: t.Object({
 			name: t.String()
 		})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,10 +1,71 @@
-import { Elysia } from '../src'
+import { Elysia, t } from '../src'
+import { openapi as OpenAPI } from '@elysiajs/openapi'
+import { fromTypes } from '@elysiajs/openapi/gen'
+import { InputSchema, IsNever } from '../src/types'
+import { TNumber } from '@sinclair/typebox'
 
-const app = new Elysia()
-	.all('/ws', () => 'hi')
-	.ws('/ws', {
-		message() {}
+const openapi = (a: any) =>
+	new Elysia().use((app) => {
+		app.use(
+			// @ts-ignore
+			OpenAPI({
+				references: fromTypes('example/a.ts')
+			})
+		)
+
+		return app
 	})
+
+// Elysia 1.4: lifecycle event type soundness
+export const app = new Elysia()
+	.use(
+		openapi({
+			references: fromTypes('example/a.ts')
+		})
+	)
+	.onError(({ status }) => {
+		if (Math.random() > 0.05) return status(400)
+	})
+	.resolve(({ status }) => {
+		if (Math.random() > 0.05) return status(401)
+	})
+	.onBeforeHandle([
+		({ status }) => {
+			if (Math.random() > 0.05) return status(402)
+		},
+		({ status }) => {
+			if (Math.random() > 0.05) return status(403)
+		}
+	])
+	.guard({
+		beforeHandle: [
+			({ status }) => {
+				if (Math.random() > 0.05) return status(405)
+			},
+			({ status }) => {
+				if (Math.random() > 0.05) return status(406)
+			}
+		],
+		afterHandle({ status }) {
+			if (Math.random() > 0.05) return status(407)
+		},
+		error({ status }) {
+			if (Math.random() > 0.05) return status(408)
+		}
+	})
+	.get('/', ({ body, status }) =>
+		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
+	)
 	.listen(3000)
 
-console.log(app.fetch.toString())
+/**
+ * From T, pick a set of properties whose keys are in the union K
+ */
+type PickIfExists<T, K extends string> = {
+	// @ts-ignore
+	[P in K as P extends keyof T ? P : never]: T[P];
+}
+
+type B = PickIfExists<{ body: "A" }, 'response'>
+
+type A = (typeof app)['~Volatile']['schema']

--- a/example/a.ts
+++ b/example/a.ts
@@ -2,37 +2,9 @@ import { Elysia, status, t } from '../src'
 import z from 'zod'
 
 const app = new Elysia()
-	.macro({
-		a: {
-			query: t.Object({
-				id: t.String()
-			}),
-			response: {
-				404: t.Literal('Thing')
-			},
-			detail: {
-				summary: 'a'
-			},
-			beforeHandle({ status }) {
-				if (Math.random() > 0.5) return status(201)
-			}
-		}
-	})
-	.get(
-		'/',
-		({ query, status }) => {
-			return status(404, 'Thing')
-		},
-		{
-			a: true,
-			response: {
-				200: t.Literal("Q"),
-				403: t.Literal('Forbidden')
-			},
-			query: t.Object({
-				name: t.String()
-			})
-		}
+	.as('global')
+	.get('/', ({ body, status }) =>
+		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
 	)
 
 type A = (typeof app)['~Routes']['get']['response']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,26 +1,32 @@
 import { Elysia, t } from '../src'
+import { mergeDeep } from '../src/utils'
 
-const a = <T>(a: T) => a
-type a = typeof a
+console.log(
+	mergeDeep(
+		{
+			tags: ['a']
+		},
+		{
+			tags: ['b']
+		}
+	)
+)
 
-new Elysia()
+const app = new Elysia()
 	.macro({
 		sartre: {
-			body: t.Object({ sartre: t.Literal('Sartre') }),
+			body: t.Object({ sartre: t.Literal('Sartre') })
 		},
 		focou: {
-			body: t.Object({ focou: t.Literal('Focou') }),
+			sartre: true,
+			body: t.Object({ focou: t.Literal('Focou') })
 		},
 		lilith: {
 			sartre: true,
 			focou: true,
-			body: t.Object({ lilith: t.Literal('Lilith') }),
-		},
+			body: t.Object({ lilith: t.Literal('Lilith') })
+		}
 	})
-
-
-
-
 	.post('/', ({ body }) => body, {
 		lilith: true
 	})

--- a/example/a.ts
+++ b/example/a.ts
@@ -13,7 +13,12 @@ const app = new Elysia()
 			body: t.Object({ lilith: t.Literal('Lilith') })
 		}
 	})
+	.macro('a', {
+		body: t.Object({ a: t.Literal('A') }),
+		beforeHandle({ body }) {}
+	})
 	.post('/:sartre', ({ body }) => body, {
+		a: true,
 		sartre: true,
 		focou: true,
 		lilith: true

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,32 +1,33 @@
 import { Elysia, t } from '../src'
-import { mergeDeep } from '../src/utils'
-
-console.log(
-	mergeDeep(
-		{
-			tags: ['a']
-		},
-		{
-			tags: ['b']
-		}
-	)
-)
+import { post, req } from '../test/utils'
 
 const app = new Elysia()
 	.macro({
 		sartre: {
-			body: t.Object({ sartre: t.Literal('Sartre') })
+			params: t.Object({ sartre: t.Literal('Sartre') })
 		},
 		focou: {
-			sartre: true,
-			body: t.Object({ focou: t.Literal('Focou') })
+			query: t.Object({ focou: t.Literal('Focou') })
 		},
 		lilith: {
-			sartre: true,
-			focou: true,
 			body: t.Object({ lilith: t.Literal('Lilith') })
 		}
 	})
-	.post('/', ({ body }) => body, {
+	.post('/:sartre', ({ body }) => body, {
+		sartre: true,
+		focou: true,
 		lilith: true
 	})
+
+const response = await app
+	.handle(
+		post('/Sartre', {
+			lilith: 'Lilith'
+		})
+	)
+	.then((x) => x.json())
+	.then(console.log)
+
+// console.log(app.routes[0].compile().toString())
+
+// console.log(app.routes[0].hooks)

--- a/example/a.ts
+++ b/example/a.ts
@@ -3,21 +3,22 @@ import z from 'zod'
 
 const app = new Elysia()
 	.macro({
-		auth: {
-			resolve: [
+		q: {
+			beforeHandle: [
 				({ status }) => {
-					if (Math.random() > 0.5) return status(401)
-
-					return { user: 'saltyaom' } as const
+					if (Math.random() > 0.05) return status(401)
+				},
+				({ status }) => {
+					if (Math.random() > 0.05) return status(402)
 				}
 			]
 		}
 	})
-	.get('/', ({ headers, user }) => user, {
-		auth: true,
-		headers: t.Object({
-			'x-api-key': t.String()
-		})
+	.guard({
+		q: true
+	})
+	.get('/', () => {}, {
 	})
 
-app['~Routes']['get']['response']
+type A = (typeof app)['~Volatile']['standaloneSchema']
+type B = (typeof app)['~Routes']['get']['response']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,5 +1,10 @@
-import { Elysia, fileType, file, form } from '../src'
+import { Elysia } from '../src'
 
-const app = new Elysia().post('/', ({ body }) => 'a').listen(3000)
+const app = new Elysia()
+	.all('/ws', () => 'hi')
+	.ws('/ws', {
+		message() {}
+	})
+	.listen(3000)
 
-app['~Routes']['post']
+console.log(app.fetch.toString())

--- a/example/a.ts
+++ b/example/a.ts
@@ -2,10 +2,32 @@ import { Elysia, MaybeArray, status, t } from '../src'
 import { req } from '../test/utils'
 
 const app = new Elysia()
-	.onBeforeHandle(() => {
-		if (Math.random() > 0.5) return 'a' as const
+	.macro({
+		a: {
+			query: t.Object({
+				name: t.Literal('lilith')
+			}),
+			cookie: t.Object({
+				name: t.Literal('lilith')
+			}),
+			params: t.Object({
+				name: t.Literal('lilith')
+			}),
+			body: t.Object({
+				name: t.Literal('lilith')
+			}),
+			headers: t.Object({
+				name: t.Literal('lilith')
+			}),
+			response: {
+				403: t.Object({
+					name: t.Literal('lilith')
+				})
+			}
+		}
 	})
-	.get('/', () => 'b' as const)
+	.post('/', ({ body }) => 'b' as const, {
+		a: true
+	})
 
-app['~Volatile']['response']
-app['~Routes']['get']['response']
+app['~Routes']['post']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,23 +1,13 @@
 import { Elysia, t } from '../src'
+import { req } from '../test/utils'
 
-new Elysia()
-	.macro({
-		a: {
-			resolve: () => ({
-				query: {
-					age: 17
-				}
-			})
-		}
+const app = new Elysia()
+	.get('/', function* () {
+		for (let i = 0; i <= 100_000; i++) yield { hello: 'world' }
 	})
-	.get(
-		'/',
-		({ query }) => {
-			query
-		},
-		{
-			query: t.Object({
-				name: t.String()
-			})
-		}
-	)
+	.listen(3000)
+
+const q = app
+	.handle(req('/'))
+	.then((x) => x.text())
+	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,26 +1,19 @@
 import { Elysia, t } from '../src'
 import { req } from '../test/utils'
 
-let isAfterResponseCalled = false
+const app = new Elysia().get('/', ({ query }) => query, {
+	query: t.Object(
+		{
+			name: t.String()
+		},
+		{ additionalProperties: true }
+	)
+})
 
-const app = new Elysia({ precompile: true })
-	.onAfterResponse(() => {
-		isAfterResponseCalled = true
-	})
-	.onError(() => {
-		return new Response('a', {
-			status: 401,
-			headers: {
-				awd: 'b'
-			}
-		})
-	})
-	.compile()
+const response = await app
+	.handle(req('/?name=nagisa&hifumi=daisuki'))
+	.then((x) => x.json())
 
-// console.log(app.handleError.toString())
+console.log(response)
 
-await app.handle(req('/'))
-// wait for next tick
-await Bun.sleep(1)
-
-console.log(isAfterResponseCalled)
+console.log(app.routes[0].hooks)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,6 +1,19 @@
 import { Elysia, t } from '../src'
 import { post, req } from '../test/utils'
 
+new Elysia()
+	.macro('a', {
+		body: t.Object({ a: t.Literal('A') }),
+		beforeHandle({ body }) {
+		}
+	})
+	.macro('b', {
+		a: true,
+		body: t.Object({ b: t.Literal('B') }),
+		beforeHandle({ body }) {
+		}
+	})
+
 const app = new Elysia()
 	.macro({
 		sartre: {

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,33 +1,26 @@
-import { Elysia, MaybeArray, status, t } from '../src'
-import { req } from '../test/utils'
+import { Elysia, t } from '../src'
 
-const app = new Elysia()
+const a = <T>(a: T) => a
+type a = typeof a
+
+new Elysia()
 	.macro({
-		a: {
-			query: t.Object({
-				name: t.Literal('lilith')
-			}),
-			cookie: t.Object({
-				name: t.Literal('lilith')
-			}),
-			params: t.Object({
-				name: t.Literal('lilith')
-			}),
-			body: t.Object({
-				name: t.Literal('lilith')
-			}),
-			headers: t.Object({
-				name: t.Literal('lilith')
-			}),
-			response: {
-				403: t.Object({
-					name: t.Literal('lilith')
-				})
-			}
-		}
-	})
-	.post('/', ({ body }) => 'b' as const, {
-		a: true
+		sartre: {
+			body: t.Object({ sartre: t.Literal('Sartre') }),
+		},
+		focou: {
+			body: t.Object({ focou: t.Literal('Focou') }),
+		},
+		lilith: {
+			sartre: true,
+			focou: true,
+			body: t.Object({ lilith: t.Literal('Lilith') }),
+		},
 	})
 
-app['~Routes']['post']
+
+
+
+	.post('/', ({ body }) => body, {
+		lilith: true
+	})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,6 +1,8 @@
-import { Elysia, status, t } from '../src'
-import z from 'zod'
+import { Elysia, MaybeArray, status, t } from '../src'
 
-const app = new Elysia().as('global').get('/', ({ body, status }) => (Math.random() > 0.05 ? status(409) : ('Hello World' as const)))
-
-type A = (typeof app)['~Routes']['get']['response']
+const app = new Elysia()
+	.guard({
+	})
+	.get('/', ({ headers, body, cookie, params, query }) => {
+		return 'Hello World' as const
+	})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,23 +1,14 @@
-import { Elysia, t } from 'elysia'
+import { Elysia, t, validateFileExtension } from '../src'
 import { z } from 'zod'
-import { type } from 'arktype'
-import * as v from 'valibot'
 
-new Elysia().get(
-	'/name/:name',
-	({ status }) => Math.random() > 0.5
-		? status(200, 'ok')
-		: status(201, 'aight'),
-	{
-		params: type({
-			name: '"Standard Schema"'
-		}),
-		query: z.object({
-			id: z.coerce.number()
-		}),
-		response: {
-			200: t.Literal('ok'),
-			201: v.literal('aight')
-		}
+const app = new Elysia()
+	.post('', ({ body: { file } }) => file, {
+		body: z.object({
+			file: z
+				.file()
+				.refine((file) => validateFileExtension(file, 'image/jpeg'))
+		})
 	})
 	.listen(3000)
+
+console.log(app.routes[0].compile().toString())

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,6 +1,7 @@
-import { Elysia, t } from '../src'
+import { Elysia, status, t } from '../src'
+import z from 'zod'
 
-export const app = new Elysia()
+const app = new Elysia()
 	.macro({
 		a: {
 			query: t.Object({
@@ -20,16 +21,17 @@ export const app = new Elysia()
 	.get(
 		'/',
 		({ query, status }) => {
-			return status(403, 'Forbidden')
+			return status(404, 'Thing')
 		},
 		{
 			a: true,
 			response: {
+				200: t.Literal("Q"),
 				403: t.Literal('Forbidden')
-			}
-			// query: t.Object({
-			// 	name: t.String()
-			// })
+			},
+			query: t.Object({
+				name: t.String()
+			})
 		}
 	)
 

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,14 +1,28 @@
-import { Elysia, t, validateFileExtension } from '../src'
-import { z } from 'zod'
+import { Elysia, t } from '../src'
+import { req } from '../test/utils'
 
 const app = new Elysia()
-	.post('', ({ body: { file } }) => file, {
-		body: z.object({
-			file: z
-				.file()
-				.refine((file) => validateFileExtension(file, 'image/jpeg'))
+	.onError(({ error, code }) => {
+		if (code === 'VALIDATION') return error.detail(error.message)
+	})
+	.post('/', () => 'Hello World!', {
+		body: t.Object({
+			x: t.Number({
+				error: 'x must be a number'
+			})
 		})
 	})
-	.listen(3000)
 
-console.log(app.routes[0].compile().toString())
+const response = await app
+	.handle(
+		new Request('http://localhost', {
+			method: 'POST',
+			body: JSON.stringify({ x: 'hi!' }),
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		})
+	)
+	.then((x) => x.text())
+
+console.log(response)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,59 +1,12 @@
 import { Elysia, t } from '../src'
-import { openapi as OpenAPI } from '@elysiajs/openapi'
-import { fromTypes } from '@elysiajs/openapi/gen'
-import { AnySchema, InputSchema, IsNever, PickIfExists } from '../src/types'
-import { TNumber } from '@sinclair/typebox'
 
-const openapi = (a: any) =>
-	new Elysia().use((app) => {
-		app.use(
-			// @ts-ignore
-			OpenAPI({
-				references: fromTypes('example/a.ts')
-			})
-		)
-
-		return app
-	})
-
-// Elysia 1.4: lifecycle event type soundness
-export const app = new Elysia()
-	.use(
-		openapi({
-			references: fromTypes('example/a.ts')
-		})
-	)
-	.onError(({ status }) => {
-		if (Math.random() > 0.05) return status(400)
-	})
-	.resolve(({ status }) => {
-		if (Math.random() > 0.05) return status(401)
-	})
-	.onBeforeHandle([
-		({ status }) => {
-			if (Math.random() > 0.05) return status(402)
-		},
-		({ status }) => {
-			if (Math.random() > 0.05) return status(403)
-		}
-	])
-	.guard({
-		beforeHandle: [
-			({ status }) => {
-				if (Math.random() > 0.05) return status(405)
-			},
-			({ status }) => {
-				if (Math.random() > 0.05) return status(406)
-			}
-		],
-		afterHandle({ status }) {
-			if (Math.random() > 0.05) return status(407)
-		},
-		error({ status }) {
-			if (Math.random() > 0.05) return status(408)
-		}
-	})
-	.get('/', ({ body, status }) =>
-		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
-	)
-	.listen(3000)
+export const app = new Elysia().group(
+	'/id/:id',
+	{
+		params: t.Object({
+			id: t.Numeric()
+		}),
+		beforeHandle({ params }) {}
+	},
+	(app) => app.get('/awd', ({ params }) => {})
+)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,10 +1,23 @@
 import { Elysia, t } from '../src'
-import { z } from 'zod'
 
-const app = new Elysia()
-	.get('/', ({ query }) => query, {
-		query: z.object({
-			x: z.array(z.string())
-		})
+new Elysia()
+	.macro({
+		a: {
+			resolve: () => ({
+				query: {
+					age: 17
+				}
+			})
+		}
 	})
-	.listen(3000)
+	.get(
+		'/',
+		({ query }) => {
+			query
+		},
+		{
+			query: t.Object({
+				name: t.String()
+			})
+		}
+	)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,18 +1,24 @@
 import { Elysia, t, UnwrapSchema } from '../src'
 import z from 'zod'
+import { req } from '../test/utils'
 
-const app = new Elysia()
-	.model({
-		id: z.object({
+const app = new Elysia().get(
+	'/:name',
+	({ route }) => {
+		return {
+			id: 'a'
+		}
+	},
+	{
+		response: z.object({
 			id: z.number()
-		}),
-		id2: t.Object({
-			id: t.Number()
 		})
-	})
-	.post('/', ({ body }) => body, {
-		body: 'id2'
-	})
-	.listen(3000)
+	}
+)
 
-type A = UnwrapSchema<'id2', typeof app['~Definitions']['typebox']>
+const lilith = await app.handle(req('/lilith')).then((x) => x.json())
+const fouco = await app.handle(req('/fouco')).then((x) => x.json())
+
+// console.log(app.routes[0].compile().toString())
+
+console.log(lilith)

--- a/example/a.ts
+++ b/example/a.ts
@@ -2,6 +2,8 @@ import { Elysia, t } from '../src'
 import { z } from 'zod'
 import { req } from '../test/utils'
 
+import type { StandardSchemaV1Like } from '../src/types'
+
 const app = new Elysia()
 	.guard({
 		schema: 'standalone',

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,24 +1,41 @@
 import { Elysia, MaybeArray, status, t } from '../src'
-import z from 'zod'
 
 const app = new Elysia()
-	.macro({
-		q: {
-			beforeHandle: [
-				({ status }) => {
-					if (Math.random() > 0.05) return status(401)
-				},
-				({ status }) => {
-					if (Math.random() > 0.05) return status(402)
-				}
-			]
-		}
+	.get('/', ({ query }) => query, {
+		query: t.Object({
+			filter: t.Object({
+				latlng: t.Object({
+					within: t.Object({
+						ne: t.Number(),
+						sw: t.Number()
+					})
+				}),
+				zoom: t.Object({
+					equalTo: t.Number({
+						minimum: 0,
+						maximum: 20,
+						multipleOf: 1
+					})
+				})
+			})
+		})
 	})
-	.guard({
-		q: true
-	})
-	.get('/', () => {}, {
-	})
+	.listen(3000)
 
-type A = (typeof app)['~Volatile']['standaloneSchema']
-type B = (typeof app)['~Routes']['get']['response']
+const filter = JSON.stringify({
+	latlng: {
+		within: {
+			ne: 1,
+			sw: 1
+		}
+	},
+	zoom: {
+		equalTo: 2
+	}
+})
+
+app.handle(new Request(`http://localhost:3000/?filter=${filter}`))
+	.then((x) => x.json())
+	.then(console.log)
+
+// console.log(app.routes[0].compile().toString())

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,12 +1,22 @@
 import { Elysia, t } from '../src'
 
-export const app = new Elysia().group(
-	'/id/:id',
-	{
-		params: t.Object({
-			id: t.Numeric()
+export const app = new Elysia()
+	.macro({
+		a: {
+			query: t.Object({
+				id: t.Number()
+			}),
+			detail: {
+				summary: 'a'
+			},
+			afterHandle({ query }) {
+
+			}
+		}
+	})
+	.get('/', ({ query }) => query, {
+		a: true,
+		query: t.Object({
+			name: t.String()
 		}),
-		beforeHandle({ params }) {}
-	},
-	(app) => app.get('/awd', ({ params }) => {})
-)
+	})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,51 +1,19 @@
 import { Elysia, t } from '../src'
 import { post, req } from '../test/utils'
 
-new Elysia()
-	.macro('a', {
-		body: t.Object({ a: t.Literal('A') }),
-		beforeHandle({ body }) {
+new Elysia().post(
+	'/user',
+	({ q }) => {
+		return { q: 'a' }
+	},
+	{
+		response: {
+			200: t.Object({
+				name: t.String()
+			}),
+			401: t.Object({
+				q: t.String()
+			})
 		}
-	})
-	.macro('b', {
-		a: true,
-		body: t.Object({ b: t.Literal('B') }),
-		beforeHandle({ body }) {
-		}
-	})
-
-const app = new Elysia()
-	.macro({
-		sartre: {
-			params: t.Object({ sartre: t.Literal('Sartre') })
-		},
-		focou: {
-			query: t.Object({ focou: t.Literal('Focou') })
-		},
-		lilith: {
-			body: t.Object({ lilith: t.Literal('Lilith') })
-		}
-	})
-	.macro('a', {
-		body: t.Object({ a: t.Literal('A') }),
-		beforeHandle({ body }) {}
-	})
-	.post('/:sartre', ({ body }) => body, {
-		a: true,
-		sartre: true,
-		focou: true,
-		lilith: true
-	})
-
-const response = await app
-	.handle(
-		post('/Sartre', {
-			lilith: 'Lilith'
-		})
-	)
-	.then((x) => x.json())
-	.then(console.log)
-
-// console.log(app.routes[0].compile().toString())
-
-// console.log(app.routes[0].hooks)
+	}
+)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,12 +1,14 @@
-import { Elysia, t } from '../src'
+import { Elysia, t } from 'elysia'
 
 new Elysia()
 	.macro('auth', {
 		headers: t.Object({ authorization: t.String() }),
 		resolve: ({ status }) =>
-			Math.random() > 0.5 ? { role: 'user' } : status(401, 'not authorized')
+			Math.random() > 0.5 ? { role: 'user' } : status(400)
 	})
-	.post('/', ({ role }) => role, {
+	.post('/', ({ role }) => `Hello ${role}`, {
 		auth: true,
-		beforeHandle: ({ role }) => {}
+		beforeHandle({ role, status }) {
+			if (role !== 'admin') return status(401)
+		}
 	})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,41 +1,31 @@
 import { Elysia, MaybeArray, status, t } from '../src'
+import { req } from '../test/utils'
 
-const app = new Elysia()
-	.get('/', ({ query }) => query, {
-		query: t.Object({
-			filter: t.Object({
-				latlng: t.Object({
-					within: t.Object({
-						ne: t.Number(),
-						sw: t.Number()
-					})
-				}),
-				zoom: t.Object({
-					equalTo: t.Number({
-						minimum: 0,
-						maximum: 20,
-						multipleOf: 1
-					})
-				})
+const app = new Elysia().get(
+	'/council',
+	({ cookie: { council } }) => council.value,
+	{
+		cookie: t.Cookie({
+			council: t.Object({
+				name: t.String(),
+				affilation: t.String()
 			})
 		})
-	})
-	.listen(3000)
-
-const filter = JSON.stringify({
-	latlng: {
-		within: {
-			ne: 1,
-			sw: 1
-		}
-	},
-	zoom: {
-		equalTo: 2
 	}
-})
+)
 
-app.handle(new Request(`http://localhost:3000/?filter=${filter}`))
-	.then((x) => x.json())
-	.then(console.log)
+const expected = {
+	name: 'Rin',
+	affilation: 'Administration'
+}
 
-// console.log(app.routes[0].compile().toString())
+const response = await app.handle(
+	req('/council', {
+		headers: {
+			cookie: 'council=' + JSON.stringify(expected)
+		}
+	})
+)
+
+console.log(await response.json())
+console.log(app.routes[0].compile().toString())

--- a/example/a.ts
+++ b/example/a.ts
@@ -4,19 +4,33 @@ export const app = new Elysia()
 	.macro({
 		a: {
 			query: t.Object({
-				id: t.Number()
+				id: t.String()
 			}),
+			response: {
+				404: t.Literal('Thing')
+			},
 			detail: {
 				summary: 'a'
 			},
-			afterHandle({ query }) {
-
+			beforeHandle({ status }) {
+				if (Math.random() > 0.5) return status(201)
 			}
 		}
 	})
-	.get('/', ({ query }) => query, {
-		a: true,
-		query: t.Object({
-			name: t.String()
-		}),
-	})
+	.get(
+		'/',
+		({ query, status }) => {
+			return status(403, 'Forbidden')
+		},
+		{
+			a: true,
+			response: {
+				403: t.Literal('Forbidden')
+			}
+			// query: t.Object({
+			// 	name: t.String()
+			// })
+		}
+	)
+
+type A = (typeof app)['~Routes']['get']['response']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,8 +1,21 @@
 import { Elysia, MaybeArray, status, t } from '../src'
+import z from 'zod'
 
 const app = new Elysia()
-	.guard({
+	.macro({
+		auth: {
+			resolve({ status }) {
+				if (Math.random() > 0.5) return status(401)
+
+				return { user: 'saltyaom' } as const
+			}
+		}
 	})
-	.get('/', ({ headers, body, cookie, params, query }) => {
-		return 'Hello World' as const
+	.get('/', ({ headers, user }) => user, {
+		auth: true,
+		headers: t.Object({
+			'x-api-key': t.String()
+		})
 	})
+
+app['~Routes']['get']['response']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,31 +1,11 @@
 import { Elysia, MaybeArray, status, t } from '../src'
 import { req } from '../test/utils'
 
-const app = new Elysia().get(
-	'/council',
-	({ cookie: { council } }) => council.value,
-	{
-		cookie: t.Cookie({
-			council: t.Object({
-				name: t.String(),
-				affilation: t.String()
-			})
-		})
-	}
-)
-
-const expected = {
-	name: 'Rin',
-	affilation: 'Administration'
-}
-
-const response = await app.handle(
-	req('/council', {
-		headers: {
-			cookie: 'council=' + JSON.stringify(expected)
-		}
+const app = new Elysia()
+	.onBeforeHandle(() => {
+		if (Math.random() > 0.5) return 'a' as const
 	})
-)
+	.get('/', () => 'b' as const)
 
-console.log(await response.json())
-console.log(app.routes[0].compile().toString())
+app['~Volatile']['response']
+app['~Routes']['get']['response']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,13 +1,24 @@
 import { Elysia, t } from '../src'
+import { z } from 'zod'
 import { req } from '../test/utils'
 
 const app = new Elysia()
-	.get('/', function* () {
-		for (let i = 0; i <= 100_000; i++) yield { hello: 'world' }
+	.guard({
+		schema: 'standalone',
+		body: z
+			.object({
+				age: z.number()
+			})
+			.loose()
+	})
+	.post('/', ({ body }) => ({ body }), {
+		body: z.object({
+			age: z.number()
+		})
 	})
 	.listen(3000)
 
-const q = app
-	.handle(req('/'))
-	.then((x) => x.text())
-	.then(console.log)
+// const q = app
+// 	.handle(req('/'))
+// 	.then((x) => x.text())
+// 	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,19 +1,12 @@
 import { Elysia, t } from '../src'
-import { post, req } from '../test/utils'
 
-new Elysia().post(
-	'/user',
-	({ q }) => {
-		return { q: 'a' }
-	},
-	{
-		response: {
-			200: t.Object({
-				name: t.String()
-			}),
-			401: t.Object({
-				q: t.String()
-			})
-		}
-	}
-)
+new Elysia()
+	.macro('auth', {
+		headers: t.Object({ authorization: t.String() }),
+		resolve: ({ status }) =>
+			Math.random() > 0.5 ? { role: 'user' } : status(401, 'not authorized')
+	})
+	.post('/', ({ role }) => role, {
+		auth: true,
+		beforeHandle: ({ role }) => {}
+	})

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,12 +1,5 @@
-import { Elysia, t, UnwrapSchema } from '../src'
-import { req } from '../test/utils'
+import { Elysia, fileType, file, form } from '../src'
 
-const app = new Elysia().get('/', () => 'hello world')
+const app = new Elysia().post('/', ({ body }) => 'a').listen(3000)
 
-app.handle(
-	new Request('http://localhost', {
-		method: 'HEAD'
-	})
-)
-	.then((x) => x.headers.toJSON())
-	.then(console.log)
+app['~Routes']['post']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,31 +1,13 @@
 import { Elysia, t } from '../src'
-import { z } from 'zod'
-import * as v from 'valibot'
-import { type } from 'arktype'
+import z from 'zod'
 
 new Elysia()
-	.guard({
-		schema: 'standalone',
-		body: z.object({
-			age: z.coerce.number()
-		})
-	})
-	.guard({
-		schema: 'standalone',
-		body: v.object({
-			vali: v.literal('vali')
-		})
-	})
-	.guard({
-		schema: 'standalone',
-		body: type({
-			'+': 'delete',
-			ark: '"type"'
+	.model({
+		id: z.object({
+			id: z.number()
 		})
 	})
 	.post('/', ({ body }) => body, {
-		body: t.Object({
-			name: t.String()
-		})
+		body: 'id'
 	})
 	.listen(3000)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,10 +1,6 @@
 import { Elysia, status, t } from '../src'
 import z from 'zod'
 
-const app = new Elysia()
-	.as('global')
-	.get('/', ({ body, status }) =>
-		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
-	)
+const app = new Elysia().as('global').get('/', ({ body, status }) => (Math.random() > 0.05 ? status(409) : ('Hello World' as const)))
 
 type A = (typeof app)['~Routes']['get']['response']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,19 +1,23 @@
-import { Elysia, sse, t } from '../src'
-import { req } from '../test/utils'
+import { Elysia, t } from '../src'
+import { z } from 'zod'
+import { type } from 'arktype'
+import * as v from 'valibot'
 
-const app = new Elysia().get('/', ({ query }) => query, {
-	query: t.Object(
-		{
-			name: t.String()
-		},
-		{ additionalProperties: true }
-	)
-})
-
-const response = await app
-	.handle(req('/?name=nagisa&hifumi=daisuki'))
-	.then((x) => x.json())
-
-console.log(response)
-
-console.log(app.routes[0].hooks)
+new Elysia().get(
+	'/name/:name',
+	({ status }) => Math.random() > 0.5
+		? status(200, 'ok')
+		: status(201, 'aight'),
+	{
+		params: type({
+			name: '"hi saltyaom"'
+		}),
+		query: z.object({
+			id: z.coerce.number()
+		}),
+		response: {
+			200: t.Literal('ok'),
+			201: v.literal('aight')
+		}
+	})
+	.listen(3000)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from '../src'
+import { Elysia, t } from 'elysia'
 import { z } from 'zod'
 import { type } from 'arktype'
 import * as v from 'valibot'
@@ -10,7 +10,7 @@ new Elysia().get(
 		: status(201, 'aight'),
 	{
 		params: type({
-			name: '"hi saltyaom"'
+			name: '"Standard Schema"'
 		}),
 		query: z.object({
 			id: z.coerce.number()

--- a/example/a.ts
+++ b/example/a.ts
@@ -4,11 +4,13 @@ import z from 'zod'
 const app = new Elysia()
 	.macro({
 		auth: {
-			resolve({ status }) {
-				if (Math.random() > 0.5) return status(401)
+			resolve: [
+				({ status }) => {
+					if (Math.random() > 0.5) return status(401)
 
-				return { user: 'saltyaom' } as const
-			}
+					return { user: 'saltyaom' } as const
+				}
+			]
 		}
 	})
 	.get('/', ({ headers, user }) => user, {

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,28 +1,10 @@
 import { Elysia, t } from '../src'
-import { req } from '../test/utils'
+import { z } from 'zod'
 
 const app = new Elysia()
-	.onError(({ error, code }) => {
-		if (code === 'VALIDATION') return error.detail(error.message)
-	})
-	.post('/', () => 'Hello World!', {
-		body: t.Object({
-			x: t.Number({
-				error: 'x must be a number'
-			})
+	.get('/', ({ query }) => query, {
+		query: z.object({
+			x: z.array(z.string())
 		})
 	})
-
-const response = await app
-	.handle(
-		new Request('http://localhost', {
-			method: 'POST',
-			body: JSON.stringify({ x: 'hi!' }),
-			headers: {
-				'Content-Type': 'application/json'
-			}
-		})
-	)
-	.then((x) => x.text())
-
-console.log(response)
+	.listen(3000)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from '../src'
 import { openapi as OpenAPI } from '@elysiajs/openapi'
 import { fromTypes } from '@elysiajs/openapi/gen'
-import { InputSchema, IsNever } from '../src/types'
+import { AnySchema, InputSchema, IsNever, PickIfExists } from '../src/types'
 import { TNumber } from '@sinclair/typebox'
 
 const openapi = (a: any) =>
@@ -57,15 +57,3 @@ export const app = new Elysia()
 		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
 	)
 	.listen(3000)
-
-/**
- * From T, pick a set of properties whose keys are in the union K
- */
-type PickIfExists<T, K extends string> = {
-	// @ts-ignore
-	[P in K as P extends keyof T ? P : never]: T[P];
-}
-
-type B = PickIfExists<{ body: "A" }, 'response'>
-
-type A = (typeof app)['~Volatile']['schema']

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,26 +1,30 @@
 import { Elysia, t } from '../src'
 import { z } from 'zod'
+import * as v from 'valibot'
 import { req } from '../test/utils'
-
-import type { StandardSchemaV1Like } from '../src/types'
 
 const app = new Elysia()
 	.guard({
 		schema: 'standalone',
-		body: z
-			.object({
-				age: z.number()
-			})
-			.loose()
-	})
-	.post('/', ({ body }) => ({ body }), {
 		body: z.object({
 			age: z.number()
 		})
 	})
+	.guard({
+		schema: 'standalone',
+		body: v.object({
+			a: v.number()
+		})
+	})
+	.guard({
+		schema: 'standalone',
+		body: v.object({
+			b: v.number()
+		})
+	})
+	.post('/', ({ body }) => ({ body }), {
+		body: t.Object({
+			name: t.String()
+		})
+	})
 	.listen(3000)
-
-// const q = app
-// 	.handle(req('/'))
-// 	.then((x) => x.text())
-// 	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,13 +1,18 @@
-import { Elysia, t } from '../src'
+import { Elysia, t, UnwrapSchema } from '../src'
 import z from 'zod'
 
-new Elysia()
+const app = new Elysia()
 	.model({
 		id: z.object({
 			id: z.number()
+		}),
+		id2: t.Object({
+			id: t.Number()
 		})
 	})
 	.post('/', ({ body }) => body, {
-		body: 'id'
+		body: 'id2'
 	})
 	.listen(3000)
+
+type A = UnwrapSchema<'id2', typeof app['~Definitions']['typebox']>

--- a/example/custom-response.ts
+++ b/example/custom-response.ts
@@ -5,7 +5,7 @@ const prettyJson = new Elysia()
 		if (response instanceof Object)
 			return new Response(JSON.stringify(response, null, 4))
 	})
-	.as('plugin')
+	.as('scoped')
 
 new Elysia()
 	.use(prettyJson)

--- a/example/openapi.ts
+++ b/example/openapi.ts
@@ -6,9 +6,7 @@ const openapi = (a: any) =>
 	new Elysia().use((app) => {
 		app.use(
 			// @ts-ignore
-			OpenAPI({
-				references: fromTypes('example/a.ts')
-			})
+			OpenAPI(a)
 		)
 
 		return app
@@ -18,40 +16,57 @@ const openapi = (a: any) =>
 export const app = new Elysia()
 	.use(
 		openapi({
-			references: fromTypes('example/a.ts')
+			references: fromTypes('example/openapi.ts')
 		})
 	)
+	.macro({
+		auth: {
+			body: t.Object({
+				a: t.String()
+			}),
+			beforeHandle({ status }) {
+				if (Math.random() < 0.05) return status(410)
+			}
+		}
+	})
 	.onError(({ status }) => {
-		if (Math.random() > 0.05) return status(400)
+		if (Math.random() < 0.05) return status(400)
 	})
 	.resolve(({ status }) => {
-		if (Math.random() > 0.05) return status(401)
+		if (Math.random() < 0.05) return status(401)
 	})
 	.onBeforeHandle([
 		({ status }) => {
-			if (Math.random() > 0.05) return status(402)
+			if (Math.random() < 0.05) return status(402)
 		},
 		({ status }) => {
-			if (Math.random() > 0.05) return status(403)
+			if (Math.random() < 0.05) return status(403)
 		}
 	])
 	.guard({
 		beforeHandle: [
 			({ status }) => {
-				if (Math.random() > 0.05) return status(405)
+				if (Math.random() < 0.05) return status(405)
 			},
 			({ status }) => {
-				if (Math.random() > 0.05) return status(406)
+				if (Math.random() < 0.05) return status(406)
 			}
 		],
 		afterHandle({ status }) {
-			if (Math.random() > 0.05) return status(407)
+			if (Math.random() < 0.05) return status(407)
 		},
 		error({ status }) {
-			if (Math.random() > 0.05) return status(408)
+			if (Math.random() < 0.05) return status(408)
 		}
 	})
-	.get('/', ({ body, status }) =>
-		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
+	.get(
+		'/',
+		({ body, status }) =>
+			Math.random() < 0.05 ? status(409) : ('Hello World' as const),
+		{
+			auth: true
+		}
 	)
 	.listen(3000)
+
+// app['~Routes']['get']['response']

--- a/example/openapi.ts
+++ b/example/openapi.ts
@@ -73,4 +73,4 @@ export const app = new Elysia()
 	)
 	.listen(3000)
 
-// app['~Routes']['post']['response']['409']
+// app['~Routes']['post']['response']

--- a/example/openapi.ts
+++ b/example/openapi.ts
@@ -1,0 +1,57 @@
+import { Elysia, t } from '../src'
+import { openapi as OpenAPI } from '@elysiajs/openapi'
+import { fromTypes } from '@elysiajs/openapi/gen'
+
+const openapi = (a: any) =>
+	new Elysia().use((app) => {
+		app.use(
+			// @ts-ignore
+			OpenAPI({
+				references: fromTypes('example/a.ts')
+			})
+		)
+
+		return app
+	})
+
+// Elysia 1.4: lifecycle event type soundness
+export const app = new Elysia()
+	.use(
+		openapi({
+			references: fromTypes('example/a.ts')
+		})
+	)
+	.onError(({ status }) => {
+		if (Math.random() > 0.05) return status(400)
+	})
+	.resolve(({ status }) => {
+		if (Math.random() > 0.05) return status(401)
+	})
+	.onBeforeHandle([
+		({ status }) => {
+			if (Math.random() > 0.05) return status(402)
+		},
+		({ status }) => {
+			if (Math.random() > 0.05) return status(403)
+		}
+	])
+	.guard({
+		beforeHandle: [
+			({ status }) => {
+				if (Math.random() > 0.05) return status(405)
+			},
+			({ status }) => {
+				if (Math.random() > 0.05) return status(406)
+			}
+		],
+		afterHandle({ status }) {
+			if (Math.random() > 0.05) return status(407)
+		},
+		error({ status }) {
+			if (Math.random() > 0.05) return status(408)
+		}
+	})
+	.get('/', ({ body, status }) =>
+		Math.random() > 0.05 ? status(409) : ('Hello World' as const)
+	)
+	.listen(3000)

--- a/example/openapi.ts
+++ b/example/openapi.ts
@@ -21,12 +21,13 @@ export const app = new Elysia()
 	)
 	.macro({
 		auth: {
-			body: t.Object({
-				a: t.String()
-			}),
+			response: {
+				201: t.Literal('a')
+			},
 			beforeHandle({ status }) {
 				if (Math.random() < 0.05) return status(410)
-			}
+			},
+			resolve: () => ({ a: 'a' })
 		}
 	})
 	.onError(({ status }) => {
@@ -59,14 +60,20 @@ export const app = new Elysia()
 			if (Math.random() < 0.05) return status(408)
 		}
 	})
-	.get(
+	.post(
 		'/',
-		({ body, status }) =>
-			Math.random() < 0.05 ? status(409) : ('Hello World' as const),
+		({ body, status }) => {
+			if (Math.random() < 0.05) return status(201, 'a')
+
+			return 'Hello World'
+		},
 		{
-			auth: true
+			auth: true,
+			response: {
+				200: t.Literal('Hello World')
+			}
 		}
 	)
 	.listen(3000)
 
-// app['~Routes']['get']['response']
+app['~Routes']['post']['response']['mac']

--- a/example/openapi.ts
+++ b/example/openapi.ts
@@ -22,7 +22,7 @@ export const app = new Elysia()
 	.macro({
 		auth: {
 			response: {
-				201: t.Literal('a')
+				409: t.Literal('Conflict')
 			},
 			beforeHandle({ status }) {
 				if (Math.random() < 0.05) return status(410)
@@ -30,50 +30,47 @@ export const app = new Elysia()
 			resolve: () => ({ a: 'a' })
 		}
 	})
-	// .onError(({ status }) => {
-	// 	if (Math.random() < 0.05) return status(400)
-	// })
-	// .resolve(({ status }) => {
-	// 	if (Math.random() < 0.05) return status(401)
-	// })
-	// .onBeforeHandle([
-	// 	({ status }) => {
-	// 		if (Math.random() < 0.05) return status(402)
-	// 	},
-	// 	({ status }) => {
-	// 		if (Math.random() < 0.05) return status(403)
-	// 	}
-	// ])
-	// .guard({
-	// 	beforeHandle: [
-	// 		({ status }) => {
-	// 			if (Math.random() < 0.05) return status(405)
-	// 		},
-	// 		({ status }) => {
-	// 			if (Math.random() < 0.05) return status(406)
-	// 		}
-	// 	],
-	// 	afterHandle({ status }) {
-	// 		if (Math.random() < 0.05) return status(407)
-	// 	},
-	// 	error({ status }) {
-	// 		if (Math.random() < 0.05) return status(408)
-	// 	}
-	// })
+	.onError(({ status }) => {
+		if (Math.random() < 0.05) return status(400)
+	})
+	.resolve(({ status }) => {
+		if (Math.random() < 0.05) return status(401)
+	})
+	.onBeforeHandle([
+		({ status }) => {
+			if (Math.random() < 0.05) return status(402)
+		},
+		({ status }) => {
+			if (Math.random() < 0.05) return status(403)
+		}
+	])
+	.guard({
+		beforeHandle: [
+			({ status }) => {
+				if (Math.random() < 0.05) return status(405)
+			},
+			({ status }) => {
+				if (Math.random() < 0.05) return status(406)
+			}
+		],
+		afterHandle({ status }) {
+			if (Math.random() < 0.05) return status(407)
+		},
+		error({ status }) {
+			if (Math.random() < 0.05) return status(408)
+		}
+	})
 	.post(
 		'/',
-		({ body, status }) => {
-			if (Math.random() < 0.05) return status(201, 'a')
-
-			return 'Hello World'
-		},
+		({ status }) =>
+			Math.random() < 0.05 ? status(409, 'Conflict') : 'Type Soundness',
 		{
 			auth: true,
 			response: {
-				200: t.String()
+				411: t.Literal('Length Required')
 			}
 		}
 	)
 	.listen(3000)
 
-app['~Routes']['post']['response']
+// app['~Routes']['post']['response']['409']

--- a/example/openapi.ts
+++ b/example/openapi.ts
@@ -30,36 +30,36 @@ export const app = new Elysia()
 			resolve: () => ({ a: 'a' })
 		}
 	})
-	.onError(({ status }) => {
-		if (Math.random() < 0.05) return status(400)
-	})
-	.resolve(({ status }) => {
-		if (Math.random() < 0.05) return status(401)
-	})
-	.onBeforeHandle([
-		({ status }) => {
-			if (Math.random() < 0.05) return status(402)
-		},
-		({ status }) => {
-			if (Math.random() < 0.05) return status(403)
-		}
-	])
-	.guard({
-		beforeHandle: [
-			({ status }) => {
-				if (Math.random() < 0.05) return status(405)
-			},
-			({ status }) => {
-				if (Math.random() < 0.05) return status(406)
-			}
-		],
-		afterHandle({ status }) {
-			if (Math.random() < 0.05) return status(407)
-		},
-		error({ status }) {
-			if (Math.random() < 0.05) return status(408)
-		}
-	})
+	// .onError(({ status }) => {
+	// 	if (Math.random() < 0.05) return status(400)
+	// })
+	// .resolve(({ status }) => {
+	// 	if (Math.random() < 0.05) return status(401)
+	// })
+	// .onBeforeHandle([
+	// 	({ status }) => {
+	// 		if (Math.random() < 0.05) return status(402)
+	// 	},
+	// 	({ status }) => {
+	// 		if (Math.random() < 0.05) return status(403)
+	// 	}
+	// ])
+	// .guard({
+	// 	beforeHandle: [
+	// 		({ status }) => {
+	// 			if (Math.random() < 0.05) return status(405)
+	// 		},
+	// 		({ status }) => {
+	// 			if (Math.random() < 0.05) return status(406)
+	// 		}
+	// 	],
+	// 	afterHandle({ status }) {
+	// 		if (Math.random() < 0.05) return status(407)
+	// 	},
+	// 	error({ status }) {
+	// 		if (Math.random() < 0.05) return status(408)
+	// 	}
+	// })
 	.post(
 		'/',
 		({ body, status }) => {
@@ -70,10 +70,10 @@ export const app = new Elysia()
 		{
 			auth: true,
 			response: {
-				200: t.Literal('Hello World')
+				200: t.String()
 			}
 		}
 	)
 	.listen(3000)
 
-app['~Routes']['post']['response']['mac']
+app['~Routes']['post']['response']

--- a/example/websocket.ts
+++ b/example/websocket.ts
@@ -12,7 +12,7 @@ const app = new Elysia()
 		},
 		message(ws, message) {
 			ws.publish('asdf', message)
-			ws.send('asdf', message)
+			ws.send(message)
 		}
 	})
 	.get('/publish/:publish', ({ params: { publish: text } }) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.13",
+	"version": "1.4.0-exp.14",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.9",
+	"version": "1.4.0-exp.10",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.7",
+	"version": "1.4.0-exp.8",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.16",
+	"version": "1.4.0-exp.17",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -208,14 +208,14 @@
 		"zod": "^4.1.5"
 	},
 	"peerDependencies": {
-		"@sinclair/typebox": ">= 0.34.0",
+		"@sinclair/typebox": ">= 0.34.0 < 1",
 		"exact-mirror": ">= 0.0.9",
 		"file-type": ">= 20.0.0",
 		"openapi-types": ">= 12.0.0",
 		"typescript": ">= 5.0.0"
 	},
 	"optionalDependencies": {
-		"@sinclair/typebox": "^0.34.33",
-		"openapi-types": "^12.1.3"
+		"@sinclair/typebox": ">= 0.34.0 < 1",
+		"openapi-types": ">= 12.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.1",
+	"version": "1.4.0-exp.2",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.3",
+	"version": "1.4.0-exp.5",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -183,9 +183,8 @@
 		"release": "npm run build && npm run test && npm publish"
 	},
 	"dependencies": {
-		"arktype": "^2.1.22",
 		"cookie": "^1.0.2",
-		"exact-mirror": "0.1.6",
+		"exact-mirror": "0.2.1",
 		"fast-decode-uri-component": "^1.0.1"
 	},
 	"devDependencies": {
@@ -194,6 +193,7 @@
 		"@types/fast-decode-uri-component": "^1.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.30.1",
 		"@typescript-eslint/parser": "^8.30.1",
+		"arktype": "^2.1.22",
 		"eslint": "^9.24.0",
 		"eslint-plugin-security": "^3.0.1",
 		"eslint-plugin-sonarjs": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.2",
+	"version": "1.4.0-exp.3",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.6",
+	"version": "1.4.0-exp.7",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.18",
+	"version": "1.4.0",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.8",
+	"version": "1.4.0-exp.9",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -183,9 +183,11 @@
 		"release": "npm run build && npm run test && npm publish"
 	},
 	"dependencies": {
+		"arktype": "^2.1.20",
 		"cookie": "^1.0.2",
 		"exact-mirror": "0.1.6",
-		"fast-decode-uri-component": "^1.0.1"
+		"fast-decode-uri-component": "^1.0.1",
+		"valibot": "^1.1.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.16",
@@ -206,13 +208,16 @@
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": ">= 0.34.0",
+		"@standard-schema/spec": "^1.0.0",
 		"exact-mirror": ">= 0.0.9",
 		"file-type": ">= 20.0.0",
 		"openapi-types": ">= 12.0.0",
-		"typescript": ">= 5.0.0"
+		"typescript": ">= 5.0.0",
+		"zod": ">= 4.0.0"
 	},
 	"optionalDependencies": {
 		"@sinclair/typebox": "^0.34.33",
-		"openapi-types": "^12.1.3"
+		"openapi-types": "^12.1.3",
+		"zod": "4.1.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.17",
+	"version": "1.4.0-exp.18",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"fast-decode-uri-component": "^1.0.1"
 	},
 	"devDependencies": {
+		"@elysiajs/openapi": "^1.3.11",
 		"@types/bun": "^1.2.16",
 		"@types/cookie": "^1.0.0",
 		"@types/fast-decode-uri-component": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.14",
+	"version": "1.4.0-exp.15",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -183,11 +183,10 @@
 		"release": "npm run build && npm run test && npm publish"
 	},
 	"dependencies": {
-		"arktype": "^2.1.20",
+		"arktype": "^2.1.22",
 		"cookie": "^1.0.2",
 		"exact-mirror": "0.1.6",
-		"fast-decode-uri-component": "^1.0.1",
-		"valibot": "^1.1.0"
+		"fast-decode-uri-component": "^1.0.1"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.16",
@@ -201,10 +200,10 @@
 		"expect-type": "^1.2.1",
 		"file-type": "^20.4.1",
 		"memoirist": "^0.4.0",
-		"mitata": "^1.0.34",
 		"prettier": "^3.5.3",
 		"tsup": "^8.4.0",
 		"typescript": "^5.8.3",
+		"valibot": "^1.1.0",
 		"zod": "^4.1.5"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.3.20",
+	"version": "1.4.0-exp.1",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -208,16 +208,13 @@
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": ">= 0.34.0",
-		"@standard-schema/spec": "^1.0.0",
 		"exact-mirror": ">= 0.0.9",
 		"file-type": ">= 20.0.0",
 		"openapi-types": ">= 12.0.0",
-		"typescript": ">= 5.0.0",
-		"zod": ">= 4.0.0"
+		"typescript": ">= 5.0.0"
 	},
 	"optionalDependencies": {
 		"@sinclair/typebox": "^0.34.33",
-		"openapi-types": "^12.1.3",
-		"zod": "4.1.1"
+		"openapi-types": "^12.1.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.10",
+	"version": "1.4.0-exp.11",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.15",
+	"version": "1.4.0-exp.16",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.11",
+	"version": "1.4.0-exp.13",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.0-exp.5",
+	"version": "1.4.0-exp.6",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -184,7 +184,7 @@
 	},
 	"dependencies": {
 		"cookie": "^1.0.2",
-		"exact-mirror": "0.2.1",
+		"exact-mirror": "0.2.2",
 		"fast-decode-uri-component": "^1.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-<<<<<<< HEAD
 	"version": "1.4.0-exp.2",
-=======
-	"version": "1.3.21",
->>>>>>> weirs
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -208,7 +204,8 @@
 		"mitata": "^1.0.34",
 		"prettier": "^3.5.3",
 		"tsup": "^8.4.0",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"zod": "^4.1.5"
 	},
 	"peerDependencies": {
 		"@sinclair/typebox": ">= 0.34.0",

--- a/src/adapter/bun/compose.ts
+++ b/src/adapter/bun/compose.ts
@@ -65,7 +65,6 @@ const createContext = (
 			hasTrace || inference.url || needsQuery
 		) +
 		`redirect,` +
-		`error:status,` +
 		`status,` +
 		`set:{headers:` +
 		(isNotEmpty(defaultHeaders)

--- a/src/adapter/bun/compose.ts
+++ b/src/adapter/bun/compose.ts
@@ -7,7 +7,7 @@ import { status } from '../../error'
 import { ELYSIA_TRACE } from '../../trace'
 
 import type { AnyElysia } from '../..'
-import type { InternalRoute } from '../../types'
+import type { InternalRoute, InputSchema } from '../../types'
 
 const allocateIf = (value: string, condition: unknown) =>
 	condition ? value : ''
@@ -38,7 +38,9 @@ const createContext = (
 	const needsQuery =
 		inference.query ||
 		!!route.hooks.query ||
-		!!route.standaloneValidators?.find((x) => x.query) ||
+		!!(route.hooks.standaloneValidator as InputSchema[])?.find(
+			(x) => x.query
+		) ||
 		app.event.request?.length
 
 	if (needsQuery) fnLiteral += getQi
@@ -130,7 +132,9 @@ export const createBunRouteHandler = (app: AnyElysia, route: InternalRoute) => {
 	const needsQuery =
 		inference.query ||
 		!!route.hooks.query ||
-		!!route.standaloneValidators?.find((x) => x.query)
+		!!(route.hooks.standaloneValidator as InputSchema[])?.find(
+			(x) => x.query
+		)
 
 	// inference.query require declaring const 'qi'
 	if (hasTrace || needsQuery || app.event.request?.length) {

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -483,7 +483,7 @@ export const BunAdapter: ElysiaAdapter = {
 					) as any
 
 				const handleResponse = createHandleWSResponse(validateResponse)
-				const parseMessage = createWSMessageParser(parse)
+				const parseMessage = createWSMessageParser(parse as any)
 
 				let _id: string | undefined
 

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -262,9 +262,9 @@ export const createStreamHandler =
 
 							// Wait for the next event loop
 							// Otherwise the data will be mixed up
-							await new Promise<void>((resolve) =>
-								setTimeout(() => resolve(), 0)
-							)
+							// await new Promise<void>((resolve) =>
+							// 	setTimeout(() => resolve(), 0)
+							// )
 						}
 					} catch (error) {
 						console.warn(error)

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -107,7 +107,6 @@ export const WebStandardAdapter: ElysiaAdapter = {
 				`path:p,` +
 				`url:u,` +
 				`redirect,` +
-				`error:status,` +
 				`status,` +
 				`set:{headers:`
 

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1490,17 +1490,6 @@ export const composeHandler = ({
 				`for(const [key,value] of Object.entries(c.cookie))` +
 				`cookieValue[key]=value.value\n`
 
-			if (validator.cookie.hasDefault)
-				for (const [key, value] of Object.entries(
-					Value.Default(validator.cookie.schema, {}) as Object
-				)) {
-					fnLiteral += `cookieValue['${key}'] = ${
-						typeof value === 'object'
-							? JSON.stringify(value)
-							: value
-					}\n`
-				}
-
 			if (validator.cookie.isOptional)
 				fnLiteral += `if(isNotEmpty(c.cookie)){`
 

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -51,7 +51,7 @@ import {
 } from './schema'
 import { Sucrose, sucrose } from './sucrose'
 import { parseCookie, type CookieOptions } from './cookies'
-import { validateFileExtension } from './type-system/utils'
+import { fileType } from './type-system/utils'
 
 import type { TraceEvent } from './trace'
 import type {
@@ -1420,7 +1420,7 @@ export const composeHandler = ({
 									continue
 
 								if (validatorLength) validateFile += ','
-								validateFile += `validateFileExtension(c.body.${k},${JSON.stringify(v.extension)},'body.${k}')`
+								validateFile += `fileType(c.body.${k},${JSON.stringify(v.extension)},'body.${k}')`
 
 								validatorLength++
 							}
@@ -1464,7 +1464,7 @@ export const composeHandler = ({
 						continue
 
 					if (i) validateFile += ','
-					validateFile += `validateFileExtension(c.body.${k},${JSON.stringify(v.extension)},'body.${k}')`
+					validateFile += `fileType(c.body.${k},${JSON.stringify(v.extension)},'body.${k}')`
 
 					i++
 				}
@@ -1984,7 +1984,7 @@ export const composeHandler = ({
 		allocateIf(`ValidationError,`, hasValidation) +
 		allocateIf(`ParseError`, hasBody) +
 		`},` +
-		`validateFileExtension,` +
+		`fileType,` +
 		`schema,` +
 		`definitions,` +
 		`ERROR_CODE,` +
@@ -2037,7 +2037,7 @@ export const composeHandler = ({
 				ValidationError: hasValidation ? ValidationError : undefined,
 				ParseError: hasBody ? ParseError : undefined
 			},
-			validateFileExtension,
+			fileType,
 			schema: app.router.history,
 			// @ts-expect-error
 			definitions: app.definitions.type,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -697,7 +697,7 @@ export const composeHandler = ({
 	const isAsyncHandler = typeof handler === 'function' && isAsync(handler)
 
 	const saveResponse =
-		hasTrace || hooks.afterResponse?.length ? 'c.response= ' : ''
+		hasTrace || hooks.afterResponse?.length ? 'c.response=c.responseValue= ' : ''
 
 	const responseKeys = Object.keys(validator.response ?? {})
 	const hasMultipleResponses = responseKeys.length > 1
@@ -1616,7 +1616,7 @@ export const composeHandler = ({
 										? `af=await e.afterHandle[${i}](c)\n`
 										: `af=e.afterHandle[${i}](c)\n`
 
-									fnLiteral += `if(af!==undefined) c.response=be=af\n`
+									fnLiteral += `if(af!==undefined) c.response=c.responseValue=be=af\n`
 								}
 
 								endUnit('af')
@@ -1633,7 +1633,7 @@ export const composeHandler = ({
 					})
 
 					if (hooks.mapResponse?.length) {
-						fnLiteral += `c.response=be\n`
+						fnLiteral += `c.response=c.responseValue=be\n`
 
 						for (let i = 0; i < hooks.mapResponse.length; i++) {
 							const mapResponse = hooks.mapResponse[i]
@@ -1645,7 +1645,7 @@ export const composeHandler = ({
 							fnLiteral +=
 								`if(mr===undefined){` +
 								`mr=${isAsyncName(mapResponse) ? 'await ' : ''}e.mapResponse[${i}](c)\n` +
-								`if(mr!==undefined)be=c.response=mr` +
+								`if(mr!==undefined)be=c.response=c.responseValue=mr` +
 								'}'
 
 							endUnit()
@@ -1672,8 +1672,8 @@ export const composeHandler = ({
 
 		if (hooks.afterHandle?.length)
 			fnLiteral += isAsyncHandler
-				? `let r=c.response=await ${handle}\n`
-				: `let r=c.response=${handle}\n`
+				? `let r=c.response=c.responseValue=await ${handle}\n`
+				: `let r=c.response=c.responseValue=${handle}\n`
 		else
 			fnLiteral += isAsyncHandler
 				? `let r=await ${handle}\n`
@@ -1710,12 +1710,12 @@ export const composeHandler = ({
 
 						fnLiteral += validation.response('af')
 
-						fnLiteral += `c.response=af}`
+						fnLiteral += `c.response=c.responseValue=af}`
 					} else {
 						fnLiteral += `if(af!==undefined){`
 						reporter.resolve()
 
-						fnLiteral += `c.response=af}`
+						fnLiteral += `c.response=c.responseValue=af}`
 					}
 				}
 			}
@@ -1744,7 +1744,7 @@ export const composeHandler = ({
 					`mr=${
 						isAsyncName(mapResponse) ? 'await ' : ''
 					}e.mapResponse[${i}](c)\n` +
-					`if(mr!==undefined)r=c.response=mr\n`
+					`if(mr!==undefined)r=c.response=c.responseValue=mr\n`
 
 				endUnit()
 			}
@@ -1771,7 +1771,7 @@ export const composeHandler = ({
 			})
 
 			if (hooks.mapResponse?.length) {
-				fnLiteral += '\nc.response=r\n'
+				fnLiteral += '\nc.response=c.responseValue=r\n'
 
 				for (let i = 0; i < hooks.mapResponse.length; i++) {
 					const mapResponse = hooks.mapResponse[i]
@@ -1783,7 +1783,7 @@ export const composeHandler = ({
 					fnLiteral +=
 						`\nif(mr===undefined){` +
 						`mr=${isAsyncName(mapResponse) ? 'await ' : ''}e.mapResponse[${i}](c)\n` +
-						`if(mr!==undefined)r=c.response=mr` +
+						`if(mr!==undefined)r=c.response=c.responseValue=mr` +
 						`}\n`
 
 					endUnit()
@@ -1820,7 +1820,7 @@ export const composeHandler = ({
 				total: hooks.mapResponse?.length
 			})
 			if (hooks.mapResponse?.length) {
-				fnLiteral += 'c.response= r\n'
+				fnLiteral += 'c.response=c.responseValue= r\n'
 
 				for (let i = 0; i < hooks.mapResponse.length; i++) {
 					const mapResponse = hooks.mapResponse[i]
@@ -1832,7 +1832,7 @@ export const composeHandler = ({
 					fnLiteral +=
 						`if(mr===undefined){` +
 						`mr=${isAsyncName(mapResponse) ? 'await ' : ''}e.mapResponse[${i}](c)\n` +
-						`if(mr!==undefined)r=c.response=mr` +
+						`if(mr!==undefined)r=c.response=c.responseValue=mr` +
 						`}`
 
 					endUnit()
@@ -1922,7 +1922,7 @@ export const composeHandler = ({
 					)
 
 					fnLiteral +=
-						`c.response=er\n` +
+						`c.response=c.responseValue=er\n` +
 						`mep=e.mapResponse[${i}](c)\n` +
 						`if(mep instanceof Promise)er=await er\n` +
 						`if(mep!==undefined)er=mep\n`
@@ -2526,7 +2526,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 						)
 
 						fnLiteral +=
-							`context.response=_r` +
+							`context.response=context.responseValue=_r` +
 							`_r=${isAsyncName(mapResponse) ? 'await ' : ''}onMapResponse[${i}](context)\n`
 
 						endUnit()
@@ -2554,7 +2554,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 	fnLiteral +=
 		`if(error instanceof Error){` +
 		afterResponse() +
-		`\nif(typeof error.toResponse==='function')return context.response=error.toResponse()\n` +
+		`\nif(typeof error.toResponse==='function')return context.response=context.responseValue=error.toResponse()\n` +
 		adapter.unknownError +
 		`\n}`
 
@@ -2564,7 +2564,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 	})
 
 	fnLiteral +=
-		'\nif(!context.response)context.response=error.message??error\n'
+		'\nif(!context.response)context.response=context.responseValue=error.message??error\n'
 
 	if (hooks.mapResponse?.length) {
 		fnLiteral += 'let mr\n'
@@ -2579,7 +2579,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 			fnLiteral +=
 				`if(mr===undefined){` +
 				`mr=${isAsyncName(mapResponse) ? 'await ' : ''}onMapResponse[${i}](context)\n` +
-				`if(mr!==undefined)error=context.response=mr` +
+				`if(mr!==undefined)error=context.response=context.responseValue=mr` +
 				'}'
 
 			endUnit()

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2269,10 +2269,17 @@ export const composeGeneralHandler = (app: AnyElysia) => {
 		if ('GET' in methods || 'WS' in methods) {
 			switchMap += `case 'GET':`
 
-			if ('WS' in methods)
+			if ('WS' in methods) {
 				switchMap +=
 					`if(r.headers.get('upgrade')==='websocket')` +
 					`return ht[${methods.WS}].composed(c)\n`
+
+				if ('GET' in methods === false) {
+					if ('ALL' in methods)
+						switchMap += `return ht[${methods.ALL}].composed(c)\n`
+					else switchMap += `break map\n`
+				}
+			}
 
 			if ('GET' in methods)
 				switchMap += `return ht[${methods.GET}].composed(c)\n`
@@ -2284,7 +2291,8 @@ export const composeGeneralHandler = (app: AnyElysia) => {
 			'HEAD' in methods === false
 		)
 			switchMap +=
-				`case 'HEAD':const _res=ht[${methods.GET}].composed(c)\n` +
+				`case 'HEAD':` +
+				`const _res=ht[${methods.GET ?? methods.ALL}].composed(c)\n` +
 				'return getResponseLength(_res).then((length)=>{' +
 				`_res.headers.set('content-length', length)\n` +
 				`return new Response(null,{status:_res.status,statusText:_res.statusText,headers:_res.headers})\n` +

--- a/src/context.ts
+++ b/src/context.ts
@@ -103,7 +103,6 @@ export type ErrorContext<
 		route: string
 		request: Request
 		store: Singleton['store']
-		response: Route['response']
 	} & Singleton['decorator'] &
 		Singleton['derive'] &
 		Singleton['resolve']

--- a/src/context.ts
+++ b/src/context.ts
@@ -124,18 +124,23 @@ export type Context<
 	{
 		body: PrettifyIfObject<Route['body'] & Singleton['resolve']['body']>
 		query: undefined extends Route['query']
-			? Record<string, string> & Singleton['resolve']['query']
+			? {} extends NonNullable<Singleton['resolve']['query']>
+				? Record<string, string>
+				: Singleton['resolve']['query']
 			: PrettifyIfObject<Route['query'] & Singleton['resolve']['query']>
 		params: undefined extends Route['params']
 			? undefined extends Path
-				? Record<string, string> & Singleton['resolve']['params']
+				? {} extends NonNullable<Singleton['resolve']['params']>
+					? Record<string, string>
+					: Singleton['resolve']['params']
 				: Path extends `${string}/${':' | '*'}${string}`
 					? ResolvePath<Path>
 					: never
 			: PrettifyIfObject<Route['params'] & Singleton['resolve']['params']>
 		headers: undefined extends Route['headers']
-			? Record<string, string | undefined> &
-					Singleton['resolve']['headers']
+			? {} extends NonNullable<Singleton['resolve']['query']>
+				? Record<string, string | undefined>
+				: Singleton['resolve']['headers']
 			: PrettifyIfObject<
 					Route['headers'] & Singleton['resolve']['headers']
 				>

--- a/src/context.ts
+++ b/src/context.ts
@@ -206,34 +206,6 @@ export type Context<
 					response: T
 					// @ts-ignore trust me bro
 				) => ElysiaCustomStatusResponse<Code, T>
-
-		/**
-		* @deprecated use `status` instead
-		*/
-		error: {} extends Route['response']
-			? typeof status
-			: <
-					const Code extends
-						| keyof Route['response']
-						| InvertedStatusMap[Extract<
-								InvertedStatusMapKey,
-								keyof Route['response']
-						  >],
-					const T extends Code extends keyof Route['response']
-						? Route['response'][Code]
-						: Code extends keyof StatusMap
-							? // @ts-ignore StatusMap[Code] always valid because Code generic check
-								Route['response'][StatusMap[Code]]
-							: never
-				>(
-					code: Code,
-					response: T
-					// @ts-ignore trust me bro
-				) => ElysiaCustomStatusResponse<Code, T>
-
-		// response?: IsNever<keyof Route['response']> extends true
-		// 	? unknown
-		// 	: Route['response'][keyof Route['response']]
 	} & Singleton['decorator'] &
 		Singleton['derive'] &
 		Singleton['resolve']
@@ -261,10 +233,6 @@ export type PreContext<
 			redirect?: string
 		}
 
-		/**
-		 * @deprecated use `status` instead
-		 */
-		error: typeof status
 		status: typeof status
 	} & Singleton['decorator']
 >

--- a/src/context.ts
+++ b/src/context.ts
@@ -136,8 +136,8 @@ export type Context<
 			? Record<string, string | undefined>
 			: PrettifyIfObject<Route['headers']>
 		cookie: undefined extends Route['cookie']
-			? Record<string, Cookie<string | undefined>>
-			: Record<string, Cookie<string | undefined>> & {
+			? Record<string, Cookie<unknown>>
+			: Record<string, Cookie<unknown>> & {
 					[key in keyof Route['cookie']]-?: Cookie<
 						Route['cookie'][key]
 					>

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -322,12 +322,24 @@ export const parseCookie = async (
 
 	const jar: Record<string, ElysiaCookie> = {}
 
-
 	const cookies = parse(cookieString)
 	for (const [name, v] of Object.entries(cookies)) {
 		if (v === undefined) continue
 
 		let value = decode(v)
+
+		if (value) {
+			const starts = value.charCodeAt(0)
+			const ends = value.charCodeAt(value.length - 1)
+
+			if (
+				(starts === 123 && ends === 125) ||
+				(starts === 91 && ends === 93)
+			)
+				try {
+					value = JSON.parse(value)
+				} catch {}
+		}
 
 		if (sign === true || sign?.includes(name)) {
 			if (!secrets)

--- a/src/error.ts
+++ b/src/error.ts
@@ -79,6 +79,12 @@ export const status = <
 	response?: T
 ) => new ElysiaCustomStatusResponse<Code, T>(code, response as any)
 
+const a = status(403, 'a')
+const b = status(403, 'b')
+
+type a = typeof a
+type b = typeof b
+
 export class InternalServerError extends Error {
 	code = 'INTERNAL_SERVER_ERROR'
 	status = 500

--- a/src/error.ts
+++ b/src/error.ts
@@ -268,8 +268,11 @@ export class ValidationError extends Error {
 		let expected
 		let customError
 
-		// @ts-ignore
-		if ('~standard' in validator || '~standard' in validator.schema) {
+		if (
+			'~standard' in validator ||
+			// @ts-ignore
+			(validator.schema && '~standard' in validator.schema)
+		) {
 			const standard = // @ts-ignore
 				('~standard' in validator ? validator : validator.schema)[
 					'~standard'
@@ -300,6 +303,8 @@ export class ValidationError extends Error {
 					null,
 					2
 				)
+
+			customError = error?.message
 		} else {
 			if (
 				value &&
@@ -332,7 +337,7 @@ export class ValidationError extends Error {
 				}
 			}
 
-			const customError =
+			customError =
 				error?.schema?.message || error?.schema?.error !== undefined
 					? typeof error.schema.error === 'function'
 						? error.schema.error(

--- a/src/error.ts
+++ b/src/error.ts
@@ -264,6 +264,8 @@ export class ValidationError extends Error {
 		let customError
 
 		if (
+			// @ts-ignore
+			validator?.provider === 'standard' ||
 			'~standard' in validator ||
 			// @ts-ignore
 			(validator.schema && '~standard' in validator.schema)
@@ -273,9 +275,9 @@ export class ValidationError extends Error {
 					'~standard'
 				]
 
-			const errors = standard.validate(value).issues
+			const _errors = errors ?? standard.validate(value).issues
 
-			error = errors?.[0]
+			error = _errors?.[0]
 
 			if (isProduction)
 				message = JSON.stringify({

--- a/src/error.ts
+++ b/src/error.ts
@@ -8,7 +8,7 @@ import type {
 
 import { StatusMap, InvertedStatusMap } from './utils'
 import type { ElysiaTypeCheck } from './schema'
-import { StandardSchemaV1 } from '@standard-schema/spec'
+import { StandardSchemaV1Like } from './types'
 
 // ? Cloudflare worker support
 const env =
@@ -259,7 +259,7 @@ export class ValidationError extends Error {
 			| TSchema
 			| TypeCheck<any>
 			| ElysiaTypeCheck<any>
-			| StandardSchemaV1,
+			| StandardSchemaV1Like,
 		public value: unknown,
 		errors?: ValueErrorIterator
 	) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -79,11 +79,6 @@ export const status = <
 	response?: T
 ) => new ElysiaCustomStatusResponse<Code, T>(code, response as any)
 
-/**
- * @deprecated use `Elysia.status` instead
- */
-export const error = status
-
 export class InternalServerError extends Error {
 	code = 'INTERNAL_SERVER_ERROR'
 	status = 500

--- a/src/error.ts
+++ b/src/error.ts
@@ -436,6 +436,8 @@ export class ValidationError extends Error {
 	}
 
 	get model() {
+		if ('~standard' in this.validator) return this.validator
+
 		return ValidationError.simplifyModel(this.validator)
 	}
 

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -192,21 +192,21 @@ function regex(str: string): boolean {
 
 /**
  * @license
- * 
+ *
  * MIT License
- * 
+ *
  * Copyright (c) 2020 Evgeny Poberezkin
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/src/index.ts
+++ b/src/index.ts
@@ -5716,7 +5716,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -5821,7 +5822,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -5920,7 +5922,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6019,7 +6022,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6118,7 +6122,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6217,7 +6222,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6316,7 +6322,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6415,7 +6422,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6515,7 +6523,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -6621,7 +6630,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			Volatile['standaloneSchema'] &
+			MacroContext,
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
 			Omit<Input, NonResolvableMacroKey>

--- a/src/index.ts
+++ b/src/index.ts
@@ -883,7 +883,6 @@ export default class Elysia<
 								headers: Object.assign({}, this.setHeaders)
 							},
 							status,
-							error: status,
 							store: this.store
 						}
 
@@ -4382,7 +4381,8 @@ export default class Elysia<
 				derive: Partial<Ephemeral['derive'] & Volatile['derive']>
 				resolve: Partial<Ephemeral['resolve'] & Volatile['resolve']>
 			},
-			Definitions['error']
+			Definitions['error'],
+			keyof Definitions['typebox'] & string
 		>
 	>(
 		macro: NewMacro
@@ -4620,7 +4620,8 @@ export default class Elysia<
 				Volatile['resolve'] &
 				MacroToContext<
 					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
+					Omit<Input, NonResolvableMacroKey>,
+					Definitions['typebox']
 				>
 		},
 		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5648,21 +5648,27 @@ export default class Elysia<
 				{
 					get: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5763,21 +5769,27 @@ export default class Elysia<
 				{
 					post: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5879,21 +5891,27 @@ export default class Elysia<
 				{
 					put: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5995,21 +6013,27 @@ export default class Elysia<
 				{
 					patch: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6111,21 +6135,27 @@ export default class Elysia<
 				{
 					delete: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6227,21 +6257,27 @@ export default class Elysia<
 				{
 					options: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6343,21 +6379,27 @@ export default class Elysia<
 				{
 					[method in string]: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6459,21 +6501,27 @@ export default class Elysia<
 				{
 					head: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6575,21 +6623,27 @@ export default class Elysia<
 				{
 					connect: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6698,21 +6752,27 @@ export default class Elysia<
 				{
 					[method in Method]: {
 						// @ts-ignore
-						body: Schema['body'] & MacroContext['body']
+						body: Prettify<Schema['body'] & MacroContext['body']>
 						params: IsNever<
 							// @ts-ignore
 							keyof (Schema['params'] & MacroContext['params'])
 						> extends true
 							? ResolvePath<Path>
-							: Schema['params'] &
-									// @ts-ignore
-									MacroContext['body']
-						query: Schema['query'] &
-							// @ts-ignore
-							MacroContext['body']
-						headers: Schema['headers'] &
-							// @ts-ignore
-							MacroContext['body']
+							: Prettify<
+									Schema['params'] &
+										// @ts-ignore
+										MacroContext['params']
+								>
+						query: Prettify<
+							Schema['query'] &
+								// @ts-ignore
+								MacroContext['query']
+						>
+						headers: Prettify<
+							Schema['headers'] &
+								// @ts-ignore
+								MacroContext['headers']
+						>
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &

--- a/src/index.ts
+++ b/src/index.ts
@@ -4117,13 +4117,15 @@ export default class Elysia<
 		>,
 		const GuardType extends GuardSchemaType,
 		const AsType extends LifeCycleType,
-		const BeforeHandle extends MaybeArray<
-			OptionalHandler<Schema, Singleton>
-		>,
-		const AfterHandle extends MaybeArray<AfterHandler<Schema, Singleton>>,
-		const ErrorHandle extends MaybeArray<
-			ErrorHandler<Definitions['error'], Schema, Singleton>
-		>
+		const BeforeHandle extends
+			| MaybeArray<OptionalHandler<Schema, Singleton>>
+			| undefined,
+		const AfterHandle extends
+			| MaybeArray<AfterHandler<Schema, Singleton>>
+			| undefined,
+		const ErrorHandle extends
+			| MaybeArray<ErrorHandler<Definitions['error'], Schema, Singleton>>
+			| undefined
 	>(
 		hook: GuardLocalHook<
 			Input,
@@ -4156,7 +4158,11 @@ export default class Elysia<
 					Ephemeral,
 					{
 						derive: Volatile['derive']
-						resolve: Prettify<Volatile['resolve'] & MacroContext>
+						resolve: Prettify<
+							Volatile['resolve'] &
+								// @ts-ignore
+								MacroContext['resolve']
+						>
 						schema: {} extends PickIfExists<
 							Input,
 							keyof InputSchema
@@ -4186,7 +4192,9 @@ export default class Elysia<
 							store: Singleton['store']
 							derive: Singleton['derive']
 							resolve: Prettify<
-								Singleton['resolve'] & MacroContext
+								Singleton['resolve'] &
+									// @ts-ignore
+									MacroContext['resolve']
 							>
 						},
 						Definitions,
@@ -4228,7 +4236,9 @@ export default class Elysia<
 						{
 							derive: Ephemeral['derive']
 							resolve: Prettify<
-								Ephemeral['resolve'] & MacroContext
+								Ephemeral['resolve'] &
+									// @ts-ignore
+									MacroContext['resolve']
 							>
 							schema: {} extends PickIfExists<
 								Input,
@@ -4266,7 +4276,11 @@ export default class Elysia<
 					Ephemeral,
 					{
 						derive: Volatile['derive']
-						resolve: Prettify<Volatile['resolve'] & MacroContext>
+						resolve: Prettify<
+							Volatile['resolve'] &
+								// @ts-ignore
+								MacroContext['resolve']
+						>
 						schema: Volatile['schema']
 						standaloneSchema: {} extends PickIfExists<
 							Input,
@@ -4289,7 +4303,9 @@ export default class Elysia<
 							store: Singleton['store']
 							derive: Singleton['derive']
 							resolve: Prettify<
-								Singleton['resolve'] & MacroContext
+								Singleton['resolve'] &
+									// @ts-ignore
+									MacroContext['resolve']
 							>
 						},
 						Definitions,
@@ -4327,7 +4343,9 @@ export default class Elysia<
 						{
 							derive: Ephemeral['derive']
 							resolve: Prettify<
-								Ephemeral['resolve'] & MacroContext
+								Ephemeral['resolve'] &
+									// @ts-ignore
+									MacroContext['resolve']
 							>
 							schema: Ephemeral['schema']
 							standaloneSchema: {} extends PickIfExists<
@@ -4378,7 +4396,11 @@ export default class Elysia<
 					decorator: Singleton['decorator']
 					store: Singleton['store']
 					derive: Singleton['derive']
-					resolve: Prettify<Singleton['resolve'] & MacroContext>
+					resolve: Prettify<
+						Singleton['resolve'] &
+							// @ts-ignore
+							MacroContext['resolve']
+					>
 				},
 				Definitions,
 				{
@@ -4403,7 +4425,11 @@ export default class Elysia<
 		Ephemeral,
 		{
 			derive: Volatile['derive']
-			resolve: Prettify<Volatile['resolve'] & MacroContext>
+			resolve: Prettify<
+				Volatile['resolve'] &
+					// @ts-ignore
+					MacroContext['resolve']
+			>
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
 			response: Volatile['response']
@@ -5489,17 +5515,20 @@ export default class Elysia<
 				Ephemeral['standaloneSchema'] &
 				Volatile['standaloneSchema']
 		>,
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>
+		>,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>,
-					Definitions['typebox']
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			Decorator,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5532,11 +5561,8 @@ export default class Elysia<
 							Metadata['response'] &
 								Ephemeral['response'] &
 								Volatile['response'] &
-								(IsAny<
-									Decorator['resolve']['response']
-								> extends true
-									? {}
-									: Decorator['resolve']['response'])
+								// @ts-ignore
+								MacroContext['response']
 						>
 					}
 				}
@@ -5585,14 +5611,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, NoInfer<Decorator>>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5623,8 +5654,12 @@ export default class Elysia<
 							Schema,
 							Handle,
 							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response']
+							Ephemeral['response'] &
+							Volatile['response'] &
+							// @ts-ignore
+							MacroContext['response'] &
+							// @ts-ignore
+							MacroContext['return']
 						>
 					}
 				}
@@ -6382,7 +6417,11 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema']
+			Volatile['standaloneSchema'],
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>
+		>
 	>(
 		path: Path,
 		options: WSLocalHook<
@@ -6392,10 +6431,8 @@ export default class Elysia<
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] &
 					Volatile['resolve'] &
-					MacroToContext<
-						Metadata['macroFn'],
-						Omit<Input, NonResolvableMacroKey>
-					>
+					// @ts-ignore
+					MacroContext['resolve']
 			}
 		>
 	): Elysia<

--- a/src/index.ts
+++ b/src/index.ts
@@ -5290,9 +5290,14 @@ export default class Elysia<
 				Ephemeral['standaloneSchema'] &
 				Volatile['standaloneSchema']
 		>,
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
 		const Property extends MaybeValueOrVoidFunction<
 			MacroProperty<
-				Schema,
+				Schema & MacroContext,
 				Singleton & {
 					derive: Partial<Ephemeral['derive'] & Volatile['derive']>
 					resolve: Partial<Ephemeral['resolve'] & Volatile['resolve']>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5556,13 +5556,13 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema & MacroContext,
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
 								Volatile['response'] &
 								// @ts-ignore
-								MacroContext['response']
+								MacroContext['return']
 						>
 					}
 				}
@@ -5651,15 +5651,13 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema & MacroContext,
 							Handle,
 							Metadata['response'] &
-							Ephemeral['response'] &
-							Volatile['response'] &
-							// @ts-ignore
-							MacroContext['response'] &
-							// @ts-ignore
-							MacroContext['return']
+								Ephemeral['response'] &
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5816,7 +5816,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -5917,7 +5918,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6018,7 +6020,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6119,7 +6122,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6220,7 +6224,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6321,7 +6326,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6422,7 +6428,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6524,7 +6531,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],
+		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6632,7 +6640,8 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],		const MacroContext extends MacroToContext<
+			Volatile['standaloneSchema'],
+		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
 			Omit<Input, NonResolvableMacroKey>
 		>

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,8 @@ import type {
 	PickIfExists,
 	SimplifyToSchema,
 	UnionResponseStatus,
-	ValueOrFunctionToResponseSchema
+	ValueOrFunctionToResponseSchema,
+	CreateEdenResponse
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>
@@ -5646,30 +5647,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					get: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					get: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -5688,7 +5670,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -5767,30 +5749,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					post: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					post: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -5809,7 +5772,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -5889,30 +5852,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					put: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					put: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -5931,7 +5875,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6011,30 +5955,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					patch: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					patch: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6053,7 +5978,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6133,30 +6058,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					delete: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					delete: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6175,7 +6081,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6255,30 +6161,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					options: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					options: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6297,7 +6184,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6377,30 +6264,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					[method in string]: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					[method in string]: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6419,7 +6287,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6499,30 +6367,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					head: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					head: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6541,7 +6390,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6621,30 +6470,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					connect: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					connect: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6663,7 +6493,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6750,30 +6580,11 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					[method in Method]: {
-						// @ts-ignore
-						body: Prettify<Schema['body'] & MacroContext['body']>
-						params: IsNever<
-							// @ts-ignore
-							keyof (Schema['params'] & MacroContext['params'])
-						> extends true
-							? ResolvePath<Path>
-							: Prettify<
-									Schema['params'] &
-										// @ts-ignore
-										MacroContext['params']
-								>
-						query: Prettify<
-							Schema['query'] &
-								// @ts-ignore
-								MacroContext['query']
-						>
-						headers: Prettify<
-							Schema['headers'] &
-								// @ts-ignore
-								MacroContext['headers']
-						>
-						response: ComposeElysiaResponse<
+					[method in Method]: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
 							Schema &
 								MacroContext &
 								Metadata['standaloneSchema'] &
@@ -6792,7 +6603,7 @@ export default class Elysia<
 								>
 							>
 						>
-					}
+					>
 				}
 			>,
 		Ephemeral,
@@ -6865,19 +6676,34 @@ export default class Elysia<
 			CreateEden<
 				JoinPath<BasePath, Path>,
 				{
-					subscribe: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
-							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
-						response: {} extends Schema['response']
-							? unknown
-							: Schema['response'] extends { [200]: any }
-								? Schema['response'][200]
-								: unknown
-					}
+					subscribe: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
+							{} extends Schema['response']
+								? unknown
+								: Schema['response'] extends { [200]: any }
+									? Schema['response'][200]
+									: unknown,
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
+						>
+					>
 				}
 			>,
 		Ephemeral,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4623,9 +4623,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4707,11 +4705,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			NoInfer<Decorator>,
-			JoinPath<BasePath, Path>
-		>
+		const Handle extends InlineHandler<NoInfer<Schema>, NoInfer<Decorator>>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4793,9 +4787,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4877,9 +4869,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -4961,9 +4951,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5045,9 +5033,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5129,9 +5115,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5213,9 +5197,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5297,9 +5279,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5382,9 +5362,7 @@ export default class Elysia<
 					Omit<Input, NonResolvableMacroKey>
 				>
 		},
-		const Handle extends InlineHandler<
-			NoInfer<Schema>,
-			Decorator>
+		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
 	>(
 		method: Method,
 		path: Path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,6 @@ import type {
 	StandaloneValidator,
 	GuardSchemaType,
 	Or,
-	PrettifySchema,
 	MergeStandaloneSchema,
 	IsNever,
 	DocumentDecoration,
@@ -3738,7 +3737,7 @@ export default class Elysia<
 				MergeSchema<Volatile['schema'], Ephemeral['schema']>,
 				Metadata['schema']
 			>
-			standaloneSchema: PrettifySchema<
+			standaloneSchema: Prettify<
 				Metadata['standaloneSchema'] &
 					Volatile['standaloneSchema'] &
 					Ephemeral['standaloneSchema']
@@ -3777,7 +3776,7 @@ export default class Elysia<
 			derive: Prettify<Ephemeral['derive'] & Volatile['derive']>
 			resolve: Prettify<Ephemeral['resolve'] & Volatile['resolve']>
 			schema: MergeSchema<Volatile['schema'], Ephemeral['schema']>
-			standaloneSchema: PrettifySchema<
+			standaloneSchema: Prettify<
 				Volatile['standaloneSchema'] & Ephemeral['standaloneSchema']
 			>
 			response: Prettify<Volatile['response'] & Ephemeral['response']>
@@ -4661,7 +4660,7 @@ export default class Elysia<
 			schema: Prettify<
 				Ephemeral['schema'] & Partial<NewElysia['~Ephemeral']['schema']>
 			>
-			standaloneSchema: PrettifySchema<
+			standaloneSchema: Prettify<
 				Ephemeral['standaloneSchema'] &
 					Partial<NewElysia['~Ephemeral']['standaloneSchema']>
 			>
@@ -4680,7 +4679,7 @@ export default class Elysia<
 			schema: Prettify<
 				Volatile['schema'] & Partial<NewElysia['~Volatile']['schema']>
 			>
-			standaloneSchema: PrettifySchema<
+			standaloneSchema: Prettify<
 				Volatile['standaloneSchema'] &
 					Partial<NewElysia['~Volatile']['standaloneSchema']>
 			>
@@ -4795,7 +4794,7 @@ export default class Elysia<
 				Volatile['schema'] &
 					Partial<LazyLoadElysia['~Ephemeral']['schema']>
 			>
-			standaloneSchema: PrettifySchema<
+			standaloneSchema: Prettify<
 				Volatile['standaloneSchema'] &
 					Partial<LazyLoadElysia['~Ephemeral']['standaloneSchema']>
 			>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import {
 	type TSchema,
 	type TModule,
 	type TRef,
-	type TProperties,
 	type TAnySchema
 } from '@sinclair/typebox'
 
@@ -162,7 +161,9 @@ import type {
 	ElysiaHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
-	SimplifyToSchema
+	SimplifyToSchema,
+	UnionResponseStatus,
+	ValueOrFunctionToResponseSchema
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>
@@ -1197,8 +1198,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchema<Handler>
+			>
 		}
 	>
 
@@ -1249,8 +1252,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
-				ElysiaHandlerToResponseSchemas<Handlers>
+			response: UnionResponseStatus<
+				Volatile['response'],
+				ElysiaHandlerToResponseSchema<Handler>
+			>
 		}
 	>
 
@@ -1325,7 +1330,7 @@ export default class Elysia<
 	 * ```
 	 */
 	onParse<const Schema extends RouteSchema, const Type extends LifeCycleType>(
-		options: { as?: Type },
+		options: { as: Type },
 		parser: MaybeArray<
 			BodyHandler<
 				MergeSchema<
@@ -1380,7 +1385,7 @@ export default class Elysia<
 	): this
 
 	onParse(
-		options: { as?: LifeCycleType } | MaybeArray<Function> | string,
+		options: { as: LifeCycleType } | MaybeArray<Function> | string,
 		handler?: MaybeArray<Function>
 	): unknown {
 		if (!handler) {
@@ -1391,7 +1396,7 @@ export default class Elysia<
 		}
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'parse',
 			handler as any
 		)
@@ -1522,7 +1527,7 @@ export default class Elysia<
 		const Schema extends RouteSchema,
 		const Type extends LifeCycleType
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		handler: MaybeArray<
 			TransformHandler<
 				MergeSchema<
@@ -1573,13 +1578,13 @@ export default class Elysia<
 	): this
 
 	onTransform(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	) {
 		if (!handler) return this.on('transform', options as any)
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'transform',
 			handler as any
 		)
@@ -1606,7 +1611,7 @@ export default class Elysia<
 			| ElysiaCustomStatusResponse<any, any, any>,
 		const Type extends LifeCycleType
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		resolver: (
 			context: Prettify<
 				Context<
@@ -1668,8 +1673,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ExtractErrorFromHandle<Resolver>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -1690,8 +1697,10 @@ export default class Elysia<
 						>
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ExtractErrorFromHandle<Resolver>
+						>
 					},
 					Volatile
 				>
@@ -1710,8 +1719,10 @@ export default class Elysia<
 						>
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ExtractErrorFromHandle<Resolver>
+						>
 					}
 				>
 
@@ -1769,12 +1780,15 @@ export default class Elysia<
 			>
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] & ExtractErrorFromHandle<Resolver>
+			response: UnionResponseStatus<
+				Volatile['response'],
+				ExtractErrorFromHandle<Resolver>
+			>
 		}
 	>
 
 	resolve(
-		optionsOrResolve: { as?: LifeCycleType } | Function,
+		optionsOrResolve: { as: LifeCycleType } | Function,
 		resolve?: Function
 	) {
 		if (!resolve) {
@@ -1823,7 +1837,10 @@ export default class Elysia<
 			resolve: ExcludeElysiaResponse<NewResolver>
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] & ExtractErrorFromHandle<NewResolver>
+			response: UnionResponseStatus<
+				Volatile['response'],
+				ExtractErrorFromHandle<NewResolver>
+			>
 		}
 	>
 
@@ -1833,7 +1850,7 @@ export default class Elysia<
 			| ElysiaCustomStatusResponse<any, any, any>,
 		const Type extends LifeCycleType
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		mapper: (
 			context: Context<
 				MergeSchema<
@@ -1884,8 +1901,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ExtractErrorFromHandle<NewResolver>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -1906,8 +1925,10 @@ export default class Elysia<
 						>
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ExtractErrorFromHandle<NewResolver>
+						>
 					},
 					Volatile
 				>
@@ -1926,13 +1947,15 @@ export default class Elysia<
 						>
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ExtractErrorFromHandle<NewResolver>
+						>
 					}
 				>
 
 	mapResolve(
-		optionsOrResolve: Function | { as?: LifeCycleType },
+		optionsOrResolve: Function | { as: LifeCycleType },
 		mapper?: Function
 	) {
 		if (!mapper) {
@@ -2000,8 +2023,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchema<Handler>
+			>
 		}
 	>
 
@@ -2057,8 +2082,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchemas<Handlers>
+			>
 		}
 	>
 
@@ -2126,7 +2153,7 @@ export default class Elysia<
 			BasePath
 		>
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		handler: Handler
 	): Type extends 'global'
 		? Elysia<
@@ -2139,8 +2166,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ElysiaHandlerToResponseSchema<Handler>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -2158,8 +2187,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ElysiaHandlerToResponseSchema<Handler>
+						>
 					},
 					Volatile
 				>
@@ -2175,8 +2206,10 @@ export default class Elysia<
 						resolve: Volatile['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ElysiaHandlerToResponseSchema<Handler>
+						>
 					}
 				>
 
@@ -2244,7 +2277,7 @@ export default class Elysia<
 			BasePath
 		>[]
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		handlers: Handlers
 	): Type extends 'global'
 		? Elysia<
@@ -2257,8 +2290,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ElysiaHandlerToResponseSchemas<Handlers>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -2276,8 +2311,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ElysiaHandlerToResponseSchemas<Handlers>
+						>
 					},
 					Volatile
 				>
@@ -2293,19 +2330,21 @@ export default class Elysia<
 						resolve: Volatile['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ElysiaHandlerToResponseSchemas<Handlers>
+						>
 					}
 				>
 
 	onBeforeHandle(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	): any {
 		if (!handler) return this.on('beforeHandle', options as any)
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'beforeHandle',
 			handler as any
 		)
@@ -2360,8 +2399,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchema<Handler>
+			>
 		}
 	>
 
@@ -2414,8 +2455,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchemas<Handlers>
+			>
 		}
 	>
 
@@ -2479,7 +2522,7 @@ export default class Elysia<
 							})
 		>
 	>(
-		options: { as?: LifeCycleType },
+		options: { as: Type },
 		handler: Handler
 	): Type extends 'global'
 		? Elysia<
@@ -2492,8 +2535,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ElysiaHandlerToResponseSchema<Handler>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -2511,8 +2556,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ElysiaHandlerToResponseSchema<Handler>
+						>
 					},
 					Volatile
 				>
@@ -2528,8 +2575,10 @@ export default class Elysia<
 						resolve: Volatile['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ElysiaHandlerToResponseSchema<Handler>
+						>
 					}
 				>
 
@@ -2593,7 +2642,7 @@ export default class Elysia<
 							})
 		>[]
 	>(
-		options: { as?: LifeCycleType },
+		options: { as: Type },
 		handler: Handlers
 	): Type extends 'global'
 		? Elysia<
@@ -2606,8 +2655,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ElysiaHandlerToResponseSchemas<Handlers>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -2625,8 +2676,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ElysiaHandlerToResponseSchemas<Handlers>
+						>
 					},
 					Volatile
 				>
@@ -2642,19 +2695,21 @@ export default class Elysia<
 						resolve: Volatile['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ElysiaHandlerToResponseSchemas<Handlers>
+						>
 					}
 				>
 
 	onAfterHandle(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	): any {
 		if (!handler) return this.on('afterHandle', options as any)
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'afterHandle',
 			handler as any
 		)
@@ -2715,7 +2770,7 @@ export default class Elysia<
 	 * ```
 	 */
 	mapResponse<const Schema extends RouteSchema, Type extends LifeCycleType>(
-		options: { as?: Type },
+		options: { as: Type },
 		handler: MaybeArray<
 			MapResponse<
 				MergeSchema<
@@ -2762,13 +2817,13 @@ export default class Elysia<
 	): this
 
 	mapResponse(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	) {
 		if (!handler) return this.on('mapResponse', options as any)
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'mapResponse',
 			handler as any
 		)
@@ -2828,7 +2883,7 @@ export default class Elysia<
 		const Schema extends RouteSchema,
 		const Type extends LifeCycleType
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		handler: MaybeArray<
 			AfterResponseHandler<
 				MergeSchema<
@@ -2875,13 +2930,13 @@ export default class Elysia<
 	): this
 
 	onAfterResponse(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	) {
 		if (!handler) return this.on('afterResponse', options as any)
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'afterResponse',
 			handler as any
 		)
@@ -2924,7 +2979,7 @@ export default class Elysia<
 	 * ```
 	 */
 	trace<const Schema extends RouteSchema>(
-		options: { as?: LifeCycleType },
+		options: { as: LifeCycleType },
 		handler: MaybeArray<TraceHandler<Schema, Singleton>>
 	): this
 
@@ -2945,7 +3000,7 @@ export default class Elysia<
 	 * ```
 	 */
 	trace(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	) {
 		if (!handler) {
@@ -2957,7 +3012,7 @@ export default class Elysia<
 
 		for (const fn of handler)
 			this.on(
-				options as { as?: LifeCycleType },
+				options as { as: LifeCycleType },
 				'trace',
 				createTracer(fn as any) as any
 			)
@@ -3179,8 +3234,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchema<Handler>
+			>
 		}
 	>
 
@@ -3230,8 +3287,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ElysiaHandlerToResponseSchemas<Handlers>
+			>
 		}
 	>
 
@@ -3251,7 +3310,7 @@ export default class Elysia<
 	 */
 	onError<
 		const Schema extends RouteSchema,
-		const Scope extends LifeCycleType,
+		const Type extends LifeCycleType,
 		const Handler extends ErrorHandler<
 			Definitions['error'],
 			MergeSchema<
@@ -3264,7 +3323,7 @@ export default class Elysia<
 				Metadata['standaloneSchema'] &
 				Ephemeral['standaloneSchema'] &
 				Volatile['standaloneSchema'],
-			Scope extends 'global'
+			Type extends 'global'
 				? {
 						store: Singleton['store']
 						decorator: Singleton['decorator']
@@ -3275,7 +3334,7 @@ export default class Elysia<
 							Ephemeral['resolve'] &
 							Volatile['resolve']
 					}
-				: Scope extends 'scoped'
+				: Type extends 'scoped'
 					? {
 							store: Singleton['store']
 							decorator: Singleton['decorator']
@@ -3283,7 +3342,7 @@ export default class Elysia<
 							resolve: Singleton['resolve'] & Ephemeral['resolve']
 						}
 					: Singleton,
-			Scope extends 'global'
+			Type extends 'global'
 				? Ephemeral
 				: {
 						derive: Partial<Ephemeral['derive']>
@@ -3292,9 +3351,9 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: Ephemeral['response']
 					},
-			Scope extends 'global'
+			Type extends 'global'
 				? Ephemeral
-				: Scope extends 'scoped'
+				: Type extends 'scoped'
 					? Ephemeral
 					: {
 							derive: Partial<Ephemeral['derive']>
@@ -3305,9 +3364,9 @@ export default class Elysia<
 						}
 		>
 	>(
-		options: { as?: Scope },
+		options: { as: Type },
 		handler: Handler
-	): Scope extends 'global'
+	): Type extends 'global'
 		? Elysia<
 				BasePath,
 				Singleton,
@@ -3318,14 +3377,16 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ElysiaHandlerToResponseSchema<Handler>
+					>
 				},
 				Routes,
 				Ephemeral,
 				Volatile
 			>
-		: Scope extends 'scoped'
+		: Type extends 'scoped'
 			? Elysia<
 					BasePath,
 					Singleton,
@@ -3337,8 +3398,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ElysiaHandlerToResponseSchema<Handler>
+						>
 					},
 					Volatile
 				>
@@ -3354,8 +3417,10 @@ export default class Elysia<
 						resolve: Volatile['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ElysiaHandlerToResponseSchema<Handler>
+						>
 					}
 				>
 
@@ -3375,7 +3440,7 @@ export default class Elysia<
 	 */
 	onError<
 		const Schema extends RouteSchema,
-		const Scope extends LifeCycleType,
+		const Type extends LifeCycleType,
 		const Handlers extends ErrorHandler<
 			Definitions['error'],
 			MergeSchema<
@@ -3388,7 +3453,7 @@ export default class Elysia<
 				Metadata['standaloneSchema'] &
 				Ephemeral['standaloneSchema'] &
 				Volatile['standaloneSchema'],
-			Scope extends 'global'
+			Type extends 'global'
 				? {
 						store: Singleton['store']
 						decorator: Singleton['decorator']
@@ -3399,7 +3464,7 @@ export default class Elysia<
 							Ephemeral['resolve'] &
 							Volatile['resolve']
 					}
-				: Scope extends 'scoped'
+				: Type extends 'scoped'
 					? {
 							store: Singleton['store']
 							decorator: Singleton['decorator']
@@ -3407,7 +3472,7 @@ export default class Elysia<
 							resolve: Singleton['resolve'] & Ephemeral['resolve']
 						}
 					: Singleton,
-			Scope extends 'global'
+			Type extends 'global'
 				? Ephemeral
 				: {
 						derive: Partial<Ephemeral['derive']>
@@ -3416,9 +3481,9 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: Ephemeral['response']
 					},
-			Scope extends 'global'
+			Type extends 'global'
 				? Ephemeral
-				: Scope extends 'scoped'
+				: Type extends 'scoped'
 					? Ephemeral
 					: {
 							derive: Partial<Ephemeral['derive']>
@@ -3429,9 +3494,9 @@ export default class Elysia<
 						}
 		>[]
 	>(
-		options: { as?: Scope },
+		options: { as: Type },
 		handler: Handlers
-	): Scope extends 'global'
+	): Type extends 'global'
 		? Elysia<
 				BasePath,
 				Singleton,
@@ -3442,14 +3507,16 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ElysiaHandlerToResponseSchemas<Handlers>
+					>
 				},
 				Routes,
 				Ephemeral,
 				Volatile
 			>
-		: Scope extends 'scoped'
+		: Type extends 'scoped'
 			? Elysia<
 					BasePath,
 					Singleton,
@@ -3461,8 +3528,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ElysiaHandlerToResponseSchemas<Handlers>
+						>
 					},
 					Volatile
 				>
@@ -3478,8 +3547,10 @@ export default class Elysia<
 						resolve: Volatile['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ElysiaHandlerToResponseSchemas<Handlers>
+						>
 					}
 				>
 
@@ -3498,13 +3569,13 @@ export default class Elysia<
 	 * ```
 	 */
 	onError(
-		options: { as?: LifeCycleType } | MaybeArray<Function>,
+		options: { as: LifeCycleType } | MaybeArray<Function>,
 		handler?: MaybeArray<Function>
 	): any {
 		if (!handler) return this.on('error', options as any)
 
 		return this.on(
-			options as { as?: LifeCycleType },
+			options as { as: LifeCycleType },
 			'error',
 			handler as any
 		)
@@ -3569,13 +3640,13 @@ export default class Elysia<
 	 * ```
 	 */
 	on<const Event extends keyof LifeCycleStore>(
-		options: { as?: LifeCycleType },
+		options: { as: LifeCycleType },
 		type: Event,
 		handlers: MaybeArray<Extract<LifeCycleStore[Event], Function[]>[0]>
 	): this
 
 	on(
-		optionsOrType: { as?: LifeCycleType } | string,
+		optionsOrType: { as: LifeCycleType } | string,
 		typeOrHandlers: MaybeArray<Function | HookContainer> | string,
 		handlers?: MaybeArray<Function | HookContainer>
 	) {
@@ -3897,7 +3968,7 @@ export default class Elysia<
 			>,
 			Metadata['schema']
 		> &
-			Metadata['standaloneSchema'],
+			Metadata['standaloneSchema']
 	>(
 		prefix: Prefix,
 		schema: LocalHook<
@@ -4159,14 +4230,18 @@ export default class Elysia<
 										Metadata['schema']
 									>
 								>
-						standaloneSchema: Volatile['standaloneSchema'] &
-							SimplifyToSchema<MacroContext>
-						response: Volatile['response'] &
-							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-							// @ts-ignore
-							MacroContext['return']
+						standaloneSchema: Prettify<
+							Volatile['standaloneSchema'] &
+								SimplifyToSchema<MacroContext>
+						>
+						response: Prettify<
+							Volatile['response'] &
+								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								// @ts-ignore
+								MacroContext['return']
+						>
 					}
 				>
 			: AsType extends 'global'
@@ -4199,17 +4274,21 @@ export default class Elysia<
 											Metadata['schema']
 										>
 									>
-							standaloneSchema: Metadata['standaloneSchema'] &
-								SimplifyToSchema<MacroContext>
+							standaloneSchema: Prettify<
+								Metadata['standaloneSchema'] &
+									SimplifyToSchema<MacroContext>
+							>
 							macro: Metadata['macro']
 							macroFn: Metadata['macroFn']
 							parser: Metadata['parser']
-							response: Metadata['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: Prettify<
+								Metadata['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+									// @ts-ignore
+									MacroContext['return']
+							>
 						},
 						Routes,
 						Ephemeral,
@@ -4243,14 +4322,18 @@ export default class Elysia<
 												Ephemeral['schema']
 										>
 									>
-							standaloneSchema: Ephemeral['standaloneSchema'] &
-								SimplifyToSchema<MacroContext>
-							response: Ephemeral['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							standaloneSchema: Prettify<
+								Ephemeral['standaloneSchema'] &
+									SimplifyToSchema<MacroContext>
+							>
+							response: Prettify<
+								Ephemeral['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+									// @ts-ignore
+									MacroContext['return']
+							>
 						},
 						Volatile
 					>
@@ -4273,23 +4356,27 @@ export default class Elysia<
 								MacroContext['resolve']
 						>
 						schema: Volatile['schema']
-						standaloneSchema: ({} extends PickIfExists<
-							Input,
-							keyof InputSchema
+						standaloneSchema: Prettify<
+							SimplifyToSchema<MacroContext> &
+								({} extends PickIfExists<
+									Input,
+									keyof InputSchema
+								>
+									? Volatile['standaloneSchema']
+									: Volatile['standaloneSchema'] &
+											UnwrapRoute<
+												Input,
+												Definitions['typebox']
+											>)
 						>
-							? Volatile['standaloneSchema']
-							: Volatile['standaloneSchema'] &
-									UnwrapRoute<
-										Input,
-										Definitions['typebox']
-									>) &
-							SimplifyToSchema<MacroContext>
-						response: Volatile['response'] &
-							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-							// @ts-ignore
-							MacroContext['return']
+						response: Prettify<
+							Volatile['response'] &
+								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								// @ts-ignore
+								MacroContext['return']
+						>
 					}
 				>
 			: AsType extends 'global'
@@ -4308,27 +4395,31 @@ export default class Elysia<
 						Definitions,
 						{
 							schema: Metadata['schema']
-							standaloneSchema: ({} extends PickIfExists<
-								Input,
-								keyof InputSchema
-							>
-								? Metadata['standaloneSchema']
-								: UnwrapRoute<
+							standaloneSchema: Prettify<
+								SimplifyToSchema<MacroContext> &
+									({} extends PickIfExists<
 										Input,
-										Definitions['typebox'],
-										BasePath
-									> &
-										Metadata['standaloneSchema']) &
-								SimplifyToSchema<MacroContext>
+										keyof InputSchema
+									>
+										? Metadata['standaloneSchema']
+										: UnwrapRoute<
+												Input,
+												Definitions['typebox'],
+												BasePath
+											> &
+												Metadata['standaloneSchema'])
+							>
 							macro: Metadata['macro']
 							macroFn: Metadata['macroFn']
 							parser: Metadata['parser']
-							response: Metadata['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: Prettify<
+								Metadata['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+									// @ts-ignore
+									MacroContext['return']
+							>
 						},
 						Routes,
 						Ephemeral,
@@ -4348,23 +4439,27 @@ export default class Elysia<
 									MacroContext['resolve']
 							>
 							schema: Ephemeral['schema']
-							standaloneSchema: ({} extends PickIfExists<
-								Input,
-								keyof InputSchema
+							standaloneSchema: Prettify<
+								SimplifyToSchema<MacroContext> &
+									({} extends PickIfExists<
+										Input,
+										keyof InputSchema
+									>
+										? Ephemeral['standaloneSchema']
+										: Ephemeral['standaloneSchema'] &
+												UnwrapRoute<
+													Input,
+													Definitions['typebox']
+												>)
 							>
-								? Ephemeral['standaloneSchema']
-								: Ephemeral['standaloneSchema'] &
-										UnwrapRoute<
-											Input,
-											Definitions['typebox']
-										>) &
-								SimplifyToSchema<MacroContext>
-							response: Ephemeral['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: Prettify<
+								Ephemeral['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+									// @ts-ignore
+									MacroContext['return']
+							>
 						},
 						Volatile
 					>
@@ -5565,11 +5660,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -5664,14 +5765,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return'] &
-								Metadata['standaloneSchema']['response'] &
-								Ephemeral['standaloneSchema']['response'] &
-								Volatile['standaloneSchema']['response']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -7147,7 +7251,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] & ExtractErrorFromHandle<Derivative>
+			response: UnionResponseStatus<
+				Volatile['response'],
+				ExtractErrorFromHandle<Derivative>
+			>
 		}
 	>
 
@@ -7173,7 +7280,7 @@ export default class Elysia<
 			| void,
 		const Type extends LifeCycleType
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		transform: (
 			context: Prettify<
 				Context<
@@ -7236,8 +7343,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ExtractErrorFromHandle<Derivative>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -7258,8 +7367,10 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ExtractErrorFromHandle<Derivative>
+						>
 					},
 					Volatile
 				>
@@ -7278,13 +7389,15 @@ export default class Elysia<
 						resolve: Ephemeral['resolve']
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ExtractErrorFromHandle<Derivative>
+						>
 					}
 				>
 
 	derive(
-		optionsOrTransform: { as?: LifeCycleType } | Function,
+		optionsOrTransform: { as: LifeCycleType } | Function,
 		transform?: Function
 	) {
 		if (!transform) {
@@ -7488,8 +7601,10 @@ export default class Elysia<
 			resolve: Volatile['resolve']
 			schema: Volatile['schema']
 			standaloneSchema: Volatile['standaloneSchema']
-			response: Volatile['response'] &
+			response: UnionResponseStatus<
+				Volatile['response'],
 				ExtractErrorFromHandle<NewDerivative>
+			>
 		}
 	>
 
@@ -7499,7 +7614,7 @@ export default class Elysia<
 			| ElysiaCustomStatusResponse<any, any, any>,
 		const Type extends LifeCycleType
 	>(
-		options: { as?: Type },
+		options: { as: Type },
 		mapper: (
 			context: Context<
 				{},
@@ -7535,11 +7650,11 @@ export default class Elysia<
 				{
 					decorator: Singleton['decorator']
 					store: Singleton['store']
-					derive: Singleton['derive']
-					resolve: Prettify<
-						Singleton['resolve'] &
+					derive: Prettify<
+						Singleton['derive'] &
 							ExcludeElysiaResponse<NewDerivative>
 					>
+					resolve: Singleton['resolve']
 				},
 				Definitions,
 				{
@@ -7548,8 +7663,10 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
+					response: UnionResponseStatus<
+						Metadata['response'],
 						ExtractErrorFromHandle<NewDerivative>
+					>
 				},
 				Routes,
 				Ephemeral,
@@ -7563,15 +7680,17 @@ export default class Elysia<
 					Metadata,
 					Routes,
 					{
-						derive: Ephemeral['derive']
-						resolve: Prettify<
-							Ephemeral['resolve'] &
+						derive: Prettify<
+							Ephemeral['derive'] &
 								ExcludeElysiaResponse<NewDerivative>
 						>
+						resolve: Ephemeral['resolve']
 						schema: Ephemeral['schema']
 						standaloneSchema: Ephemeral['standaloneSchema']
-						response: Ephemeral['response'] &
+						response: UnionResponseStatus<
+							Ephemeral['response'],
 							ExtractErrorFromHandle<NewDerivative>
+						>
 					},
 					Volatile
 				>
@@ -7590,13 +7709,15 @@ export default class Elysia<
 						>
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema']
-						response: Volatile['response'] &
+						response: UnionResponseStatus<
+							Volatile['response'],
 							ExtractErrorFromHandle<NewDerivative>
+						>
 					}
 				>
 
 	mapDerive(
-		optionsOrDerive: { as?: LifeCycleType } | Function,
+		optionsOrDerive: { as: LifeCycleType } | Function,
 		mapper?: Function
 	) {
 		if (!mapper) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5484,11 +5484,11 @@ export default class Elysia<
 			MergeSchema<
 				Volatile['schema'],
 				MergeSchema<Ephemeral['schema'], Metadata['schema']>
-			>
-		> &
-			Metadata['standaloneSchema'] &
-			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'],
+			> &
+				Metadata['standaloneSchema'] &
+				Ephemeral['standaloneSchema'] &
+				Volatile['standaloneSchema']
+		>,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
@@ -5531,12 +5531,7 @@ export default class Elysia<
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response'] &
-								(IsNever<
-									Decorator['resolve']['response']
-								> extends false
-									? Decorator['resolve']['response']
-									: {})
+								Volatile['response']
 						>
 					}
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3611,10 +3611,11 @@ export default class Elysia<
 					if (!this.standaloneValidator[type])
 						this.standaloneValidator[type] = []
 
-					const response =
-						hook?.response ||
-						typeof hook?.response === 'string' ||
-						(hook?.response && Kind in hook.response)
+					const response = !hook?.response
+						? undefined
+						: typeof hook.response === 'string' ||
+							  Kind in hook.response ||
+							  '~standard' in hook.response
 							? {
 									200: hook.response
 								}
@@ -6366,7 +6367,9 @@ export default class Elysia<
 		return this
 	}
 
-	Ref<K extends keyof Definitions['typebox'] & string>(key: K) {
+	Ref<K extends keyof Extract<Definitions['typebox'], TAnySchema> & string>(
+		key: K
+	) {
 		return t.Ref(key)
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,6 +493,8 @@ export default class Elysia<
 
 		localHook ??= {}
 
+		this.applyMacro(localHook)
+
 		let standaloneValidators = [] as InputSchema[]
 
 		if (localHook.standaloneValidator)
@@ -770,8 +772,6 @@ export default class Elysia<
 				Object.assign({}, this.config.detail!),
 				localHook.detail
 			)
-
-		this.applyMacro(localHook)
 
 		const hooks = isNotEmpty(this.event)
 			? mergeHook(this.event, localHookToLifeCycleStore(localHook))
@@ -5392,7 +5392,7 @@ export default class Elysia<
 					case 'object':
 						if (Array.isArray(localHook[k]))
 							(localHook[k] as any[]).push(value)
-						else localHook[k] = [localHook[k]]
+						else localHook[k] = [localHook[k], value]
 						break
 
 					case 'undefined':

--- a/src/index.ts
+++ b/src/index.ts
@@ -5386,7 +5386,6 @@ export default class Elysia<
 		}: { iteration?: number; applied?: { [key: number]: true } } = {}
 	) {
 		if (iteration >= 16) return
-
 		const macro = this.extender.macro
 
 		for (let [key, value] of Object.entries(appliable)) {
@@ -5397,12 +5396,13 @@ export default class Elysia<
 					? macro[key](value)
 					: macro[key]
 
-			if (!macroHook) return
-
-			if (typeof macro[key] === 'object' && value === false) return
+			if (
+				!macroHook ||
+				(typeof macro[key] === 'object' && value === false)
+			)
+				return
 
 			const seed = checksum(key + JSON.stringify(macroHook.seed ?? value))
-
 			if (seed in applied) continue
 
 			applied[seed] = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,9 @@ import type {
 	MergeStandaloneSchema,
 	IsNever,
 	DocumentDecoration,
-	AfterHandler
+	AfterHandler,
+	AnyBaseHookLifeCycle,
+	NonResolvableMacroKey
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>
@@ -3037,7 +3039,8 @@ export default class Elysia<
 	group<
 		const Prefix extends string,
 		const NewElysia extends AnyElysia,
-		const Input extends InputSchema<keyof Definitions['typebox'] & string>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
 				Input,
@@ -3066,7 +3069,6 @@ export default class Elysia<
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
 			},
 			Definitions['error'],
-			Metadata['macro'],
 			keyof Metadata['parser']
 		>,
 		run: (
@@ -3216,17 +3218,15 @@ export default class Elysia<
 	}
 
 	guard<
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
-			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>,
 		const GuardType extends GuardSchemaType,
 		const AsType extends LifeCycleType
@@ -3242,14 +3242,13 @@ export default class Elysia<
 			 */
 			schema?: GuardType
 		} & LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
 			},
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Or<
@@ -3272,10 +3271,7 @@ export default class Elysia<
 						resolve: Prettify<Volatile['resolve'] & MacroContext>
 						schema: Prettify<
 							MergeSchema<
-								UnwrapRoute<
-									LocalSchema,
-									Definitions['typebox']
-								>,
+								UnwrapRoute<Input, Definitions['typebox']>,
 								Metadata['schema']
 							>
 						>
@@ -3298,7 +3294,7 @@ export default class Elysia<
 							schema: Prettify<
 								MergeSchema<
 									UnwrapRoute<
-										LocalSchema,
+										Input,
 										Definitions['typebox'],
 										BasePath
 									>,
@@ -3327,10 +3323,7 @@ export default class Elysia<
 							>
 							schema: Prettify<
 								MergeSchema<
-									UnwrapRoute<
-										LocalSchema,
-										Definitions['typebox']
-									>,
+									UnwrapRoute<Input, Definitions['typebox']>,
 									Metadata['schema'] & Ephemeral['schema']
 								>
 							>
@@ -3354,7 +3347,7 @@ export default class Elysia<
 						resolve: Prettify<Volatile['resolve'] & MacroContext>
 						schema: Volatile['schema']
 						standaloneSchema: Volatile['standaloneSchema'] &
-							UnwrapRoute<LocalSchema, Definitions['typebox']>
+							UnwrapRoute<Input, Definitions['typebox']>
 					}
 				>
 			: AsType extends 'global'
@@ -3372,7 +3365,7 @@ export default class Elysia<
 						{
 							schema: Metadata['schema']
 							standaloneSchema: UnwrapRoute<
-								LocalSchema,
+								Input,
 								Definitions['typebox'],
 								BasePath
 							> &
@@ -3398,27 +3391,25 @@ export default class Elysia<
 							>
 							schema: Ephemeral['schema']
 							standaloneSchema: Ephemeral['standaloneSchema'] &
-								UnwrapRoute<LocalSchema, Definitions['typebox']>
+								UnwrapRoute<Input, Definitions['typebox']>
 						},
 						Volatile
 					>
 
 	guard<
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
-			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>
 	>(
 		hook: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
@@ -3427,7 +3418,6 @@ export default class Elysia<
 					MacroContext
 			},
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -3442,7 +3432,7 @@ export default class Elysia<
 			resolve: Prettify<Volatile['resolve'] & MacroContext>
 			schema: Prettify<
 				MergeSchema<
-					UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+					UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 					MergeSchema<
 						Volatile['schema'],
 						MergeSchema<Ephemeral['schema'], Metadata['schema']>
@@ -3462,10 +3452,10 @@ export default class Elysia<
 			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
+		const Input extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>
 	>(
 		run: (
@@ -3501,29 +3491,26 @@ export default class Elysia<
 	>
 
 	guard<
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const NewElysia extends AnyElysia,
 		const Schema extends MergeSchema<
-			UnwrapRoute<LocalSchema, Definitions['typebox'], BasePath>,
+			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 			Metadata['schema']
 		>,
-		const Macro extends Metadata['macro'],
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			NoInfer<Macro>
+			NoInfer<Omit<Input, keyof InputSchema>>
 		>
 	>(
 		schema: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
 			},
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>,
 		run: (
@@ -4611,12 +4598,11 @@ export default class Elysia<
 	 */
 	get<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4628,27 +4614,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4697,12 +4682,11 @@ export default class Elysia<
 	 */
 	post<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4714,27 +4698,28 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
+			NoInfer<Decorator>,
 			JoinPath<BasePath, Path>
 		>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4783,12 +4768,11 @@ export default class Elysia<
 	 */
 	put<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4800,27 +4784,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4869,12 +4852,11 @@ export default class Elysia<
 	 */
 	patch<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4886,27 +4868,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -4955,12 +4936,11 @@ export default class Elysia<
 	 */
 	delete<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -4972,27 +4952,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5041,12 +5020,11 @@ export default class Elysia<
 	 */
 	options<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5058,27 +5036,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5127,12 +5104,11 @@ export default class Elysia<
 	 */
 	all<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5144,27 +5120,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5213,12 +5188,11 @@ export default class Elysia<
 	 */
 	head<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5230,27 +5204,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5299,12 +5272,11 @@ export default class Elysia<
 	 */
 	connect<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5316,27 +5288,26 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		>
 	): Elysia<
@@ -5386,12 +5357,11 @@ export default class Elysia<
 	route<
 		const Method extends HTTPMethod,
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5403,28 +5373,27 @@ export default class Elysia<
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
 			Volatile['standaloneSchema'],
-		const Macro extends Metadata['macro'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] &
 				Volatile['resolve'] &
-				MacroToContext<Metadata['macroFn'], Macro>
+				MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>
+				>
 		},
 		const Handle extends InlineHandler<
 			NoInfer<Schema>,
-			Decorator,
-			JoinPath<BasePath, Path>
-		>
+			Decorator>
 	>(
 		method: Method,
 		path: Path,
 		handler: Handle,
 		hook?: LocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Decorator,
 			Definitions['error'],
-			Macro,
 			keyof Metadata['parser']
 		> & {
 			config?: {
@@ -5479,12 +5448,11 @@ export default class Elysia<
 	 */
 	ws<
 		const Path extends string,
-		const LocalSchema extends InputSchema<
-			keyof Definitions['typebox'] & string
-		>,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
 		const Schema extends MergeSchema<
 			UnwrapRoute<
-				LocalSchema,
+				Input,
 				Definitions['typebox'],
 				JoinPath<BasePath, Path>
 			>,
@@ -5492,20 +5460,21 @@ export default class Elysia<
 				Volatile['schema'],
 				MergeSchema<Ephemeral['schema'], Metadata['schema']>
 			>
-		>,
-		const Macro extends Metadata['macro']
+		>
 	>(
 		path: Path,
 		options: WSLocalHook<
-			LocalSchema,
+			Input,
 			Schema,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] &
 					Volatile['resolve'] &
-					MacroToContext<Metadata['macroFn'], Macro>
-			},
-			Macro
+					MacroToContext<
+						Metadata['macroFn'],
+						Omit<Input, NonResolvableMacroKey>
+					>
+			}
 		>
 	): Elysia<
 		BasePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6800,7 +6800,11 @@ export default class Elysia<
 export { Elysia }
 
 export { t } from './type-system'
-export { validationDetail } from './type-system/utils'
+export {
+	validationDetail,
+	validateFile,
+	validateFileExtension
+} from './type-system/utils'
 export type {
 	ElysiaTypeCustomError,
 	ElysiaTypeCustomErrorCallback

--- a/src/index.ts
+++ b/src/index.ts
@@ -5816,9 +5816,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -5919,9 +5917,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6022,9 +6018,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6125,9 +6119,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6228,9 +6220,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6331,9 +6321,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6434,9 +6422,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6538,9 +6524,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const Decorator extends Singleton & {
+			Volatile['standaloneSchema'],		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
@@ -6648,9 +6632,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
-		const MacroContext extends MacroToContext<
+			Volatile['standaloneSchema'],		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
 			Omit<Input, NonResolvableMacroKey>
 		>

--- a/src/index.ts
+++ b/src/index.ts
@@ -669,7 +669,7 @@ export default class Elysia<
 							models,
 							normalize,
 							validators: standaloneValidators.map(
-								(x) => x.response
+								(x) => x.response as any
 							),
 							sanitize
 						})
@@ -769,7 +769,7 @@ export default class Elysia<
 									models,
 									normalize,
 									validators: standaloneValidators.map(
-										(x) => x.response
+										(x) => x.response as any
 									),
 									sanitize
 								}

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ import {
 	type ParseError,
 	type NotFoundError,
 	type InternalServerError,
-	ElysiaCustomStatusResponse
+	type ElysiaCustomStatusResponse
 } from './error'
 
 import type { TraceHandler } from './trace'
@@ -147,28 +147,21 @@ import type {
 	ValidatorLayer,
 	MergeElysiaInstances,
 	HookMacroFn,
-	ResolveHandler,
-	ResolveResolutions,
-	UnwrapTypeModule,
 	MacroToContext,
 	StandaloneValidator,
 	GuardSchemaType,
 	Or,
-	MergeStandaloneSchema,
 	IsNever,
 	DocumentDecoration,
 	AfterHandler,
-	AnyBaseHookLifeCycle,
 	NonResolvableMacroKey,
 	StandardSchemaV1Like,
 	ElysiaHandlerToResponseSchema,
 	ElysiaHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
-	UnionToIntersect,
 	ElysiaHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
-	IsAny,
 	SimplifyToSchema
 } from './types'
 
@@ -3905,15 +3898,6 @@ export default class Elysia<
 			Metadata['schema']
 		> &
 			Metadata['standaloneSchema'],
-		const Resolutions extends MaybeArray<
-			ResolveHandler<
-				Schema,
-				Singleton & {
-					derive: Ephemeral['derive'] & Volatile['derive']
-					resolve: Ephemeral['resolve'] & Volatile['resolve']
-				}
-			>
-		>
 	>(
 		prefix: Prefix,
 		schema: LocalHook<
@@ -3940,8 +3924,7 @@ export default class Elysia<
 					resolve: Prettify<
 						Singleton['resolve'] &
 							Ephemeral['resolve'] &
-							Volatile['resolve'] &
-							ResolveResolutions<Resolutions>
+							Volatile['resolve']
 					>
 				},
 				Definitions,
@@ -5295,7 +5278,7 @@ export default class Elysia<
 	>
 
 	macro<
-		NewMacro extends HookMacroFn<
+		const NewMacro extends HookMacroFn<
 			Metadata['schema'],
 			Singleton & {
 				derive: Partial<Ephemeral['derive'] & Volatile['derive']>

--- a/src/index.ts
+++ b/src/index.ts
@@ -3923,7 +3923,7 @@ export default class Elysia<
 				},
 				Definitions,
 				{
-					schema: Prettify<Schema>
+					schema: Schema
 					standaloneSchema: Metadata['standaloneSchema']
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
@@ -4121,7 +4121,10 @@ export default class Elysia<
 					{
 						derive: Volatile['derive']
 						resolve: Prettify<Volatile['resolve'] & MacroContext>
-						schema: {} extends PickIfExists<Input, keyof InputSchema>
+						schema: {} extends PickIfExists<
+							Input,
+							keyof InputSchema
+						>
 							? Volatile['schema']
 							: Prettify<
 									MergeSchema<
@@ -4152,7 +4155,10 @@ export default class Elysia<
 						},
 						Definitions,
 						{
-							schema: {} extends PickIfExists<Input, keyof InputSchema>
+							schema: {} extends PickIfExists<
+								Input,
+								keyof InputSchema
+							>
 								? Metadata['schema']
 								: Prettify<
 										MergeSchema<
@@ -4188,7 +4194,10 @@ export default class Elysia<
 							resolve: Prettify<
 								Ephemeral['resolve'] & MacroContext
 							>
-							schema: {} extends PickIfExists<Input, keyof InputSchema>
+							schema: {} extends PickIfExists<
+								Input,
+								keyof InputSchema
+							>
 								? EphemeralType['schema']
 								: Prettify<
 										MergeSchema<
@@ -4337,7 +4346,7 @@ export default class Elysia<
 				},
 				Definitions,
 				{
-					schema: Prettify<Schema>
+					schema: Schema
 					standaloneSchema: Metadata['standaloneSchema']
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
@@ -4506,7 +4515,13 @@ export default class Elysia<
 		this.model(sandbox.definitions.type)
 
 		Object.values(instance.router.history).forEach(
-			({ method, path, handler, hooks: localHook }) => {
+			({
+				method,
+				path,
+				handler,
+				hooks: localHook,
+				standaloneValidators
+			}) => {
 				this.add(
 					method,
 					path,
@@ -4524,7 +4539,9 @@ export default class Elysia<
 										localHook.error,
 										...(sandbox.event.error ?? [])
 									]
-					})
+					}),
+					undefined,
+					standaloneValidators
 				)
 			}
 		)
@@ -6325,7 +6342,10 @@ export default class Elysia<
 				Volatile['schema'],
 				MergeSchema<Ephemeral['schema'], Metadata['schema']>
 			>
-		>
+		> &
+			Metadata['standaloneSchema'] &
+			Ephemeral['standaloneSchema'] &
+			Volatile['standaloneSchema']
 	>(
 		path: Path,
 		options: WSLocalHook<

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,8 @@ import type {
 	UnionToIntersect,
 	ElysiaHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
-	PickIfExists
+	PickIfExists,
+	IsAny
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>
@@ -5530,7 +5531,12 @@ export default class Elysia<
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								(IsAny<
+									Decorator['resolve']['response']
+								> extends true
+									? {}
+									: Decorator['resolve']['response'])
 						>
 					}
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,11 @@ import { Memoirist } from 'memoirist'
 import {
 	Kind,
 	type TObject,
-	type Static,
 	type TSchema,
 	type TModule,
 	type TRef,
 	type TProperties,
-	TAnySchema
+	type TAnySchema
 } from '@sinclair/typebox'
 
 import fastDecodeURIComponent from 'fast-decode-uri-component'
@@ -82,13 +81,13 @@ import {
 } from './dynamic-handle'
 
 import {
+	status,
 	ERROR_CODE,
 	ValidationError,
 	type ParseError,
 	type NotFoundError,
 	type InternalServerError,
-	ElysiaCustomStatusResponse,
-	status
+	ElysiaCustomStatusResponse
 } from './error'
 
 import type { TraceHandler } from './trace'
@@ -6792,11 +6791,7 @@ export default class Elysia<
 export { Elysia }
 
 export { t } from './type-system'
-export {
-	validationDetail,
-	validateFile,
-	validateFileExtension
-} from './type-system/utils'
+export { validationDetail, fileType } from './type-system/utils'
 export type {
 	ElysiaTypeCustomError,
 	ElysiaTypeCustomErrorCallback

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,8 @@ import type {
 	ElysiaHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
-	IsAny
+	IsAny,
+	SimplifyToSchema
 } from './types'
 
 export type AnyElysia = Elysia<any, any, any, any, any, any, any>
@@ -4117,15 +4118,13 @@ export default class Elysia<
 		>,
 		const GuardType extends GuardSchemaType,
 		const AsType extends LifeCycleType,
-		const BeforeHandle extends
-			| MaybeArray<OptionalHandler<Schema, Singleton>>
-			| undefined,
-		const AfterHandle extends
-			| MaybeArray<AfterHandler<Schema, Singleton>>
-			| undefined,
-		const ErrorHandle extends
-			| MaybeArray<ErrorHandler<Definitions['error'], Schema, Singleton>>
-			| undefined
+		const BeforeHandle extends MaybeArray<
+			OptionalHandler<Schema, Singleton>
+		>,
+		const AfterHandle extends MaybeArray<AfterHandler<Schema, Singleton>>,
+		const ErrorHandle extends MaybeArray<
+			ErrorHandler<Definitions['error'], Schema, Singleton>
+		>
 	>(
 		hook: GuardLocalHook<
 			Input,
@@ -4177,11 +4176,14 @@ export default class Elysia<
 										Metadata['schema']
 									>
 								>
-						standaloneSchema: Volatile['standaloneSchema']
+						standaloneSchema: Volatile['standaloneSchema'] &
+							SimplifyToSchema<MacroContext>
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							// @ts-ignore
+							MacroContext['return']
 					}
 				>
 			: AsType extends 'global'
@@ -4214,14 +4216,17 @@ export default class Elysia<
 											Metadata['schema']
 										>
 									>
-							standaloneSchema: Metadata['standaloneSchema']
+							standaloneSchema: Metadata['standaloneSchema'] &
+								SimplifyToSchema<MacroContext>
 							macro: Metadata['macro']
 							macroFn: Metadata['macroFn']
 							parser: Metadata['parser']
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								// @ts-ignore
+								MacroContext['return']
 						},
 						Routes,
 						Ephemeral,
@@ -4255,11 +4260,14 @@ export default class Elysia<
 												Ephemeral['schema']
 										>
 									>
-							standaloneSchema: Ephemeral['standaloneSchema']
+							standaloneSchema: Ephemeral['standaloneSchema'] &
+								SimplifyToSchema<MacroContext>
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								// @ts-ignore
+								MacroContext['return']
 						},
 						Volatile
 					>
@@ -4282,17 +4290,23 @@ export default class Elysia<
 								MacroContext['resolve']
 						>
 						schema: Volatile['schema']
-						standaloneSchema: {} extends PickIfExists<
+						standaloneSchema: ({} extends PickIfExists<
 							Input,
 							keyof InputSchema
 						>
 							? Volatile['standaloneSchema']
 							: Volatile['standaloneSchema'] &
-									UnwrapRoute<Input, Definitions['typebox']>
+									UnwrapRoute<
+										Input,
+										Definitions['typebox']
+									>) &
+							SimplifyToSchema<MacroContext>
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							// @ts-ignore
+							MacroContext['return']
 					}
 				>
 			: AsType extends 'global'
@@ -4311,7 +4325,7 @@ export default class Elysia<
 						Definitions,
 						{
 							schema: Metadata['schema']
-							standaloneSchema: {} extends PickIfExists<
+							standaloneSchema: ({} extends PickIfExists<
 								Input,
 								keyof InputSchema
 							>
@@ -4321,14 +4335,17 @@ export default class Elysia<
 										Definitions['typebox'],
 										BasePath
 									> &
-										Metadata['standaloneSchema']
+										Metadata['standaloneSchema']) &
+								SimplifyToSchema<MacroContext>
 							macro: Metadata['macro']
 							macroFn: Metadata['macroFn']
 							parser: Metadata['parser']
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								// @ts-ignore
+								MacroContext['return']
 						},
 						Routes,
 						Ephemeral,
@@ -4348,7 +4365,7 @@ export default class Elysia<
 									MacroContext['resolve']
 							>
 							schema: Ephemeral['schema']
-							standaloneSchema: {} extends PickIfExists<
+							standaloneSchema: ({} extends PickIfExists<
 								Input,
 								keyof InputSchema
 							>
@@ -4357,11 +4374,14 @@ export default class Elysia<
 										UnwrapRoute<
 											Input,
 											Definitions['typebox']
-										>
+										>) &
+								SimplifyToSchema<MacroContext>
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								// @ts-ignore
+								MacroContext['return']
 						},
 						Volatile
 					>
@@ -5275,7 +5295,7 @@ export default class Elysia<
 	>
 
 	macro<
-		const NewMacro extends HookMacroFn<
+		NewMacro extends HookMacroFn<
 			Metadata['schema'],
 			Singleton & {
 				derive: Partial<Ephemeral['derive'] & Volatile['derive']>
@@ -5556,7 +5576,11 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema & MacroContext,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
@@ -5651,13 +5675,20 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema & MacroContext,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
 								Volatile['response'] &
 								// @ts-ignore
-								MacroContext['return']
+								MacroContext['return'] &
+								Metadata['standaloneSchema']['response'] &
+								Ephemeral['standaloneSchema']['response'] &
+								Volatile['standaloneSchema']['response']
 						>
 					}
 				}
@@ -5706,14 +5737,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5741,11 +5777,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -5794,14 +5836,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5829,11 +5876,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -5882,14 +5935,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -5917,11 +5975,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -5970,14 +6034,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -6005,11 +6074,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -6058,14 +6133,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -6093,11 +6173,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -6146,14 +6232,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -6181,11 +6272,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -6234,14 +6331,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		path: Path,
 		handler: Handle,
@@ -6269,11 +6371,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}
@@ -6323,14 +6431,19 @@ export default class Elysia<
 			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
-			resolve: Ephemeral['resolve'] &
-				Volatile['resolve'] &
-				MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>
-				>
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
 		},
-		const Handle extends InlineHandler<NoInfer<Schema>, Decorator>
+		const MacroContext extends MacroToContext<
+			Metadata['macroFn'],
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
+		>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
 	>(
 		method: Method,
 		path: Path,
@@ -6364,11 +6477,17 @@ export default class Elysia<
 						query: Schema['query']
 						headers: Schema['headers']
 						response: ComposeElysiaResponse<
-							Schema,
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								// @ts-ignore
+								MacroContext['return']
 						>
 					}
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6233,7 +6233,7 @@ export default class Elysia<
 	>
 
 	model<
-		const Recorder extends Record<string, TAnySchema | StandardSchemaV1Like>
+		const Recorder extends Record<string, TSchema | StandardSchemaV1Like>
 	>(
 		record: Recorder
 	): Elysia<
@@ -6249,13 +6249,11 @@ export default class Elysia<
 		Volatile
 	>
 
-	model<
-		const NewType extends Record<string, TAnySchema | StandardSchemaV1Like>
-	>(
+	model<const NewType extends Record<string, TSchema | StandardSchemaV1Like>>(
 		mapper: (
 			decorators: Definitions['typebox'] extends infer Models
 				? {
-						[Name in keyof Models]: Models[Name] extends TAnySchema
+						[Name in keyof Models]: Models[Name] extends TSchema
 							? TRef<Name & string>
 							: Models[Name]
 					}
@@ -6287,7 +6285,7 @@ export default class Elysia<
 			| Record<string, TAnySchema | StandardSchemaV1Like>
 			| Function,
 		model?: TAnySchema | StandardSchemaV1Like
-	) {
+	): AnyElysia {
 		const onlyTypebox = <
 			A extends Record<string, TAnySchema | StandardSchemaV1Like>
 		>(
@@ -6355,7 +6353,7 @@ export default class Elysia<
 				return this
 		}
 
-		if(!model) return this
+		if (!model) return this
 
 		this.definitions.type[name] = model!
 		if ('~standard' in model) return this

--- a/src/index.ts
+++ b/src/index.ts
@@ -5632,7 +5632,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -5647,12 +5647,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					get: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5716,8 +5726,7 @@ export default class Elysia<
 		> &
 			Metadata['standaloneSchema'] &
 			Ephemeral['standaloneSchema'] &
-			Volatile['standaloneSchema'] &
-			MacroContext,
+			Volatile['standaloneSchema'],
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']
 			resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -5738,7 +5747,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -5753,12 +5762,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					post: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5844,7 +5863,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -5859,12 +5878,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					put: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5872,11 +5901,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -5944,7 +5979,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -5959,12 +5994,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					patch: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -5972,11 +6017,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -6044,7 +6095,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -6059,12 +6110,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					delete: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6072,11 +6133,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -6144,7 +6211,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -6159,12 +6226,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					options: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6172,11 +6249,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -6244,7 +6327,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -6259,12 +6342,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					[method in string]: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6272,11 +6365,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -6344,7 +6443,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -6359,12 +6458,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					head: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6372,11 +6481,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -6444,7 +6559,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -6459,12 +6574,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					connect: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6472,11 +6597,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}
@@ -6546,7 +6677,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
-			Schema,
+			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
@@ -6566,12 +6697,22 @@ export default class Elysia<
 				JoinPath<BasePath, Path>,
 				{
 					[method in Method]: {
-						body: Schema['body']
-						params: IsNever<keyof Schema['params']> extends true
+						// @ts-ignore
+						body: Schema['body'] & MacroContext['body']
+						params: IsNever<
+							// @ts-ignore
+							keyof (Schema['params'] & MacroContext['params'])
+						> extends true
 							? ResolvePath<Path>
-							: Schema['params']
-						query: Schema['query']
-						headers: Schema['headers']
+							: Schema['params'] &
+									// @ts-ignore
+									MacroContext['body']
+						query: Schema['query'] &
+							// @ts-ignore
+							MacroContext['body']
+						headers: Schema['headers'] &
+							// @ts-ignore
+							MacroContext['body']
 						response: ComposeElysiaResponse<
 							Schema &
 								MacroContext &
@@ -6579,11 +6720,17 @@ export default class Elysia<
 								Ephemeral['standaloneSchema'] &
 								Volatile['standaloneSchema'],
 							Handle,
-							Metadata['response'] &
-								Ephemeral['response'] &
-								Volatile['response'] &
-								// @ts-ignore
-								MacroContext['return']
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
 						>
 					}
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5616,7 +5616,8 @@ export default class Elysia<
 		>,
 		const MacroContext extends MacroToContext<
 			Metadata['macroFn'],
-			Omit<Input, NonResolvableMacroKey>
+			Omit<Input, NonResolvableMacroKey>,
+			Definitions['typebox']
 		>,
 		const Decorator extends Singleton & {
 			derive: Ephemeral['derive'] & Volatile['derive']

--- a/src/index.ts
+++ b/src/index.ts
@@ -6793,7 +6793,6 @@ export {
 
 export {
 	status,
-	error,
 	mapValueError,
 	ParseError,
 	NotFoundError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,8 @@ import {
 	getSchemaValidator,
 	getResponseSchemaValidator,
 	getCookieValidator,
-	ElysiaTypeCheck
+	ElysiaTypeCheck,
+	queryCoercions
 } from './schema'
 import {
 	composeHandler,
@@ -653,7 +654,7 @@ export default class Elysia<
 							models,
 							normalize,
 							coerce: true,
-							additionalCoerce: stringToStructureCoercions(),
+							additionalCoerce: queryCoercions(),
 							validators: standaloneValidators.map(
 								(x) => x.query
 							),
@@ -739,8 +740,7 @@ export default class Elysia<
 									dynamic,
 									models,
 									coerce: true,
-									additionalCoerce:
-										stringToStructureCoercions(),
+									additionalCoerce: queryCoercions(),
 									validators: standaloneValidators.map(
 										(x) => x.query
 									),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5531,7 +5531,12 @@ export default class Elysia<
 							Handle,
 							Metadata['response'] &
 								Ephemeral['response'] &
-								Volatile['response']
+								Volatile['response'] &
+								(IsNever<
+									Decorator['resolve']['response']
+								> extends false
+									? Decorator['resolve']['response']
+									: {})
 						>
 					}
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3911,7 +3911,12 @@ export default class Elysia<
 		prefix: Prefix,
 		schema: LocalHook<
 			Input,
-			Schema,
+			// @ts-ignore
+			Schema & {
+				response: {}
+				return: {}
+				resolve: {}
+			},
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -4417,7 +4422,8 @@ export default class Elysia<
 	>(
 		schema: LocalHook<
 			Input,
-			Schema,
+			// @ts-ignore
+			Schema & MacroContext,
 			Singleton & {
 				derive: Ephemeral['derive'] & Volatile['derive']
 				resolve: Ephemeral['resolve'] & Volatile['resolve']
@@ -5659,8 +5665,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -5761,6 +5767,7 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
 			Decorator,
 			Definitions['error'],
@@ -5863,8 +5870,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -5965,8 +5972,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -6067,8 +6074,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -6169,8 +6176,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -6271,8 +6278,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -6373,8 +6380,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -6475,8 +6482,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		>
@@ -6579,8 +6586,8 @@ export default class Elysia<
 		handler: Handle,
 		hook?: LocalHook<
 			Input,
+			// @ts-ignore
 			Schema & MacroContext,
-			Decorator,
 			Definitions['error'],
 			keyof Metadata['parser']
 		> & {

--- a/src/parse-query.ts
+++ b/src/parse-query.ts
@@ -118,6 +118,130 @@ export function parseQueryFromURL(
  * @callback parse
  * @param {string} input
  */
+export function parseQueryStandardSchema(
+	input: string,
+	startIndex: number = 0
+) {
+	const result = Object.create(null) as Record<string, string | string[]>
+
+	let flags = 0
+
+	const inputLength = input.length
+	let startingIndex = startIndex - 1
+	let equalityIndex = startingIndex
+
+	for (let i = 0; i < inputLength; i++)
+		switch (input.charCodeAt(i)) {
+			// '&'
+			case 38:
+				processKeyValuePair(input, i)
+
+				// Reset state variables
+				startingIndex = i
+				equalityIndex = i
+				flags = 0
+
+				break
+
+			// '='
+			case 61:
+				if (equalityIndex <= startingIndex) equalityIndex = i
+				// If '=' character occurs again, we should decode the input
+				else flags |= VALUE_NEEDS_DECODE
+
+				break
+
+			// '+'
+			case 43:
+				if (equalityIndex > startingIndex) flags |= VALUE_HAS_PLUS
+				else flags |= KEY_HAS_PLUS
+
+				break
+
+			// '%'
+			case 37:
+				if (equalityIndex > startingIndex) flags |= VALUE_NEEDS_DECODE
+				else flags |= KEY_NEEDS_DECODE
+
+				break
+		}
+
+	// Process the last pair if needed
+	if (startingIndex < inputLength) processKeyValuePair(input, inputLength)
+
+	return result
+
+	function processKeyValuePair(input: string, endIndex: number) {
+		const hasBothKeyValuePair = equalityIndex > startingIndex
+		const effectiveEqualityIndex = hasBothKeyValuePair
+			? equalityIndex
+			: endIndex
+
+		const keySlice = input.slice(startingIndex + 1, effectiveEqualityIndex)
+
+		// Skip processing if key is empty
+		if (!hasBothKeyValuePair && keySlice.length === 0) return
+
+		let finalKey = keySlice
+		if (flags & KEY_HAS_PLUS) finalKey = finalKey.replace(/\+/g, ' ')
+		if (flags & KEY_NEEDS_DECODE) finalKey = decode(finalKey) || finalKey
+
+		let finalValue = ''
+		if (hasBothKeyValuePair) {
+			let valueSlice = input.slice(equalityIndex + 1, endIndex)
+			if (flags & VALUE_HAS_PLUS)
+				valueSlice = valueSlice.replace(/\+/g, ' ')
+			if (flags & VALUE_NEEDS_DECODE)
+				valueSlice = decode(valueSlice) || valueSlice
+			finalValue = valueSlice
+		}
+
+		const currentValue = result[finalKey]
+
+		if (
+			finalValue.charCodeAt(0) === 91 &&
+			finalValue.charCodeAt(finalValue.length - 1) === 93
+		) {
+			try {
+				// @ts-ignore
+				finalValue = JSON.parse(finalValue)
+			} catch {
+				// If JSON parsing fails, treat it as a regular string
+			}
+
+			if (currentValue === undefined) result[finalKey] = finalValue
+			else if (Array.isArray(currentValue)) currentValue.push(finalValue)
+			else result[finalKey] = [currentValue, finalValue]
+		} else if (
+			finalValue.charCodeAt(0) === 123 &&
+			finalValue.charCodeAt(finalValue.length - 1) === 125
+		) {
+			try {
+				// @ts-ignore
+				finalValue = JSON.parse(finalValue)
+			} catch {
+				// If JSON parsing fails, treat it as a regular string
+			}
+
+			if (currentValue === undefined) result[finalKey] = finalValue
+			else if (Array.isArray(currentValue)) currentValue.push(finalValue)
+			else result[finalKey] = [currentValue, finalValue]
+		} else {
+			if (finalValue.includes(','))
+				// @ts-ignore
+				finalValue = finalValue.split(',')
+
+			if (currentValue === undefined) result[finalKey] = finalValue
+			else if (Array.isArray(currentValue)) currentValue.push(finalValue)
+			else result[finalKey] = [currentValue, finalValue]
+		}
+	}
+}
+
+/**
+ * @callback parse
+ * @param {string} input
+ */
 export function parseQuery(input: string) {
 	const result = Object.create(null) as Record<string, string | string[]>
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -753,6 +753,7 @@ export const getSchemaValidator = <
 		modules,
 		normalize = false,
 		additionalProperties = false,
+		forceAdditionalProperties = false,
 		coerce = false,
 		additionalCoerce = [],
 		validators,
@@ -761,6 +762,7 @@ export const getSchemaValidator = <
 		models?: Record<string, TSchema>
 		modules?: TModule<any, any>
 		additionalProperties?: boolean
+		forceAdditionalProperties?: boolean
 		dynamic?: boolean
 		normalize?: ElysiaConfig<''>['normalize']
 		coerce?: boolean
@@ -891,6 +893,7 @@ export const getSchemaValidator = <
 				dynamic,
 				normalize,
 				additionalProperties: true,
+				forceAdditionalProperties: true,
 				coerce,
 				additionalCoerce
 			})!
@@ -900,10 +903,11 @@ export const getSchemaValidator = <
 
 			// @ts-ignore
 			return (v) => {
-				if (vali.Check(v))
+				if (vali.Check(v)) {
 					return {
 						value: vali.Decode(v)
 					}
+				}
 				else
 					return {
 						issues: [...vali.Errors(v)]
@@ -1054,7 +1058,8 @@ export const getSchemaValidator = <
 	} else {
 		if (
 			schema.type === 'object' &&
-			'additionalProperties' in schema === false
+			('additionalProperties' in schema === false ||
+				forceAdditionalProperties)
 		)
 			schema.additionalProperties = additionalProperties
 		else

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1523,14 +1523,12 @@ export const getResponseSchemaValidator = (
 	// @ts-ignore
 	if (typeof s !== 'string') maybeSchemaOrRecord = s!
 	else {
-		const isArray = s.endsWith('[]')
-		const key = isArray ? s.substring(0, s.length - 2) : s
+		maybeSchemaOrRecord = // @ts-expect-error private property
+			modules && s in modules.$defs
+				? (modules as TModule<{}, {}>).Import(s as never)
+				: models[s]
 
-		maybeSchemaOrRecord =
-			(modules as TModule<{}, {}>).Import(key as never) ?? models[key]
-
-		if (isArray)
-			maybeSchemaOrRecord = t.Array(maybeSchemaOrRecord as TSchema)
+		if (!maybeSchemaOrRecord) return undefined as any
 	}
 
 	if (!maybeSchemaOrRecord) return

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -540,9 +540,9 @@ const _replaceSchemaType = (
 				v.default === '{}'
 			) {
 				transform = t.ObjectString(properties, rest)
-				value.default = JSON.stringify(
-					Value.Create(t.Object(properties))
-				)
+				// value.default = JSON.stringify(
+				// 	Value.Create(t.Object(properties))
+				// )
 				value.properties = properties
 			}
 
@@ -554,7 +554,7 @@ const _replaceSchemaType = (
 				v.default === '[]'
 			) {
 				transform = t.ArrayString(items, rest)
-				value.default = JSON.stringify(Value.Create(t.Array(items)))
+				// value.default = JSON.stringify(Value.Create(t.Array(items)))
 				value.items = items
 			}
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -28,8 +28,8 @@ import type {
 	MaybeArray,
 	StandaloneInputSchema
 } from './types'
-import { StandardSchemaV1 } from '@standard-schema/spec'
-import { fa } from 'zod/locales'
+
+import type { StandardSchemaV1Like } from './types'
 
 type MapValueError = ReturnType<typeof mapValueError>
 
@@ -743,7 +743,7 @@ const createCleaner = (schema: TAnySchema) => (value: unknown) => {
 // const caches = <Record<string, ElysiaTypeCheck<any>>>{}
 
 export const getSchemaValidator = <
-	T extends TSchema | StandardSchemaV1 | string | undefined
+	T extends TSchema | StandardSchemaV1Like | string | undefined
 >(
 	s: T,
 	{
@@ -801,10 +801,10 @@ export const getSchemaValidator = <
 	}
 
 	const mapSchema = (
-		s: string | TSchema | StandardSchemaV1 | undefined
-	): TSchema | StandardSchemaV1 => {
+		s: string | TSchema | StandardSchemaV1Like | undefined
+	): TSchema | StandardSchemaV1Like => {
 		if (s && typeof s !== 'string' && '~standard' in s)
-			return s as StandardSchemaV1
+			return s as StandardSchemaV1Like
 
 		let schema: TSchema
 
@@ -1053,6 +1053,7 @@ export const getSchemaValidator = <
 				Code: () => '',
 				// @ts-ignore
 				Decode(value) {
+					// @ts-ignore
 					const response = schema['~standard'].validate(value)
 
 					if (response instanceof Promise)
@@ -1141,6 +1142,7 @@ export const getSchemaValidator = <
 			schema,
 			references: '',
 			checkFunc(value: unknown) {
+				// @ts-ignore
 				const response = schema['~standard'].validate(value)
 
 				if (response instanceof Promise)
@@ -1168,6 +1170,7 @@ export const getSchemaValidator = <
 			Code: () => '',
 			// @ts-ignore
 			Decode(value) {
+				// @ts-ignore
 				const response = schema['~standard'].validate(value)
 
 				if (response instanceof Promise)
@@ -1358,9 +1361,10 @@ export const getResponseSchemaValidator = (
 
 	let maybeSchemaOrRecord:
 		| TSchema
-		| StandardSchemaV1
-		| Record<number, string | TSchema | StandardSchemaV1>
+		| StandardSchemaV1Like
+		| Record<number, string | TSchema | StandardSchemaV1Like>
 
+	// @ts-ignore
 	if (typeof s !== 'string') maybeSchemaOrRecord = s!
 	else {
 		const isArray = s.endsWith('[]')
@@ -1378,7 +1382,7 @@ export const getResponseSchemaValidator = (
 	if (Kind in maybeSchemaOrRecord || '~standard' in maybeSchemaOrRecord)
 		return {
 			200: getSchemaValidator(
-				maybeSchemaOrRecord as TSchema | StandardSchemaV1,
+				maybeSchemaOrRecord as TSchema | StandardSchemaV1Like,
 				{
 					modules,
 					models,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -930,17 +930,47 @@ export const getSchemaValidator = <
 	if (dynamic) {
 		if (Kind in schema) {
 			const validator: ElysiaTypeCheck<any> = {
+				provider: 'standard',
 				schema,
 				references: '',
-				checkFunc: () => {},
+				checkFunc(value: unknown) {
+					const response = schema['~standard']['validate'](value)
+
+					if (response instanceof Promise)
+						throw Error(
+							'Async validation is not supported in non-dynamic schema'
+						)
+
+					return response
+				},
 				code: '',
-				// @ts-expect-error
-				Check: (value: unknown) => Value.Check(schema, value),
-				Errors: (value: unknown) => Value.Errors(schema, value),
+				Check: schema['~standard']['validate'],
+				// @ts-ignore
+				Errors(value: unknown) {
+					// @ts-ignore
+					const response = schema['~standard']['validate'](value)
+
+					if (response instanceof Promise)
+						throw Error(
+							'Async validation is not supported in non-dynamic schema'
+						)
+
+					return response.issues
+				},
 				Code: () => '',
-				Clean: createCleaner(schema),
-				Decode: (value: unknown) => Value.Decode(schema, value),
-				Encode: (value: unknown) => Value.Encode(schema, value),
+				// @ts-ignore
+				Decode(value) {
+					const response = schema['~standard']['validate'](value)
+
+					if (response instanceof Promise)
+						throw Error(
+							'Async validation is not supported in non-dynamic schema'
+						)
+
+					return response
+				},
+				// @ts-ignore
+				Encode: (value: unknown) => value,
 				get hasAdditionalProperties() {
 					if ('~hasAdditionalProperties' in this)
 						return this['~hasAdditionalProperties'] as boolean
@@ -1036,16 +1066,7 @@ export const getSchemaValidator = <
 				checkFunc: () => {},
 				code: '',
 				// @ts-ignore
-				Check(value) {
-					const response = schema['~standard']['validate'](value)
-
-					if (response instanceof Promise)
-						throw Error(
-							'Async validation is not supported in non-dynamic schema'
-						)
-
-					return response
-				},
+				Check: schema['~standard']['validate'],
 				// @ts-ignore
 				Errors(value: unknown) {
 					// @ts-ignore
@@ -1122,10 +1143,7 @@ export const getSchemaValidator = <
 			provider: 'standard',
 			schema,
 			references: '',
-			checkFunc: () => {},
-			code: '',
-			// @ts-ignore
-			Check(value) {
+			checkFunc(value: unknown) {
 				const response = schema['~standard']['validate'](value)
 
 				if (response instanceof Promise)
@@ -1135,6 +1153,9 @@ export const getSchemaValidator = <
 
 				return response
 			},
+			code: '',
+			// @ts-ignore
+			Check: schema['~standard']['validate'],
 			// @ts-ignore
 			Errors(value: unknown) {
 				// @ts-ignore

--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -49,6 +49,7 @@ import { ValidationError } from '../error'
 import { parseDateTimeEmptySpace } from './format'
 import { replaceSchemaType } from '../schema'
 import { isJSDocDeprecatedTag } from 'typescript'
+import { ElysiaFile } from '../universal/file'
 
 const t = Object.assign({}, Type) as unknown as Omit<
 	JavaScriptTypeBuilder,

--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -285,13 +285,18 @@ export const ElysiaType = {
 
 		return t
 			.Transform(
-				t.Union([
-					t.String({
-						format: 'ObjectString',
-						default: defaultValue
-					}),
-					schema
-				])
+				t.Union(
+					[
+						t.String({
+							format: 'ObjectString',
+							default: defaultValue
+						}),
+						schema
+					],
+					{
+						elysiaMeta: 'ObjectString'
+					}
+				)
 			)
 			.Decode((value) => {
 				if (typeof value === 'string') {
@@ -333,13 +338,13 @@ export const ElysiaType = {
 			}
 
 			// has , (as used in nuqs)
-			if (value.indexOf(',') !== -1) {
-				// const newValue = value.split(',').map((v) => v.trim())
+			// if (value.indexOf(',') !== -1) {
+			// 	// const newValue = value.split(',').map((v) => v.trim())
 
-				if (!compiler.Check(value)) throw compiler.Error(value)
+			// 	if (!compiler.Check(value)) throw compiler.Error(value)
 
-				return compiler.Decode(value)
-			}
+			// 	return compiler.Decode(value)
+			// }
 
 			if (isProperty) return value
 
@@ -364,6 +369,72 @@ export const ElysiaType = {
 						const v = value[i]
 						if (typeof v === 'string') {
 							const t = decode(v, true)
+							if (Array.isArray(t)) values = values.concat(t)
+							else values.push(t)
+
+							continue
+						}
+
+						values.push(v)
+					}
+
+					return values
+				}
+
+				if (typeof value === 'string') return decode(value)
+
+				// Is probably transformed, unable to check schema
+				return value
+			})
+			.Encode((value) => {
+				let original
+				if (typeof value === 'string')
+					value = tryParse((original = value), schema)
+
+				if (!compiler.Check(value))
+					throw new ValidationError('property', schema, value)
+
+				return original ?? JSON.stringify(value)
+			}) as any as TArray<T>
+	},
+
+	ArrayQuery: <T extends TSchema = TString>(
+		children: T = t.String() as any,
+		options?: ArrayOptions
+	) => {
+		const schema = t.Array(children, options)
+		const compiler = compile(schema)
+
+		const decode = (value: string) => {
+			// has , (as used in nuqs)
+			if (value.indexOf(',') !== -1)
+				return compiler.Decode(value.split(','))
+
+			return [value]
+		}
+
+		return t
+			.Transform(
+				t.Union(
+					[
+						t.String({
+							default: options?.default
+						}),
+						schema
+					],
+					{
+						elysiaMeta: 'ArrayQuery'
+					}
+				)
+			)
+			.Decode((value) => {
+				if (Array.isArray(value)) {
+					let values = <unknown[]>[]
+
+					for (let i = 0; i < value.length; i++) {
+						const v = value[i]
+						if (typeof v === 'string') {
+							const t = decode(v)
 							if (Array.isArray(t)) values = values.concat(t)
 							else values.push(t)
 
@@ -539,6 +610,7 @@ export const ElysiaType = {
 t.BooleanString = ElysiaType.BooleanString
 t.ObjectString = ElysiaType.ObjectString
 t.ArrayString = ElysiaType.ArrayString
+t.ArrayQuery = ElysiaType.ArrayQuery
 t.Numeric = ElysiaType.Numeric
 t.Integer = ElysiaType.Integer
 

--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -282,15 +282,13 @@ export const ElysiaType = {
 		const schema = t.Object(properties, options)
 		const compiler = compile(schema)
 
-		const defaultValue = JSON.stringify(compiler.Create())
-
 		return t
 			.Transform(
 				t.Union(
 					[
 						t.String({
 							format: 'ObjectString',
-							default: defaultValue
+							default: '{}'
 						}),
 						schema
 					],

--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -16,6 +16,7 @@ import type { TypeCheck } from '@sinclair/typebox/compiler'
 import { ElysiaFormData } from '../utils'
 import type { CookieOptions } from '../cookies'
 import type { MaybeArray } from '../types'
+import { ElysiaFile } from '../universal/file'
 
 export type FileUnit = number | `${number}${'k' | 'm'}`
 

--- a/src/type-system/utils.ts
+++ b/src/type-system/utils.ts
@@ -13,7 +13,8 @@ import { InvalidFileType, ValidationError } from '../error'
 import type {
 	ElysiaTypeCustomErrorCallback,
 	FileOptions,
-	FileUnit
+	FileUnit,
+	FileType
 } from './types'
 import type { MaybeArray } from '../types'
 
@@ -126,7 +127,7 @@ export const fileTypeFromBlob = (file: Blob | File) => {
 
 export const validateFileExtension = async (
 	file: MaybeArray<Blob | File | undefined>,
-	extension: string | string[],
+	extension: FileType | FileType[],
 	// @ts-ignore
 	name = file?.name ?? ''
 ): Promise<boolean> => {

--- a/src/type-system/utils.ts
+++ b/src/type-system/utils.ts
@@ -125,7 +125,7 @@ export const fileTypeFromBlob = (file: Blob | File) => {
 	})
 }
 
-export const validateFileExtension = async (
+export const fileType = async (
 	file: MaybeArray<Blob | File | undefined>,
 	extension: FileType | FileType[],
 	// @ts-ignore
@@ -133,7 +133,7 @@ export const validateFileExtension = async (
 ): Promise<boolean> => {
 	if (Array.isArray(file)) {
 		await Promise.all(
-			file.map((f) => validateFileExtension(f, extension, name))
+			file.map((f) => fileType(f, extension, name))
 		)
 
 		return true
@@ -154,6 +154,10 @@ export const validateFileExtension = async (
 	throw new InvalidFileType(name, extension)
 }
 
+/**
+ * This only check file extension based on it's name / mimetype
+ * to actual check the file type, use `validateFileExtension` instead
+ */
 export const validateFile = (options: FileOptions, value: any) => {
 	if (value instanceof ElysiaFile) return true
 
@@ -165,8 +169,6 @@ export const validateFile = (options: FileOptions, value: any) => {
 	if (options.maxSize && value.size > parseFileUnit(options.maxSize))
 		return false
 
-	// This only check file extension based on it's name / mimetype
-	// to actual check the file type, use `validateFileExtension` instead
 	if (options.extension) {
 		if (typeof options.extension === 'string')
 			return checkFileExtension(value.type, options.extension)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1578,7 +1578,6 @@ export interface InternalRoute {
 	handler: Handler
 	hooks: AnyLocalHook
 	websocket?: AnyWSLocalHook
-	standaloneValidators?: InputSchema[]
 }
 
 export interface SchemaValidator {
@@ -1729,7 +1728,7 @@ export type HookMacroFn<
 					AfterResponseHandler<TypedRoute, Singleton>
 				>
 				resolve?: MaybeArray<ResolveHandler<TypedRoute, Singleton>>
-				detail?: AnyBaseHookLifeCycle['detail']
+				detail?: DocumentDecoration
 		  } & InputSchema<Name>)
 		| ((...a: any) =>
 				| void
@@ -1756,7 +1755,7 @@ export type HookMacroFn<
 						resolve?: MaybeArray<
 							ResolveHandler<TypedRoute, Singleton>
 						>
-						detail?: AnyBaseHookLifeCycle['detail']
+						detail?: DocumentDecoration
 				  } & InputSchema<Name>))
 }
 
@@ -1785,6 +1784,15 @@ export interface MacroManager<
 	},
 	in out Errors extends Record<string, Error> = {}
 > {
+	body(schema: InputSchema['body']): unknown
+	headers(schema: InputSchema['headers']): unknown
+	query(schema: InputSchema['query']): unknown
+	params(schema: InputSchema['params']): unknown
+	cookie(schema: InputSchema['cookie']): unknown
+	response(schema: InputSchema['response']): unknown
+
+	detail(detail: DocumentDecoration): unknown
+
 	onParse(fn: MaybeArray<BodyHandler<TypedRoute, Singleton>>): unknown
 	onParse(
 		options: MacroOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,9 @@ import type {
 
 import type { AnyWSLocalHook } from './ws/types'
 import type { WebSocketHandler } from './ws/bun'
+
 import type { Instruction as ExactMirrorInstruction } from 'exact-mirror'
-import { Static } from '@sinclair/typebox/parser'
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 
 type PartialServe = Partial<Serve>
 
@@ -43,11 +44,14 @@ export type IsNever<T> = [T] extends [never] ? true : false
 // Standard Schema reduce to bare minimum to save inference time
 export interface StandardSchemaV1Like<
 	in out Input = unknown,
-	in out Output = unknown
+	in out Output = Input
 > {
 	readonly '~standard': {
-		readonly types:
-			| any
+		readonly types?:
+			| {
+					readonly input: Input
+					readonly output: Output
+			  }
 			| undefined
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1165,10 +1165,10 @@ export type InlineHandler<
 										: unknown)
 								// This could be possible because of set.status
 								| Route['response'][keyof Route['response']]
-						| InlineHandlerResponse<
-								Route['response'] &
-									MacroContext['response']
-						  >
+								| InlineHandlerResponse<
+										Route['response'] &
+											MacroContext['response']
+								  >
 			  >)
 
 export type OptionalHandler<
@@ -1626,9 +1626,15 @@ export type NonResolvableMacroKey =
 	| keyof AnyBaseHookLifeCycle
 	| keyof InputSchema
 
+interface RouteSchemaWithResolvedMacro extends RouteSchema {
+	response: PossibleResponse
+	return: PossibleResponse
+	resolve: Record<string, unknown>
+}
+
 export type LocalHook<
 	Input extends BaseMacro,
-	Schema extends RouteSchema,
+	Schema extends RouteSchemaWithResolvedMacro,
 	Singleton extends SingletonBase,
 	Errors extends { [key in string]: Error },
 	Parser extends keyof any = ''
@@ -1645,31 +1651,35 @@ export type LocalHook<
 	 * - 'urlencoded' / 'application/x-www-form-urlencoded: parse body as urlencoded
 	 * - 'arraybuffer': parse body as readable stream
 	 */
-	parse?: MaybeArray<BodyHandler<Schema, Singleton> | ContentType | Parser>
+	parse?: MaybeArray<
+		| BodyHandler<Schema, Singleton & { resolve: Schema['resolve'] }>
+		| ContentType
+		| Parser
+	>
 	/**
 	 * Transform context's value
 	 */
-	transform?: MaybeArray<TransformHandler<Schema, Singleton>>
+	transform?: MaybeArray<TransformHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
 	/**
 	 * Execute before main handler
 	 */
-	beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
+	beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
 	/**
 	 * Execute after main handler
 	 */
-	afterHandle?: MaybeArray<AfterHandler<Schema, Singleton>>
+	afterHandle?: MaybeArray<AfterHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
 	/**
 	 * Execute after main handler
 	 */
-	mapResponse?: MaybeArray<MapResponse<Schema, Singleton>>
+	mapResponse?: MaybeArray<MapResponse<Schema, Singleton & { resolve: Schema['resolve'] }>>
 	/**
 	 * Execute after response is sent
 	 */
-	afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton>>
+	afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
 	/**
 	 * Catch error
 	 */
-	error?: MaybeArray<ErrorHandler<Errors, Schema, Singleton>>
+	error?: MaybeArray<ErrorHandler<Errors, Schema, Singleton & { resolve: Schema['resolve'] }>>
 	tags?: DocumentDecoration['tags']
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,8 @@ export interface ElysiaConfig<Prefix extends string | undefined> {
 	 * - 'exactMirror': use Elysia's custom exact-mirror which precompile a schema
 	 * - 'typebox': Since this uses dynamic Value.Clean, it have performance impact
 	 *
+	 * Note: This option only works when Elysia schema is provided, doesn't work with Standard Schema
+	 *
 	 * @default true
 	 */
 	normalize?: boolean | 'exactMirror' | 'typebox'
@@ -518,7 +520,10 @@ export interface UnwrapRoute<
 			? ResolvePath<Path>
 			: UnwrapSchema<Schema['params'], Definitions>
 	cookie: UnwrapSchema<Schema['cookie'], Definitions>
-	response: Schema['response'] extends TSchema | string
+	response: Schema['response'] extends
+		| StandardSchemaV1Like
+		| TAnySchema
+		| string
 		? {
 				200: CoExist<
 					UnwrapSchema<Schema['response'], Definitions>,
@@ -941,11 +946,7 @@ export type InlineHandler<
 	},
 	Path extends string | undefined = undefined
 > =
-	| ((
-			context: Context<Route, Singleton, Path> & {
-				route: Prettify<Route>
-			}
-	  ) =>
+	| ((context: Context<Route, Singleton, Path>) =>
 			| Response
 			| MaybePromise<
 					{} extends Route['response']

--- a/src/types.ts
+++ b/src/types.ts
@@ -432,7 +432,7 @@ export type UnwrapSchema<
 		? Schema extends OptionalField
 			? Partial<
 					TImport<
-						// @ts-ignore Schema is always a TSchema
+						// @ts-expect-error Internal typebox already filter for TSchema
 						Definitions & {
 							readonly __elysia: Schema
 						},
@@ -440,7 +440,7 @@ export type UnwrapSchema<
 					>['static']
 				>
 			: TImport<
-					// @ts-ignore Schema is always a TSchema
+					// @ts-expect-error Internal typebox already filter for TSchema
 					Definitions & {
 						readonly __elysia: Schema
 					},
@@ -453,7 +453,8 @@ export type UnwrapSchema<
 				? Schema extends keyof Definitions
 					? Definitions[Schema] extends TAnySchema
 						? TImport<
-								Extract<Definitions, TAnySchema>,
+								// @ts-expect-error Internal typebox already filter for TSchema
+								Definitions,
 								Schema
 							>['static']
 						: NonNullable<
@@ -471,7 +472,7 @@ export type UnwrapBodySchema<
 		? Schema extends OptionalField
 			? Partial<
 					TImport<
-						// @ts-ignore Schema is always a TSchema
+						// @ts-expect-error Internal typebox already filter for TSchema
 						Definitions & {
 							readonly __elysia: Schema
 						},
@@ -479,7 +480,7 @@ export type UnwrapBodySchema<
 					>['static']
 				> | null
 			: TImport<
-					// @ts-ignore Schema is always a TSchema
+					// @ts-expect-error Internal typebox already filter for TSchema
 					Definitions & {
 						readonly __elysia: Schema
 					},
@@ -492,7 +493,8 @@ export type UnwrapBodySchema<
 				? Schema extends keyof Definitions
 					? Definitions[Schema] extends TAnySchema
 						? TImport<
-								Extract<Definitions, TAnySchema>,
+								// @ts-expect-error Internal typebox already filter for TSchema
+								Definitions,
 								Schema
 							>['static']
 						: // @ts-ignore Schema is StandardSchemaV1Like

--- a/src/types.ts
+++ b/src/types.ts
@@ -1796,9 +1796,9 @@ export type BaseMacro = Record<
 	string | number | boolean | Object | undefined | null
 >
 
-type MaybeValueOrVoidFunction<T> = T | ((...a: any) => void | T)
+export type MaybeValueOrVoidFunction<T> = T | ((...a: any) => void | T)
 
-export type Macro<
+export interface MacroProperty<
 	in out TypedRoute extends RouteSchema = {},
 	in out Singleton extends SingletonBase = {
 		decorator: {}
@@ -1806,27 +1806,36 @@ export type Macro<
 		derive: {}
 		resolve: {}
 	},
-	in out Errors extends Record<string, Error> = {},
-	in out Name extends string = ''
-> = {
-	[K in keyof any]: MaybeValueOrVoidFunction<
-		InputSchema<Name> & {
-			/**
-			 * Deduplication similar to Elysia.constructor.seed
-			 */
-			seed?: unknown
-			parse?: MaybeArray<BodyHandler<TypedRoute, Singleton>>
-			transform?: MaybeArray<VoidHandler<TypedRoute, Singleton>>
-			beforeHandle?: MaybeArray<OptionalHandler<TypedRoute, Singleton>>
-			afterHandle?: MaybeArray<AfterHandler<TypedRoute, Singleton>>
-			error?: MaybeArray<ErrorHandler<Errors, TypedRoute, Singleton>>
-			mapResponse?: MaybeArray<MapResponse<TypedRoute, Singleton>>
-			afterResponse?: MaybeArray<
-				AfterResponseHandler<TypedRoute, Singleton>
-			>
-			resolve?: MaybeArray<ResolveHandler<TypedRoute, Singleton>>
-			detail?: DocumentDecoration
-		}
+	in out Errors extends Record<string, Error> = {}
+> {
+	/**
+	 * Deduplication similar to Elysia.constructor.seed
+	 */
+	seed?: unknown
+	parse?: MaybeArray<BodyHandler<TypedRoute, Singleton>>
+	transform?: MaybeArray<VoidHandler<TypedRoute, Singleton>>
+	beforeHandle?: MaybeArray<OptionalHandler<TypedRoute, Singleton>>
+	afterHandle?: MaybeArray<AfterHandler<TypedRoute, Singleton>>
+	error?: MaybeArray<ErrorHandler<Errors, TypedRoute, Singleton>>
+	mapResponse?: MaybeArray<MapResponse<TypedRoute, Singleton>>
+	afterResponse?: MaybeArray<AfterResponseHandler<TypedRoute, Singleton>>
+	resolve?: MaybeArray<ResolveHandler<TypedRoute, Singleton>>
+	detail?: DocumentDecoration
+}
+
+export interface Macro<
+	in out Input extends BaseMacro = {},
+	in out TypedRoute extends RouteSchema = {},
+	in out Singleton extends SingletonBase = {
+		decorator: {}
+		store: {}
+		derive: {}
+		resolve: {}
+	},
+	in out Errors extends Record<string, Error> = {}
+> {
+	[K: keyof any]: MaybeValueOrVoidFunction<
+		Input & MacroProperty<TypedRoute, Singleton, Errors>
 	>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -861,14 +861,6 @@ type ReturnTypeIfPossible<T> = T extends AnyContextFn ? ReturnType<T> : T
 
 type AnyElysiaCustomStatusResponse = ElysiaCustomStatusResponse<any, any, any>
 
-type MacroResolveLike = MaybeArray<
-	(
-		...v: any
-	) => MaybePromise<
-		Record<keyof any, unknown> | void | AnyElysiaCustomStatusResponse
-	>
->
-
 type MergeAllMacroContext<T> = Prettify<UnionToIntersect<T[keyof T]>>
 
 type ExtractMacroContext<A> =
@@ -1968,7 +1960,7 @@ type _ComposeElysiaResponse<
 					: Handle
 			} & Schema['response']) &
 		ExtractErrorFromHandle<Handle> &
-		(EmptyRouteSchema extends Schema
+		(EmptyRouteSchema extends Pick<Schema, keyof EmptyRouteSchema>
 			? {}
 			: {
 					422: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,12 +206,12 @@ export interface ValidatorLayer {
 }
 
 export interface StandaloneInputSchema<Name extends string = string> {
-	body?: TSchema | Name | `${Name}[]`
-	headers?: TSchema | Name | `${Name}[]`
-	query?: TSchema | Name | `${Name}[]`
-	params?: TSchema | Name | `${Name}[]`
-	cookie?: TSchema | Name | `${Name}[]`
-	response?: { [status in number]: `${Name}[]` | Name | TSchema }
+	body?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	headers?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	query?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	params?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	cookie?: TSchema | StandardSchemaV1 | Name | `${Name}[]`
+	response?: { [status in number]: `${Name}[]` | Name | TSchema | StandardSchemaV1 }
 }
 
 export interface StandaloneValidator {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1199,6 +1199,12 @@ export type AfterHandler<
 	Path extends string | undefined = undefined
 > = (
 	context: Context<Route, Singleton, Path> & {
+		responseValue: {} extends Route['response']
+			? unknown
+			: Route['response'][keyof Route['response']]
+		/**
+		 * @deprecated use `context.responseValue` instead
+		 */
 		response: {} extends Route['response']
 			? unknown
 			: Route['response'][keyof Route['response']]
@@ -1222,17 +1228,17 @@ export type MapResponse<
 	},
 	Path extends string | undefined = undefined
 > = (
-	context: Context<
-		Omit<Route, 'response'>,
-		Singleton & {
-			derive: {
-				response: {} extends Route['response']
-					? unknown
-					: Route['response']
-			}
-		},
-		Path
-	>
+	context: Context<Route, Singleton, Path> & {
+		responseValue: {} extends Route['response']
+			? unknown
+			: Route['response'][keyof Route['response']]
+		/**
+		 * @deprecated use `context.responseValue` instead
+		 */
+		response: {} extends Route['response']
+			? unknown
+			: Route['response'][keyof Route['response']]
+	}
 ) => MaybePromise<Response | void>
 
 // Handler<
@@ -1328,6 +1334,12 @@ export type AfterResponseHandler<
 	}
 > = (
 	context: Context<Route, Singleton> & {
+		responseValue: {} extends Route['response']
+			? unknown
+			: Route['response'][keyof Route['response']]
+		/**
+		 * @deprecated use `context.responseValue` instead
+		 */
 		response: {} extends Route['response']
 			? unknown
 			: Route['response'][keyof Route['response']]
@@ -1659,27 +1671,39 @@ export type LocalHook<
 	/**
 	 * Transform context's value
 	 */
-	transform?: MaybeArray<TransformHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
+	transform?: MaybeArray<
+		TransformHandler<Schema, Singleton & { resolve: Schema['resolve'] }>
+	>
 	/**
 	 * Execute before main handler
 	 */
-	beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
+	beforeHandle?: MaybeArray<
+		OptionalHandler<Schema, Singleton & { resolve: Schema['resolve'] }>
+	>
 	/**
 	 * Execute after main handler
 	 */
-	afterHandle?: MaybeArray<AfterHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
+	afterHandle?: MaybeArray<
+		AfterHandler<Schema, Singleton & { resolve: Schema['resolve'] }>
+	>
 	/**
 	 * Execute after main handler
 	 */
-	mapResponse?: MaybeArray<MapResponse<Schema, Singleton & { resolve: Schema['resolve'] }>>
+	mapResponse?: MaybeArray<
+		MapResponse<Schema, Singleton & { resolve: Schema['resolve'] }>
+	>
 	/**
 	 * Execute after response is sent
 	 */
-	afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton & { resolve: Schema['resolve'] }>>
+	afterResponse?: MaybeArray<
+		AfterResponseHandler<Schema, Singleton & { resolve: Schema['resolve'] }>
+	>
 	/**
 	 * Catch error
 	 */
-	error?: MaybeArray<ErrorHandler<Errors, Schema, Singleton & { resolve: Schema['resolve'] }>>
+	error?: MaybeArray<
+		ErrorHandler<Errors, Schema, Singleton & { resolve: Schema['resolve'] }>
+	>
 	tags?: DocumentDecoration['tags']
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,7 +277,7 @@ export type GetPathParameter<Path extends string> =
 		? IsPathParameter<A> | GetPathParameter<B>
 		: IsPathParameter<Path>
 
-export type ResolvePath<Path extends string> = Prettify<
+type _ResolvePath<Path extends string> = Prettify<
 	{
 		[Param in GetPathParameter<Path> as Param extends `${string}?`
 			? never
@@ -288,6 +288,10 @@ export type ResolvePath<Path extends string> = Prettify<
 			: never]?: string
 	}
 >
+
+export type ResolvePath<Path extends string> = Path extends PathParameterLike
+	? _ResolvePath<Path>
+	: {}
 
 export type Or<T1 extends boolean, T2 extends boolean> = T1 extends true
 	? true

--- a/src/types.ts
+++ b/src/types.ts
@@ -1116,6 +1116,14 @@ type InlineHandlerResponse<Route extends RouteSchema['response']> = {
 	>
 }[keyof Route]
 
+type InlineResponse =
+	| string
+	| number
+	| boolean
+	| Record<any, unknown>
+	| Response
+	| AnyElysiaCustomStatusResponse
+
 export type InlineHandler<
 	Route extends RouteSchema = {},
 	Singleton extends SingletonBase = {
@@ -1134,10 +1142,15 @@ export type InlineHandler<
 		resolve: {}
 	}
 > =
+	| InlineResponse
 	| ((
 			context: Context<
 				Route & MacroContext,
-				Singleton & { resolve: MacroContext['resolve'] }
+				Singleton & { resolve: MacroContext['resolve'] } & {
+					resolve: {
+						q: Prettify<Route>
+					}
+				}
 			>
 	  ) =>
 			| Response
@@ -1152,18 +1165,11 @@ export type InlineHandler<
 										: unknown)
 								// This could be possible because of set.status
 								| Route['response'][keyof Route['response']]
-								| InlineHandlerResponse<
-										Route['response'] &
-											MacroContext['response']
-								  >
+					// | InlineHandlerResponse<
+					// 		Route['response'] &
+					// 			MacroContext['response']
+					//   >
 			  >)
-	| ({} extends Route['response']
-			? string | number | boolean | Record<any, unknown>
-			: Route['response'] extends { 200: any }
-				? Route['response'][200]
-				: string | number | boolean | Record<any, unknown>)
-	| Response
-	| AnyElysiaCustomStatusResponse
 
 export type OptionalHandler<
 	in out Route extends RouteSchema = {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -1165,10 +1165,10 @@ export type InlineHandler<
 										: unknown)
 								// This could be possible because of set.status
 								| Route['response'][keyof Route['response']]
-					// | InlineHandlerResponse<
-					// 		Route['response'] &
-					// 			MacroContext['response']
-					//   >
+						| InlineHandlerResponse<
+								Route['response'] &
+									MacroContext['response']
+						  >
 			  >)
 
 export type OptionalHandler<

--- a/src/types.ts
+++ b/src/types.ts
@@ -2462,3 +2462,31 @@ export type UnionResponseStatus<A, B> = {} extends A
 						? B[key]
 						: never
 			}
+
+export type CreateEdenResponse<
+	Path extends string,
+	Schema extends RouteSchema,
+	MacroContext extends RouteSchema,
+	// This should be handled by ComposeElysiaResponse
+	Res extends PossibleResponse
+> = RouteSchema extends MacroContext
+	? {
+			body: Schema['body']
+			params: IsNever<keyof Schema['params']> extends true
+				? ResolvePath<Path>
+				: Schema['params']
+			query: Schema['query']
+			headers: Schema['headers']
+			response: Res
+		}
+	: {
+			body: Prettify<Schema['body'] & MacroContext['body']>
+			params: IsNever<
+				keyof (Schema['params'] & MacroContext['params'])
+			> extends true
+				? ResolvePath<Path>
+				: Prettify<Schema['params'] & MacroContext['params']>
+			query: Prettify<Schema['query'] & MacroContext['query']>
+			headers: Prettify<Schema['headers'] & MacroContext['headers']>
+			response: Res
+		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -926,54 +926,67 @@ type ExtractAllResponseFromMacro<A> =
 export type MacroToContext<
 	in out MacroFn extends BaseMacroFn = {},
 	in out SelectedMacro extends BaseMacro = {},
-	in out Definitions extends DefinitionBase['typebox'] = {}
+	in out Definitions extends DefinitionBase['typebox'] = {},
+	in out R extends 1[] = [1]
 > = Prettify<
 	{} extends SelectedMacro
 		? {}
-		: UnionToIntersect<
-				{
-					[key in keyof SelectedMacro]: ReturnTypeIfPossible<
-						MacroFn[key]
-					> extends infer Value
-						? {
-								resolve: true extends SelectedMacro[key]
-									? ExtractMacroContext<
-											ResolveReturnType<
-												// @ts-expect-error type is checked in key mapping
-												Value['resolve']
+		: R['length'] extends 16
+			? {}
+			: UnionToIntersect<
+					{
+						[key in keyof SelectedMacro]: ReturnTypeIfPossible<
+							MacroFn[key]
+						> extends infer Value
+							? {
+									resolve: true extends SelectedMacro[key]
+										? ExtractMacroContext<
+												ResolveReturnType<
+													// @ts-expect-error type is checked in key mapping
+													Value['resolve']
+												>
 											>
+										: {}
+								} & UnwrapMacroSchema<
+									// @ts-ignore Trust me bro
+									Value,
+									Definitions
+								> &
+									ExtractAllResponseFromMacro<
+										FunctionArrayReturnType<
+											// @ts-expect-error type is checked in key mapping
+											Value['beforeHandle']
 										>
-									: {}
-							} & UnwrapMacroSchema<
-								// @ts-ignore Trust me bro
-								Value,
-								Definitions
-							> &
-								ExtractAllResponseFromMacro<
-									FunctionArrayReturnType<
+									> &
+									ExtractAllResponseFromMacro<
+										FunctionArrayReturnType<
+											// @ts-expect-error type is checked in key mapping
+											Value['afterHandle']
+										>
+									> &
+									ExtractAllResponseFromMacro<
 										// @ts-expect-error type is checked in key mapping
-										Value['beforeHandle']
+										FunctionArrayReturnType<Value['error']>
+									> &
+									ExtractOnlyResponseFromMacro<
+										FunctionArrayReturnType<
+											// @ts-expect-error type is checked in key mapping
+											Value['resolve']
+										>
+									> &
+									MacroToContext<
+										MacroFn,
+										// @ts-ignore trust me bro
+										Pick<
+											Value,
+											Extract<keyof MacroFn, keyof Value>
+										>,
+										Definitions,
+										[...R, 1]
 									>
-								> &
-								ExtractAllResponseFromMacro<
-									FunctionArrayReturnType<
-										// @ts-expect-error type is checked in key mapping
-										Value['afterHandle']
-									>
-								> &
-								ExtractAllResponseFromMacro<
-									// @ts-expect-error type is checked in key mapping
-									FunctionArrayReturnType<Value['error']>
-								> &
-								ExtractOnlyResponseFromMacro<
-									FunctionArrayReturnType<
-										// @ts-expect-error type is checked in key mapping
-										Value['resolve']
-									>
-								>
-						: {}
-				}[keyof SelectedMacro]
-			>
+							: {}
+					}[keyof SelectedMacro]
+				>
 >
 
 type UnwrapMacroSchema<

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,12 @@ export interface StandardSchemaV1Like<
 	}
 }
 
+export type StandardSchemaV1LikeValidate = <T>(
+	v: T
+) => MaybePromise<
+	{ value: T; issues?: never } | { value?: never; issues: unknown[] }
+>
+
 export interface ElysiaConfig<Prefix extends string | undefined> {
 	/**
 	 * @default BunAdapter

--- a/src/types.ts
+++ b/src/types.ts
@@ -1070,9 +1070,7 @@ export type InlineHandler<
 								| Route['response'][keyof Route['response']]
 								| InlineHandlerResponse<
 										Route['response'] &
-											({} extends MacroContext['response']
-												? {}
-												: MacroContext['response'])
+											MacroContext['response']
 								  >
 			  >)
 	| ({} extends Route['response']
@@ -1080,6 +1078,7 @@ export type InlineHandler<
 			: Route['response'] extends { 200: any }
 				? Route['response'][200]
 				: string | number | boolean | Record<any, unknown>)
+	| Response
 	| AnyElysiaCustomStatusResponse
 
 export type OptionalHandler<

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,9 @@ export interface StandardSchemaV1Like<
 	in out Input = unknown,
 	in out Output = unknown
 > {
-	'~standard': {
-		types:
-			| {
-					input: Input
-					output: Output
-			  }
+	readonly '~standard': {
+		readonly types:
+			| any
 			| undefined
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -998,27 +998,33 @@ export type InlineHandler<
 	| ((
 			context: Context<
 				Route &
-					(IsAny<Singleton['resolve']['response']> extends false
-						? { response: Singleton['resolve']['response'] }
-						: {}),
+					({} extends Route['response']
+						? {}
+						: IsAny<Singleton['resolve']['response']> extends true
+							? {}
+							: { response: Singleton['resolve']['response'] }),
 				Singleton,
 				Path
 			>
 	  ) => MaybePromise<
-			| (IsAny<Singleton['resolve']['response']> extends false
-					? Response | InlineHandlerResponse<Singleton['resolve']['response']>
-					: Response)
-			| ({} extends Route['response']
-					? unknown
-					:
-							| (Route['response'] extends {
-									200: any
-							  }
-									? Route['response'][200]
-									: unknown)
-							// This could be possible because of set.status
-							| Route['response'][keyof Route['response']]
-							| InlineHandlerResponse<Route['response']>)
+			{} extends Route['response']
+				? unknown
+				:
+						| (Route['response'] extends {
+								200: any
+						  }
+								? Route['response'][200]
+								: unknown)
+						// This could be possible because of set.status
+						| Route['response'][keyof Route['response']]
+						| InlineHandlerResponse<Route['response']>
+						| (IsAny<Singleton['resolve']['response']> extends true
+								? Response
+								:
+										| Response
+										| InlineHandlerResponse<
+												Singleton['resolve']['response']
+										  >)
 	  >)
 	| ({} extends Route['response']
 			? string | number | boolean | Record<any, unknown>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1997,7 +1997,7 @@ export type ValueOrFunctionToResponseSchema<T> = T extends (
 export type ElysiaHandlerToResponseSchema<in out Handle extends Function> =
 	Prettify<
 		Handle extends (...a: any) => MaybePromise<infer R>
-			? ValueToResponseSchema<R>
+			? ValueToResponseSchema<Exclude<R, undefined>>
 			: {}
 	>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -705,19 +705,6 @@ export interface InputSchema<in out Name extends string = string> {
 		  }
 }
 
-export interface PrettifySchema<in out A extends RouteSchema> {
-	body: unknown extends A['body'] ? A['body'] : Prettify<A['body']>
-	headers: unknown extends A['headers']
-		? A['headers']
-		: Prettify<A['headers']>
-	query: unknown extends A['query'] ? A['query'] : Prettify<A['query']>
-	params: unknown extends A['params'] ? A['params'] : Prettify<A['params']>
-	cookie: unknown extends A['cookie'] ? A['cookie'] : Prettify<A['cookie']>
-	response: unknown extends A['response']
-		? A['response']
-		: Prettify<A['response']>
-}
-
 type PathParameterLike = `${string}/${':' | '*'}${string}`
 
 export type MergeSchema<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -556,6 +556,7 @@ export const StatusMap = {
 	'Range Not Satisfiable': 416,
 	'Expectation Failed': 417,
 	"I'm a teapot": 418,
+	'Enhance Your Calm': 420,
 	'Misdirected Request': 421,
 	'Unprocessable Content': 422,
 	Locked: 423,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1208,3 +1208,18 @@ export const sse = <
 
 	return payload as any
 }
+
+export async function getResponseLength(response: Response) {
+	if (response.bodyUsed || !response.body) return 0
+
+	let length = 0
+	const reader = response.body.getReader()
+
+	while (true) {
+		const { done, value } = await reader.read()
+		if (done) break
+		length += value.byteLength
+	}
+
+	return length
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { isStringTextContainingNode } from 'typescript'
 import type { Sucrose } from './sucrose'
 import type { TraceHandler } from './trace'
 
@@ -20,7 +21,8 @@ import type {
 	SchemaValidator,
 	AnyLocalHook,
 	SSEPayload,
-	Prettify
+	Prettify,
+	RouteSchema
 } from './types'
 import { ElysiaFile } from './universal/file'
 
@@ -56,15 +58,27 @@ export const mergeDeep = <
 	options?: {
 		skipKeys?: string[]
 		override?: boolean
+		mergeArray?: boolean
 	}
 ): A & B => {
 	const skipKeys = options?.skipKeys
 	const override = options?.override ?? true
+	const mergeArray = options?.mergeArray ?? true
 
 	if (!isObject(target) || !isObject(source)) return target as A & B
 
 	for (const [key, value] of Object.entries(source)) {
 		if (skipKeys?.includes(key)) continue
+
+		if (mergeArray && Array.isArray(value)) {
+			target[key as keyof typeof target] = Array.isArray(
+				(target as any)[key]
+			)
+				? [...(target as any)[key], ...value]
+				: (target[key as keyof typeof target] = value as any)
+
+			continue
+		}
 
 		if (!isObject(value) || !(key in target) || isClass(value)) {
 			if (override || !(key in target))
@@ -76,7 +90,7 @@ export const mergeDeep = <
 		target[key as keyof typeof target] = mergeDeep(
 			(target as any)[key] as any,
 			value,
-			{ skipKeys, override }
+			{ skipKeys, override, mergeArray }
 		)
 	}
 
@@ -87,7 +101,8 @@ export const mergeCookie = <const A extends Object, const B extends Object>(
 	b: B
 ): A & B => {
 	const v = mergeDeep(Object.assign({}, a), b, {
-		skipKeys: ['properties']
+		skipKeys: ['properties'],
+		mergeArray: false
 	}) as A & B
 
 	// @ts-expect-error
@@ -645,171 +660,31 @@ export const unsignCookie = async (input: string, secret: string | null) => {
 	return expectedInput === input ? tentativeValue : false
 }
 
-export const traceBackMacro = (
-	extension: unknown,
-	property: Record<string, unknown>,
-	manage: ReturnType<typeof createMacroManager>
+export const insertStandaloneValidator = <const Name extends keyof InputSchema>(
+	hook: { standaloneValidator: InputSchema[] },
+	name: Name,
+	value: InputSchema[Name]
 ) => {
-	if (!extension || typeof extension !== 'object' || !property) return
-
-	for (const [key, value] of Object.entries(property)) {
-		if (primitiveHookMap[key] || !(key in extension)) continue
-
-		const v = extension[
-			key as unknown as keyof typeof extension
-		] as BaseMacro[string]
-
-		if (typeof v === 'function') {
-			const hook = v(value)
-
-			if (typeof hook === 'object')
-				for (const [k, v] of Object.entries(hook))
-					manage(k as keyof LifeCycleStore)({
-						fn: v as any
-					})
-		}
-
-		delete property[key as unknown as keyof typeof extension]
+	if (
+		!hook.standaloneValidator?.length ||
+		!Array.isArray(hook.standaloneValidator)
+	) {
+		hook.standaloneValidator = [
+			{
+				[name]: value
+			}
+		]
+		return
 	}
+
+	const last = hook.standaloneValidator[hook.standaloneValidator.length - 1]
+
+	if (name in last)
+		hook.standaloneValidator.push({
+			[name]: value
+		})
+	else last[name] = value
 }
-
-export const createMacroManager =
-	({
-		globalHook,
-		localHook
-	}: {
-		globalHook: Partial<LifeCycleStore>
-		localHook: Partial<AnyLocalHook>
-	}) =>
-	(stackOrSchema: keyof LifeCycleStore | keyof InputSchema | 'detail') =>
-	(
-		type:
-			| {
-					insert?: 'before' | 'after'
-					stack?: 'global' | 'local'
-			  }
-			| MaybeArray<HookContainer>,
-		fn?: MaybeArray<HookContainer>
-	) => {
-		const schemaName = stackOrSchema as keyof InputSchema
-
-		if (
-			schemaName === 'query' ||
-			schemaName === 'params' ||
-			schemaName === 'headers' ||
-			schemaName === 'cookie' ||
-			schemaName === 'body' ||
-			schemaName === 'response'
-		) {
-			let schema = 'fn' in type ? type.fn : type
-			if (typeof schema === 'function') return
-
-			if (
-				!localHook.standaloneValidator ||
-				!localHook.standaloneValidator.length ||
-				Array.isArray(localHook.standaloneValidator)
-			) {
-				localHook.standaloneValidator = [
-					{
-						[schemaName]: schema
-					}
-				]
-				return
-			}
-
-			const last =
-				localHook.standaloneValidator[
-					localHook.standaloneValidator.length - 1
-				]
-
-			if (schemaName in last)
-				localHook.standaloneValidator.push({
-					[schemaName]: schema
-				})
-			else last[schemaName] = schema
-
-			return
-		}
-
-		if (stackOrSchema === 'detail') {
-			let schema = 'fn' in type ? type.fn : type
-			if (typeof schema === 'function' || Array.isArray(schema)) return
-
-			localHook.detail = localHook.detail
-				? mergeDeep(localHook.detail, schema)
-				: schema
-
-			return
-		}
-
-		const stackName = stackOrSchema as keyof LifeCycleStore
-
-		if (typeof type === 'function')
-			type = {
-				fn: type
-			}
-
-		// @ts-expect-error this is available in macro v2
-		if (stackName === 'resolve')
-			type = {
-				...type,
-				subType: 'resolve'
-			}
-
-		if (!localHook[stackName]) localHook[stackName] = []
-		if (typeof localHook[stackName] === 'function')
-			localHook[stackName] = [localHook[stackName]]
-		if (!Array.isArray(localHook[stackName]))
-			localHook[stackName] = [localHook[stackName]]
-
-		if ('fn' in type || Array.isArray(type)) {
-			if (Array.isArray(type))
-				localHook[stackName] = (
-					localHook[stackName] as unknown[]
-				).concat(type) as any
-			else localHook[stackName].push(type)
-
-			return
-		}
-
-		const { insert = 'after', stack = 'local' } = type
-
-		if (typeof fn === 'function') fn = { fn }
-
-		if (stack === 'global') {
-			if (!Array.isArray(fn)) {
-				if (insert === 'before') {
-					;(globalHook[stackName] as any[]).unshift(fn)
-				} else {
-					;(globalHook[stackName] as any[]).push(fn)
-				}
-			} else {
-				if (insert === 'before') {
-					globalHook[stackName] = fn.concat(
-						globalHook[stackName] as any
-					) as any
-				} else {
-					globalHook[stackName] = (
-						globalHook[stackName] as any[]
-					).concat(fn)
-				}
-			}
-		} else {
-			if (!Array.isArray(fn)) {
-				if (insert === 'before') {
-					;(localHook[stackName] as any[]).unshift(fn)
-				} else {
-					;(localHook[stackName] as any[]).push(fn)
-				}
-			} else {
-				if (insert === 'before') {
-					localHook[stackName] = fn.concat(localHook[stackName])
-				} else {
-					localHook[stackName] = localHook[stackName].concat(fn)
-				}
-			}
-		}
-	}
 
 const parseNumericString = (message: string | number): number | null => {
 	if (typeof message === 'number') return message
@@ -1277,3 +1152,12 @@ export async function getResponseLength(response: Response) {
 
 	return length
 }
+
+export const emptySchema = {
+	headers: true,
+	cookie: true,
+	query: true,
+	params: true,
+	body: true,
+	response: true
+} as const satisfies RouteSchema

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -696,12 +696,11 @@ export const createMacroManager =
 			}
 
 		// @ts-expect-error this is available in macro v2
-		if (stackName === 'resolve') {
+		if (stackName === 'resolve')
 			type = {
 				...type,
 				subType: 'resolve'
 			}
-		}
 
 		if (!localHook[stackName]) localHook[stackName] = []
 		if (typeof localHook[stackName] === 'function')

--- a/src/ws/types.ts
+++ b/src/ws/types.ts
@@ -121,48 +121,46 @@ export type WSParseHandler<Route extends RouteSchema, Context = {}> = (
 	message: unknown
 ) => MaybePromise<Route['body'] | void | undefined>
 
-export type AnyWSLocalHook = WSLocalHook<any, any, any, any>
+export type AnyWSLocalHook = WSLocalHook<any, any, any>
 
 export type WSLocalHook<
-	LocalSchema extends InputSchema,
+	Input extends BaseMacro,
 	Schema extends RouteSchema,
 	Singleton extends SingletonBase,
-	Macro extends MetadataBase['macro']
-> = Prettify<Macro> &
-	(LocalSchema extends any ? LocalSchema : Prettify<LocalSchema>) & {
-		detail?: DocumentDecoration
-		/**
-		 * Headers to register to websocket before `upgrade`
-		 */
-		upgrade?: Record<string, unknown> | ((context: Context) => unknown)
-		parse?: MaybeArray<WSParseHandler<Schema>>
+> = Prettify<Input> & {
+	detail?: DocumentDecoration
+	/**
+	 * Headers to register to websocket before `upgrade`
+	 */
+	upgrade?: Record<string, unknown> | ((context: Context) => unknown)
+	parse?: MaybeArray<WSParseHandler<Schema>>
 
-		/**
-		 * Transform context's value
-		 */
-		transform?: MaybeArray<TransformHandler<Schema, Singleton>>
-		/**
-		 * Execute before main handler
-		 */
-		beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
-		/**
-		 * Execute after main handler
-		 */
-		afterHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
-		/**
-		 * Execute after main handler
-		 */
-		mapResponse?: MaybeArray<MapResponse<Schema, Singleton>>
-		/**
-		 * Execute after response is sent
-		 */
-		afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton>>
-		/**
-		 * Catch error
-		 */
-		error?: MaybeArray<ErrorHandler<{}, Schema, Singleton>>
-		tags?: DocumentDecoration['tags']
-	} & TypedWebSocketHandler<
+	/**
+	 * Transform context's value
+	 */
+	transform?: MaybeArray<TransformHandler<Schema, Singleton>>
+	/**
+	 * Execute before main handler
+	 */
+	beforeHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
+	/**
+	 * Execute after main handler
+	 */
+	afterHandle?: MaybeArray<OptionalHandler<Schema, Singleton>>
+	/**
+	 * Execute after main handler
+	 */
+	mapResponse?: MaybeArray<MapResponse<Schema, Singleton>>
+	/**
+	 * Execute after response is sent
+	 */
+	afterResponse?: MaybeArray<AfterResponseHandler<Schema, Singleton>>
+	/**
+	 * Catch error
+	 */
+	error?: MaybeArray<ErrorHandler<{}, Schema, Singleton>>
+	tags?: DocumentDecoration['tags']
+} & TypedWebSocketHandler<
 		Omit<Context<Schema, Singleton>, 'body'> & {
 			body: never
 		},

--- a/test/adapter/web-standard/map-early-response.test.ts
+++ b/test/adapter/web-standard/map-early-response.test.ts
@@ -235,6 +235,7 @@ describe('Web Standard - Map Early Response', () => {
 
 		expect(response).toBeInstanceOf(Response)
 		expect(await response?.text()).toEqual('Shiroko')
+		// @ts-ignore
 		expect(response?.headers.toJSON()).toEqual({
 			...headers,
 			name: 'Himari'

--- a/test/adapter/web-standard/map-response.test.ts
+++ b/test/adapter/web-standard/map-response.test.ts
@@ -276,6 +276,7 @@ describe('Web Standard - Map Response', () => {
 
 		expect(response).toBeInstanceOf(Response)
 		expect(await response.text()).toEqual('Shiroko')
+		// @ts-ignore
 		expect(response.headers.toJSON()).toEqual({
 			...headers,
 			name: 'Himari'

--- a/test/aot/analysis.test.ts
+++ b/test/aot/analysis.test.ts
@@ -102,7 +102,7 @@ describe('Static code analysis', () => {
 		}
 
 		const app = new Elysia().post('/json', (c) => c.body, {
-			type: 'json'
+			parse: 'json'
 		})
 
 		const res = await app.handle(post('/json', body)).then((x) => x.json())

--- a/test/aot/response.test.ts
+++ b/test/aot/response.test.ts
@@ -6,7 +6,6 @@ import { signCookie } from '../../src/utils'
 const secrets = 'We long for the seven wailings. We bear the koan of Jericho.'
 
 const getCookies = (response: Response) =>
-	// @ts-expect-error
 	response.headers.getAll('Set-Cookie').map((x) => {
 		return decodeURIComponent(x)
 	})

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -297,7 +297,7 @@ describe('Cookie Response', () => {
 	})
 
 	it("don't parse cookie type unless specified", async () => {
-		let value: string | undefined
+		let value: unknown
 
 		const app = new Elysia().get(
 			'/council',
@@ -355,7 +355,6 @@ describe('Cookie Response', () => {
 			return 'a'
 		})
 
-		// @ts-expect-error
 		const res = app.handle(req('/')).then((x) => x.headers.toJSON())
 
 		// @ts-expect-error

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -285,9 +285,7 @@ describe('Cookie Response', () => {
 		const response = await app.handle(
 			req('/council', {
 				headers: {
-					cookie:
-						'council=' +
-						encodeURIComponent(JSON.stringify(expected))
+					cookie: 'council=' + JSON.stringify(expected)
 				}
 			})
 		)
@@ -296,32 +294,33 @@ describe('Cookie Response', () => {
 		expect(await response.json()).toEqual(expected)
 	})
 
-	it("don't parse cookie type unless specified", async () => {
-		let value: unknown
+	// this is removed there's no way to accurately determine object on Standard Schema
+	// it("don't parse cookie type unless specified", async () => {
+	// 	let value: unknown
 
-		const app = new Elysia().get(
-			'/council',
-			({ cookie: { council } }) => (value = council.value)
-		)
+	// 	const app = new Elysia().get(
+	// 		'/council',
+	// 		({ cookie: { council } }) => (value = council.value)
+	// 	)
 
-		const expected = {
-			name: 'Rin',
-			affilation: 'Administration'
-		}
+	// 	const expected = {
+	// 		name: 'Rin',
+	// 		affilation: 'Administration'
+	// 	}
 
-		const response = await app.handle(
-			req('/council', {
-				headers: {
-					cookie:
-						'council=' +
-						encodeURIComponent(JSON.stringify(expected))
-				}
-			})
-		)
+	// 	const response = await app.handle(
+	// 		req('/council', {
+	// 			headers: {
+	// 				cookie:
+	// 					'council=' +
+	// 					encodeURIComponent(JSON.stringify(expected))
+	// 			}
+	// 		})
+	// 	)
 
-		expect(response.status).toBe(200)
-		expect(value).toEqual(JSON.stringify(expected))
-	})
+	// 	expect(response.status).toBe(200)
+	// 	expect(value).toEqual(JSON.stringify(expected))
+	// })
 
 	it('handle optional at root', async () => {
 		const app = new Elysia().get('/', ({ cookie: { id } }) => id.value, {
@@ -391,13 +390,14 @@ describe('Cookie Response', () => {
 			})
 			.get('/', () => 'Hello, world!')
 
-		const res = await app.handle(
-			new Request('http://localhost:3000/', {
-				headers: {
-					cookie: 'test=Hello, world!'
-				}
-			})
-		)
+		const res = await app
+			.handle(
+				new Request('http://localhost:3000/', {
+					headers: {
+						cookie: 'test=Hello, world!'
+					}
+				})
+			)
 			.then((x) => x.headers)
 
 		expect(res.getSetCookie()).toEqual([])

--- a/test/core/elysia.test.ts
+++ b/test/core/elysia.test.ts
@@ -387,4 +387,34 @@ describe('Edge Case', () => {
 
 		expect(response.status).toBe(200)
 	})
+
+	it('automatically handle HEAD request for GET static path', async () => {
+		const app = new Elysia().get('/', () => 'hello world')
+
+		const response = await app.handle(
+			new Request('http://localhost', {
+				method: 'HEAD'
+			})
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.headers.toJSON()).toEqual({
+			'content-length': '11',
+		})
+	})
+
+	it('automatically handle HEAD request for GET dynamic path', async () => {
+		const app = new Elysia().get('/:id', () => 'hello world')
+
+		const response = await app.handle(
+			new Request('http://localhost/1', {
+				method: 'HEAD'
+			})
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.headers.toJSON()).toEqual({
+			'content-length': '11',
+		})
+	})
 })

--- a/test/core/elysia.test.ts
+++ b/test/core/elysia.test.ts
@@ -123,7 +123,6 @@ describe('Edge Case', () => {
 
 		const response = await app
 			.handle(req('/'))
-			// @ts-expect-error
 			.then((x) => x.headers.toJSON())
 
 		expect(response['set-cookie']).toHaveLength(1)

--- a/test/core/handle-error.test.ts
+++ b/test/core/handle-error.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, InternalServerError, NotFoundError, error, t } from '../../src'
+import { Elysia, InternalServerError, NotFoundError, status, t } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -142,8 +142,8 @@ describe('Handle Error', () => {
 	})
 
 	it('handle thrown error function', async () => {
-		const app = new Elysia().get('/', () => {
-			throw error(404, 'Not Found :(')
+		const app = new Elysia().get('/', ({ status }) => {
+			throw status(404, 'Not Found :(')
 		})
 
 		const response = await app.handle(req('/'))
@@ -153,8 +153,8 @@ describe('Handle Error', () => {
 	})
 
 	it('handle thrown Response', async () => {
-		const app = new Elysia().get('/', () => {
-			throw error(404, 'Not Found :(')
+		const app = new Elysia().get('/', ({ status }) => {
+			throw status(404, 'Not Found :(')
 		})
 
 		const response = await app.handle(req('/'))
@@ -253,8 +253,8 @@ describe('Handle Error', () => {
 
 		const response: Response = await new Elysia()
 			.get('/', () => 'Hello', {
-				beforeHandle({ error }) {
-					throw error("I'm a teapot", { message: 'meow!' })
+				beforeHandle({ status }) {
+					throw status("I'm a teapot", { message: 'meow!' })
 				}
 			})
 			// @ts-expect-error private property
@@ -265,7 +265,7 @@ describe('Handle Error', () => {
 						headers: {}
 					}
 				},
-				error(422, value) as any
+				status(422, value) as any
 			)
 
 		expect(await response.json()).toEqual(value)
@@ -288,8 +288,8 @@ describe('Handle Error', () => {
 					})
 			})
 			.get('/', () => 'Hello', {
-				beforeHandle({ error }) {
-					throw error("I'm a teapot", { message: 'meow!' })
+				beforeHandle({ status }) {
+					throw status("I'm a teapot", { message: 'meow!' })
 				}
 			})
 			// @ts-expect-error private property
@@ -300,7 +300,7 @@ describe('Handle Error', () => {
 						headers: {}
 					}
 				},
-				error(422, value) as any
+				status(422, value) as any
 			)
 
 		expect(await response.text()).toBe('Don Quixote')

--- a/test/core/mount.test.ts
+++ b/test/core/mount.test.ts
@@ -119,7 +119,6 @@ describe('Mount', () => {
 
 	it('preserve headers', async () => {
 		const app = new Elysia().mount((request) => {
-			// @ts-expect-error Bun has toJSON
 			return Response.json(request.headers.toJSON())
 		})
 

--- a/test/core/native-static.test.ts
+++ b/test/core/native-static.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Elysia } from '../../src'
 import { describe, expect, it } from 'bun:test'
 

--- a/test/core/normalize.test.ts
+++ b/test/core/normalize.test.ts
@@ -100,7 +100,7 @@ describe('Normalize', () => {
 			normalize: false
 		}).get(
 			'/',
-			({ error }) => error(418, { name: 'Nagisa', hifumi: 'daisuki' }),
+			({ status }) => status(418, { name: 'Nagisa', hifumi: 'daisuki' }),
 			{
 				response: {
 					200: t.Object({

--- a/test/core/normalize.test.ts
+++ b/test/core/normalize.test.ts
@@ -75,7 +75,8 @@ describe('Normalize', () => {
 	it('normalize multiple response', async () => {
 		const app = new Elysia().get(
 			'/',
-			({ error }) => error(418, { name: 'Nagisa', hifumi: 'daisuki' }),
+			// @ts-ignore
+			({ status }) => status(418, { name: 'Nagisa', hifumi: 'daisuki' }),
 			{
 				response: {
 					200: t.Object({
@@ -100,6 +101,7 @@ describe('Normalize', () => {
 			normalize: false
 		}).get(
 			'/',
+			// @ts-ignore
 			({ status }) => status(418, { name: 'Nagisa', hifumi: 'daisuki' }),
 			{
 				response: {

--- a/test/extends/models.test.ts
+++ b/test/extends/models.test.ts
@@ -125,8 +125,8 @@ describe('Model', () => {
 				})
 			})
 			.post('/arr', ({ body }) => body, {
-				response: 'number[]',
-				body: 'number[]',
+				response: 'number',
+				body: 'number',
 			})
 
 		const correct = await app.handle(
@@ -149,7 +149,7 @@ describe('Model', () => {
 				headers: {
 					'content-type': 'application/json'
 				},
-				body: JSON.stringify([1, 2])
+				body: 1
 			})
 		)
 

--- a/test/extends/models.test.ts
+++ b/test/extends/models.test.ts
@@ -332,14 +332,14 @@ describe('Model', () => {
 					400: 'res'
 				}
 			})
-			.get('/400', ({ error }) => error(400, 'ok'), {
+			.get('/400', ({ status }) => status(400, 'ok'), {
 				response: {
 					200: 'res',
 					400: 'res'
 				}
 			})
 			// @ts-expect-error
-			.get('/error', ({ error }) => error(400, 1), {
+			.get('/error', ({ status }) => status(400, 1), {
 				response: {
 					200: 'res',
 					400: 'res'

--- a/test/lifecycle/after-handle.test.ts
+++ b/test/lifecycle/after-handle.test.ts
@@ -88,6 +88,24 @@ describe('After Handle', () => {
 		const app = new Elysia().get('/', () => 'NOOP', {
 			afterHandle({ response }) {
 				return response
+			},
+			mapResponse() {
+
+			}
+		})
+
+		const res = await app.handle(req('/')).then((x) => x.text())
+
+		expect(res).toBe('NOOP')
+	})
+
+	it('accept responseValue', async () => {
+		const app = new Elysia().get('/', () => 'NOOP', {
+			afterHandle({ responseValue }) {
+				return responseValue
+			},
+			mapResponse() {
+
 			}
 		})
 

--- a/test/lifecycle/derive.test.ts
+++ b/test/lifecycle/derive.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, error } from '../../src'
+import { Elysia } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -182,9 +182,7 @@ describe('derive', () => {
 
 	it('handle error', async () => {
 		const app = new Elysia()
-			.derive(() => {
-				return error(418)
-			})
+			.derive(({ status }) => status(418))
 			.get('/', () => '')
 
 		const res = await app.handle(req('/')).then((x) => x.text())

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -4,7 +4,6 @@ import {
 	InternalServerError,
 	ParseError,
 	ValidationError,
-	error,
 	t,
 	validationDetail
 } from '../../src'
@@ -127,8 +126,8 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct number status on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) =>
-				error(418, 'I am a teapot')
+			const app = new Elysia({ aot }).get('/', ({ status }) =>
+				status(418, 'I am a teapot')
 			)
 
 			const response = await app.handle(req('/'))
@@ -140,8 +139,8 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct named status on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) =>
-				error("I'm a teapot", 'I am a teapot')
+			const app = new Elysia({ aot }).get('/', ({ status }) =>
+				status("I'm a teapot", 'I am a teapot')
 			)
 
 			const response = await app.handle(req('/'))
@@ -153,7 +152,7 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct number status without value on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) => error(418))
+			const app = new Elysia({ aot }).get('/', ({ status }) => status(418))
 
 			const response = await app.handle(req('/'))
 
@@ -165,8 +164,8 @@ describe('error', () => {
 	it.each([true, false])(
 		'return correct named status without value on error function with aot: %p',
 		async (aot) => {
-			const app = new Elysia({ aot }).get('/', ({ error }) =>
-				error("I'm a teapot")
+			const app = new Elysia({ aot }).get('/', ({ status }) =>
+				status("I'm a teapot")
 			)
 
 			const response = await app.handle(req('/'))

--- a/test/lifecycle/hook-types.test.ts
+++ b/test/lifecycle/hook-types.test.ts
@@ -13,19 +13,19 @@ describe('Hook Types', () => {
 			}
 		)
 
-		expect(plugin.event.transform[0].scope).toBe('scoped')
+		expect(plugin.event.transform?.[0].scope).toBe('scoped')
 
 		const a = new Elysia().use(plugin).get('/foo', ({ id }) => {
 			return { id, name: 'foo' }
 		})
 
-		expect(plugin.event.transform[0].scope).toBe('scoped')
+		expect(plugin.event.transform?.[0].scope).toBe('scoped')
 
 		const b = new Elysia().use(plugin).get('/bar', ({ id }) => {
 			return { id, name: 'bar' }
 		})
 
-		expect(plugin.event.transform[0].scope).toBe('scoped')
+		expect(plugin.event.transform?.[0].scope).toBe('scoped')
 
 		const [res1, res2] = await Promise.all([
 			a.handle(req('/foo')).then((x) => x.json()),

--- a/test/lifecycle/map-response.test.ts
+++ b/test/lifecycle/map-response.test.ts
@@ -243,7 +243,7 @@ describe('Map Response', () => {
 		const app = new Elysia()
 			.onAfterHandle(() => {})
 			.mapResponse((context) => {
-				return context.response
+				return new Response(context.response + '')
 			})
 			.get('/', async () => 'aru')
 

--- a/test/lifecycle/parser.test.ts
+++ b/test/lifecycle/parser.test.ts
@@ -428,6 +428,7 @@ describe('Parser', () => {
 
 		const app = new Elysia()
 			.onError((ctx) => {
+				// @ts-ignore
 				code = ctx.code
 			})
 			.post('/', () => '', {

--- a/test/lifecycle/resolve.test.ts
+++ b/test/lifecycle/resolve.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, error } from '../../src'
+import { Elysia } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
@@ -211,8 +211,8 @@ describe('resolve', () => {
 
 	it('handle error', async () => {
 		const route = new Elysia()
-			.resolve(() => {
-				return error(418)
+			.resolve(({ status }) => {
+				return status(418)
 			})
 			.get('/', () => '')
 

--- a/test/lifecycle/response.test.ts
+++ b/test/lifecycle/response.test.ts
@@ -60,22 +60,57 @@ describe('On After Response', () => {
 		expect(order).toEqual(['A', 'B'])
 	})
 
-	// it('inherits from plugin', async () => {
-	// 	const transformType = new Elysia().onResponse(
-	// 		{ as: 'global' },
-	// 		({ response }) => {
-	// 			if (response === 'string') return 'number'
-	// 		}
-	// 	)
+	it('inherits from plugin', async () => {
+		let type = ''
 
-	// 	const app = new Elysia()
-	// 		.use(transformType)
-	// 		.get('/id/:id', ({ params: { id } }) => typeof id)
+		const afterResponse = new Elysia().onAfterResponse(
+			{ as: 'global' },
+			({ response }) => {
+				type = typeof response
+			}
+		)
 
-	// 	const res = await app.handle(req('/id/1'))
+		const app = new Elysia()
+			.use(afterResponse)
+			.get('/id/:id', ({ params: { id } }) => id, {
+				params: t.Object({
+					id: t.Number()
+				})
+			})
 
-	// 	expect(await res.text()).toBe('number')
-	// })
+		await app.handle(req('/id/1'))
+
+		// wait for next tick
+		await Bun.sleep(1)
+
+		expect(type).toBe('number')
+	})
+
+	it('inherits from plugin using responseValue', async () => {
+		let type = ''
+
+		const afterResponse = new Elysia().onAfterResponse(
+			{ as: 'global' },
+			({ responseValue }) => {
+				type = typeof responseValue
+			}
+		)
+
+		const app = new Elysia()
+			.use(afterResponse)
+			.get('/id/:id', ({ params: { id } }) => id, {
+				params: t.Object({
+					id: t.Number()
+				})
+			})
+
+		await app.handle(req('/id/1'))
+
+		// wait for next tick
+		await Bun.sleep(1)
+
+		expect(type).toBe('number')
+	})
 
 	it('as global', async () => {
 		const called = <string[]>[]

--- a/test/lifecycle/transform.test.ts
+++ b/test/lifecycle/transform.test.ts
@@ -41,17 +41,13 @@ describe('Transform', () => {
 
 	it('group transform', async () => {
 		const app = new Elysia()
-			.group('/scoped', (app) =>
+			.group('/scoped/id/:id', (app) =>
 				app
-					.onTransform<{
-						params: {
-							id: number
-						} | null
-					}>((request) => {
-						if (request.params?.id)
-							request.params.id = +request.params.id
+					.onTransform(({ params }) => {
+						// @ts-ignore
+						if (params.id) params.id = +params.id
 					})
-					.get('/id/:id', ({ params: { id } }) => typeof id)
+					.get('', ({ params: { id } }) => typeof id)
 			)
 			.get('/id/:id', ({ params: { id } }) => typeof id)
 
@@ -71,6 +67,7 @@ describe('Transform', () => {
 			},
 			'global'
 		>({ as: 'global' }, (request) => {
+			// @ts-ignore
 			if (request.params?.id) request.params.id = +request.params.id
 		})
 

--- a/test/macro/macro.test.ts
+++ b/test/macro/macro.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, it, expect } from 'bun:test'
-import Elysia, { error, t } from '../../src'
+import Elysia, { t } from '../../src'
 import { req } from '../utils'
+import { status } from '../../dist/cjs'
 
 describe('Macro', () => {
 	it('work', async () => {
@@ -362,7 +363,7 @@ describe('Macro', () => {
 			requiredUser(value: boolean) {
 				onBeforeHandle(async () => {
 					if (value)
-						return error(401, {
+						return status(401, {
 							code: 'S000002',
 							message: 'Unauthorized'
 						})
@@ -416,8 +417,8 @@ describe('Macro', () => {
 		const authGuard = new Elysia().macro(({ onBeforeHandle }) => ({
 			isAuth(shouldAuth: boolean) {
 				if (shouldAuth) {
-					onBeforeHandle(({ cookie: { session }, error }) => {
-						if (!session.value) return error(418)
+					onBeforeHandle(({ cookie: { session }, status }) => {
+						if (!session.value) return status(418)
 					})
 				}
 			}
@@ -438,8 +439,8 @@ describe('Macro', () => {
 		const authGuard = new Elysia().macro(({ onBeforeHandle }) => ({
 			isAuth(shouldAuth: boolean) {
 				if (shouldAuth) {
-					onBeforeHandle(({ cookie: { session }, error }) => {
-						if (!session.value) return error(418)
+					onBeforeHandle(({ cookie: { session }, status }) => {
+						if (!session.value) return status(418)
 					})
 				}
 			}
@@ -456,12 +457,12 @@ describe('Macro', () => {
 		expect(status).toBe(418)
 	})
 
-	it('inherits macro in group', async () => {
+	it('inherits macro from plugin', async () => {
 		const authGuard = new Elysia().macro(({ onBeforeHandle }) => ({
 			isAuth(shouldAuth: boolean) {
 				if (shouldAuth) {
-					onBeforeHandle(({ cookie: { session }, error }) => {
-						if (!session.value) return error(418)
+					onBeforeHandle(({ cookie: { session }, status }) => {
+						if (!session.value) return status(418)
 					})
 				}
 			}
@@ -482,6 +483,7 @@ describe('Macro', () => {
 		const called = <string[]>[]
 
 		const plugin = new Elysia().get('/hello', () => 'hello', {
+			// @ts-ignore
 			hello: 'nagisa'
 		})
 
@@ -581,7 +583,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -615,7 +617,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -650,7 +652,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -685,7 +687,7 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => ({
+					resolve: () => ({
 						account: 'A'
 					})
 				})
@@ -720,8 +722,8 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: ({ error }) => {
-						if (Math.random() > 2) return error(401)
+					resolve: () => {
+						if (Math.random() > 2) return status(401)
 
 						return {
 							account: 'A'
@@ -758,8 +760,8 @@ describe('Macro', () => {
 		const plugin = new Elysia()
 			.macro({
 				account: (a: boolean) => ({
-					resolve: async ({ error }) => {
-						if (Math.random() > 2) return error(401)
+					resolve: async () => {
+						if (Math.random() > 2) return status(401)
 
 						return {
 							account: 'A'
@@ -809,8 +811,8 @@ describe('Macro', () => {
 			})
 			.get(
 				'/',
-				({ user, error }) => {
-					if (!user) return error(401)
+				({ user, status }) => {
+					if (!user) return status(401)
 
 					return { hello: 'hanabi' }
 				},
@@ -903,6 +905,7 @@ describe('Macro', () => {
 					// @ts-expect-error Property `a` does not exist
 					a,
 					b,
+					// @ts-expect-error Property `c` does not exist
 					c
 				}) => ({ a, b, c }),
 				{

--- a/test/macro/macro.test.ts
+++ b/test/macro/macro.test.ts
@@ -1258,4 +1258,185 @@ describe('Macro', () => {
 			tags: ['philosopher', 'npc']
 		})
 	})
+
+	it('handle macro name', async () => {
+		const app = new Elysia()
+			.macro('sartre', {
+				params: t.Object({ sartre: t.Literal('Sartre') })
+			})
+			.macro({
+				focou: {
+					query: t.Object({ focou: t.Literal('Focou') })
+				},
+				lilith: {
+					body: t.Object({ lilith: t.Literal('Lilith') })
+				}
+			})
+			.post('/:sartre', ({ body }) => body, {
+				sartre: true,
+				focou: true,
+				lilith: true
+			})
+
+		expect(app.routes[0].hooks.standaloneValidator.length).toBe(1)
+
+		const valid = await app.handle(
+			post('/Sartre?focou=Focou', {
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(valid.status).toBe(200)
+		expect(await valid.json()).toEqual({
+			lilith: 'Lilith'
+		})
+
+		const invalid1 = await app.handle(
+			post('/Sartre?focou=Focou', {
+				lilith: 'Not Lilith'
+			})
+		)
+
+		expect(invalid1.status).toBe(422)
+
+		const invalid2 = await app.handle(
+			post('/Not Sartre?focou=Focou', {
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(invalid2.status).toBe(422)
+
+		const invalid3 = await app.handle(
+			post('/Sartre?focou=Not Focou', {
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(invalid3.status).toBe(422)
+	})
+
+	it('handle macro name with function', async () => {
+		const app = new Elysia()
+			.macro('sartre', (_: boolean) => ({
+				params: t.Object({ sartre: t.Literal('Sartre') })
+			}))
+			.macro({
+				focou: {
+					query: t.Object({ focou: t.Literal('Focou') })
+				},
+				lilith: {
+					body: t.Object({ lilith: t.Literal('Lilith') })
+				}
+			})
+			.post('/:sartre', ({ body }) => body, {
+				sartre: true,
+				focou: true,
+				lilith: true
+			})
+
+		expect(app.routes[0].hooks.standaloneValidator.length).toBe(1)
+
+		const valid = await app.handle(
+			post('/Sartre?focou=Focou', {
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(valid.status).toBe(200)
+		expect(await valid.json()).toEqual({
+			lilith: 'Lilith'
+		})
+
+		const invalid1 = await app.handle(
+			post('/Sartre?focou=Focou', {
+				lilith: 'Not Lilith'
+			})
+		)
+
+		expect(invalid1.status).toBe(422)
+
+		const invalid2 = await app.handle(
+			post('/Not Sartre?focou=Focou', {
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(invalid2.status).toBe(422)
+
+		const invalid3 = await app.handle(
+			post('/Sartre?focou=Not Focou', {
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(invalid3.status).toBe(422)
+	})
+
+	it('handle macro name extends', async () => {
+		const app = new Elysia()
+			.macro('sartre', {
+				body: t.Object({ sartre: t.Literal('Sartre') })
+			})
+			.macro({
+				focou: {
+					sartre: true,
+					body: t.Object({ focou: t.Literal('Focou') })
+				},
+				lilith: {
+					focou: true,
+					body: t.Object({ lilith: t.Literal('Lilith') })
+				}
+			})
+			.post('/', ({ body }) => body, {
+				lilith: true
+			})
+
+		expect(app.routes[0].hooks.standaloneValidator.length).toBe(3)
+
+		const response = await app.handle(
+			post('/', {
+				sartre: 'Sartre',
+				focou: 'Focou',
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			sartre: 'Sartre',
+			focou: 'Focou',
+			lilith: 'Lilith'
+		})
+
+		const invalid1 = await app.handle(
+			post('/', {
+				sartre: 'Not Sartre',
+				focou: 'Focou',
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(invalid1.status).toBe(422)
+
+		const invalid2 = await app.handle(
+			post('/', {
+				sartre: 'Sartre',
+				focou: 'Not Focou',
+				lilith: 'Lilith'
+			})
+		)
+
+		expect(invalid2.status).toBe(422)
+
+		const invalid3 = await app.handle(
+			post('/', {
+				sartre: 'Sartre',
+				focou: 'Focou',
+				lilith: 'Not Lilith'
+			})
+		)
+
+		expect(invalid3.status).toBe(422)
+	})
 })

--- a/test/path/group.test.ts
+++ b/test/path/group.test.ts
@@ -247,4 +247,23 @@ describe('group', () => {
 
 		expect(response).toEqual('a')
 	})
+
+	it('cast callback function schema to standaloneValidator', async () => {
+		const app = new Elysia().group(
+			'/group/:id',
+			{ params: t.Object({ id: t.Number() }) },
+			(app) =>
+				app.get('/:name', ({ params }) => params, {
+					params: t.Object({ name: t.String() })
+				})
+		)
+
+		const valid = app.handle(req('/group/1/saltyaom')).then((x) => x.json())
+		const invalid = app
+			.handle(req('/group/a/saltyaom'))
+			.then((x) => x.status)
+
+		expect(await valid).toEqual({ id: 1, name: 'saltyaom' })
+		expect(await invalid).toBe(422)
+	})
 })

--- a/test/path/guard.test.ts
+++ b/test/path/guard.test.ts
@@ -420,4 +420,23 @@ describe('guard', () => {
 			'500'
 		])
 	})
+
+	it('cast callback function schema to standaloneValidator', async () => {
+		const app = new Elysia().guard(
+			{ params: t.Object({ id: t.Number() }) },
+			(app) =>
+				app.get('/guard/:id/:name', ({ params }) => params, {
+					params: t.Object({ name: t.String() })
+				})
+		)
+
+		const valid = app.handle(req('/guard/1/saltyaom')).then((x) => x.json())
+		const invalid = app
+			.handle(req('/guard/a/saltyaom'))
+			.then((x) => x.status)
+
+		expect(await valid).toEqual({ id: 1, name: 'saltyaom' })
+		expect(await invalid).toBe(422)
+	})
+
 })

--- a/test/plugins/checksum.test.ts
+++ b/test/plugins/checksum.test.ts
@@ -304,7 +304,7 @@ describe('Checksum', () => {
 		let i = 0
 
 		const plugin = new Elysia().use(
-			new Elysia({ prefix: '/call', scoped: true })
+			new Elysia({ prefix: '/call' })
 				.derive(() => {
 					i++ // <-- should not be called, when requesting /asdf
 					return { test: 'test' }

--- a/test/response/redirect.test.ts
+++ b/test/response/redirect.test.ts
@@ -10,7 +10,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi'
 		})
@@ -24,7 +23,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(301)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi'
 		})
@@ -40,7 +38,6 @@ describe('Response Redirect', () => {
 		const { headers, status } = await app.handle(req('/'))
 
 		expect(status).toBe(302)
-		// @ts-expect-error
 		expect(headers.toJSON()).toEqual({
 			location: '/skadi',
 			alias: 'Abyssal Hunter'

--- a/test/standard-schema/reference.test.ts
+++ b/test/standard-schema/reference.test.ts
@@ -1,0 +1,353 @@
+import { Elysia } from '../../src'
+import { describe, it, expect } from 'bun:test'
+import { z } from 'zod'
+import { post, req } from '../utils'
+
+describe('Standard Schema Validate', () => {
+	it('validate body', async () => {
+		const app = new Elysia()
+			.model({
+				body: z.object({
+					id: z.number()
+				})
+			})
+			.post('/', ({ body }) => body, {
+				body: 'body'
+			})
+
+		const value = await app
+			.handle(
+				post('/', {
+					id: 1
+				})
+			)
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(
+			post('/', {
+				id: '1'
+			})
+		)
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate query', async () => {
+		const app = new Elysia()
+			.model({
+				query: z.object({
+					id: z.coerce.number()
+				})
+			})
+			.get('/', ({ query }) => query, {
+				query: 'query'
+			})
+
+		const value = await app.handle(req('/?id=1')).then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(req('/?id=a'))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate params', async () => {
+		const app = new Elysia()
+			.model({
+				params: z.object({
+					id: z.coerce.number()
+				})
+			})
+			.get('/user/:id', ({ params }) => params, {
+				params: 'params'
+			})
+
+		const value = await app.handle(req('/user/1')).then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(req('/user/a'))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate headers', async () => {
+		const app = new Elysia()
+			.model({
+				headers: z.object({
+					id: z.coerce.number()
+				})
+			})
+			.get('/', ({ headers }) => headers, {
+				headers: 'headers'
+			})
+
+		const value = await app
+			.handle(
+				req('/', {
+					headers: {
+						id: '1'
+					}
+				})
+			)
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(req('/', {}))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate single response', async () => {
+		const app = new Elysia()
+			.model({
+				response: z.boolean()
+			})
+			.get(
+				'/:name',
+				// @ts-expect-error
+				({ params: { name } }) =>
+					name === 'lilith' ? undefined : true,
+				{
+					response: 'response'
+				}
+			)
+
+		const exists = await app.handle(req('/fouco'))
+		const nonExists = await app.handle(req('/lilith'))
+
+		expect(exists.status).toBe(200)
+		expect(nonExists.status).toBe(422)
+	})
+
+	it('validate multiple response', async () => {
+		const app = new Elysia()
+			.model({
+				'response.404': z.literal('lilith'),
+				'response.418': z.literal('fouco')
+			})
+			.get(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, 'lilith')
+						: status(418, name as any),
+				{
+					response: {
+						404: 'response.404',
+						418: 'response.418'
+					}
+				}
+			)
+
+		const exists = await app.handle(req('/fouco'))
+		const nonExists = await app.handle(req('/lilith'))
+
+		expect(exists.status).toBe(418)
+		expect(nonExists.status).toBe(404)
+
+		const invalid = await app.handle(req('/unknown'))
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate multiple schema together', async () => {
+		const app = new Elysia()
+			.model({
+				body: z.object({
+					id: z.number()
+				}),
+				query: z.object({
+					limit: z.coerce.number()
+				}),
+				params: z.object({
+					name: z.literal('fouco').or(z.literal('lilith'))
+				}),
+				'response.404': z.literal('lilith'),
+				'response.418': z.literal('fouco')
+			})
+			.post(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, 'lilith')
+						: status(418, name as any),
+				{
+					body: 'body',
+					query: 'query',
+					params: 'params',
+					response: {
+						404: 'response.404',
+						418: 'response.418'
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith?limit=1', {
+					id: 1
+				}),
+				post('/fouco?limit=10', {
+					id: 2
+				}),
+				post('/unknown?limit=10', {
+					id: 2
+				}),
+				post('/fouco?limit=a', {
+					id: 2
+				}),
+				post('/fouco?limit=10', {
+					id: '2'
+				}),
+				post('/fouco', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+	})
+
+	it('merge guard', async () => {
+		const app = new Elysia()
+			.model({
+				body: z.object({
+					id: z.number()
+				}),
+				query: z.object({
+					limit: z.coerce.number()
+				}),
+				params: z.object({
+					name: z.literal('fouco').or(z.literal('lilith'))
+				}),
+				'response.404': z.literal('lilith'),
+				'response.418': z.literal('fouco')
+			})
+			.guard({
+				body: 'body',
+				query: 'query',
+				response: {
+					404: 'response.404'
+				}
+			})
+			.post(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, 'lilith')
+						: status(418, name as any),
+				{
+					params: 'params',
+					response: {
+						418: 'response.418'
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith?limit=1', {
+					id: 1
+				}),
+				post('/fouco?limit=10', {
+					id: 2
+				}),
+				post('/unknown?limit=10', {
+					id: 2
+				}),
+				post('/fouco?limit=a', {
+					id: 2
+				}),
+				post('/fouco?limit=10', {
+					id: '2'
+				}),
+				post('/fouco', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+	})
+
+	it('merge plugin', async () => {
+		const plugin = new Elysia()
+			.model({
+				body: z.object({
+					id: z.number()
+				}),
+				query: z.object({
+					limit: z.coerce.number()
+				}),
+				params: z.object({
+					name: z.literal('fouco').or(z.literal('lilith'))
+				}),
+				'response.404': z.literal('lilith'),
+				'response.418': z.literal('fouco')
+			})
+			.guard({
+				as: 'scoped',
+				body: 'body',
+				query: 'query',
+				response: {
+					404: 'response.404'
+				}
+			})
+
+		const app = new Elysia()
+			.use(plugin)
+			.post(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, 'lilith')
+						: status(418, name as any),
+				{
+					params: z.object({
+						name: z.literal('fouco').or(z.literal('lilith'))
+					}),
+					response: {
+						418: 'response.418'
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith?limit=1', {
+					id: 1
+				}),
+				post('/fouco?limit=10', {
+					id: 2
+				}),
+				post('/unknown?limit=10', {
+					id: 2
+				}),
+				post('/fouco?limit=a', {
+					id: 2
+				}),
+				post('/fouco?limit=10', {
+					id: '2'
+				}),
+				post('/fouco', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+	})
+})

--- a/test/standard-schema/standalone.test.ts
+++ b/test/standard-schema/standalone.test.ts
@@ -213,6 +213,9 @@ describe('Standard Schema Standalone', () => {
 
 	it('validate multiple schema together', async () => {
 		const app = new Elysia()
+			.onError(({ error, code }) => {
+				if (code !== 'VALIDATION') console.log(error)
+			})
 			.guard({
 				schema: 'standalone',
 				body: z.object({

--- a/test/standard-schema/standalone.test.ts
+++ b/test/standard-schema/standalone.test.ts
@@ -1,0 +1,573 @@
+import { Elysia, t } from '../../src'
+import { describe, it, expect } from 'bun:test'
+import { z } from 'zod'
+import * as v from 'valibot'
+import { type } from 'arktype'
+import { post, req } from '../utils'
+
+describe('Standard Schema Standalone', () => {
+	it('validate and normalize body', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				body: z.object({
+					id: z.number()
+				})
+			})
+			.post('/', ({ body }) => body, {
+				body: t.Object({
+					name: t.Literal('lilith')
+				})
+			})
+
+		const value = await app
+			.handle(
+				post('/', {
+					id: 1,
+					name: 'lilith',
+					extra: false
+				})
+			)
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1, name: 'lilith' })
+
+		const invalid = await app.handle(
+			post('/', {
+				id: '1',
+				name: 'fouco',
+				extra: false
+			})
+		)
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate query', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				query: z.object({
+					id: z.coerce.number()
+				})
+			})
+			.get('/', ({ query }) => query, {
+				query: t.Object({
+					name: t.Literal('lilith')
+				})
+			})
+
+		const value = await app
+			.handle(req('/?id=1&name=lilith&extra=true'))
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1, name: 'lilith' })
+
+		const invalid = await app.handle(req('/?id=a&name=fouco'))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate and normalize params', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				params: z.object({
+					id: z.coerce.number()
+				})
+			})
+			.get('/:name/:id', ({ params }) => params, {
+				params: t.Object({
+					name: t.Literal('lilith')
+				})
+			})
+
+		const value = await app.handle(req('/lilith/1')).then((x) => x.json())
+
+		expect(value).toEqual({ id: 1, name: 'lilith' })
+
+		const invalid = await app.handle(req('/user/a?name=fouco'))
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate and normalize headers', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				headers: z.object({
+					id: z.coerce.number()
+				})
+			})
+			.get('/', ({ headers }) => headers, {
+				headers: t.Object({
+					name: t.Literal('lilith')
+				})
+			})
+
+		const value = await app
+			.handle(
+				req('/', {
+					headers: {
+						id: '1',
+						name: 'lilith',
+						extra: 'false'
+					}
+				})
+			)
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1, name: 'lilith' })
+
+		const invalid = await app.handle(
+			req('/', {
+				headers: {
+					id: 'a',
+					name: 'fouco'
+				}
+			})
+		)
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate and normalize single response', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				response: z.object({
+					id: z.number()
+				})
+			})
+			.get(
+				'/:name',
+				// @ts-expect-error
+				({ params: { name } }) => ({
+					name,
+					id: name !== 'lilith' ? undefined : 1,
+					extra: false
+				}),
+				{
+					response: t.Object({
+						name: t.Literal('lilith')
+					})
+				}
+			)
+
+		const valid = await app.handle(req('/lilith')).then((x) => x.json())
+
+		expect(valid).toEqual({ id: 1, name: 'lilith' })
+
+		const invalid = await app.handle(req('/focou'))
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate and normalize multiple response', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				response: {
+					404: z.object({
+						id: z.number()
+					}),
+					418: z.object({
+						id: z.number()
+					})
+				}
+			})
+			.get(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, {
+								name,
+								id: 1,
+								extra: false
+							})
+						: status(418, {
+								// @ts-expect-error
+								name,
+								id: 2,
+								extra: false
+							}),
+				{
+					response: {
+						404: t.Object({
+							name: t.Literal('lilith')
+						}),
+						418: t.Object({
+							name: t.Literal('fouco')
+						})
+					}
+				}
+			)
+
+		const lilith = await app.handle(req('/lilith')).then((x) => x.json())
+		const fouco = await app.handle(req('/fouco')).then((x) => x.json())
+
+		expect(lilith).toEqual({ id: 1, name: 'lilith' })
+		expect(fouco).toEqual({ id: 2, name: 'fouco' })
+
+		const invalid = await app.handle(req('/unknown'))
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate multiple schema together', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				body: z.object({
+					name: z.string()
+				}),
+				query: z.object({
+					id: z.coerce.number()
+				}),
+				params: z.object({
+					id: z.coerce.number()
+				}),
+				response: {
+					404: z.object({
+						id: z.number()
+					}),
+					418: z.object({
+						id: z.number()
+					})
+				}
+			})
+			.post(
+				'/:name/:id',
+				({ params: { name, id }, status }) =>
+					name === 'lilith'
+						? status(404, {
+								name,
+								id,
+								extra: true
+							})
+						: status(418, {
+								name,
+								id,
+								extra: true
+							}),
+				{
+					body: t.Object({
+						id: t.Number()
+					}),
+					query: t.Object({
+						limit: t.Number()
+					}),
+					params: t.Object({
+						name: t.UnionEnum(['fouco', 'lilith'])
+					}),
+					response: {
+						404: z.object({ name: z.literal('lilith') }),
+						418: z.object({ name: z.literal('fouco') })
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith/1?limit=1&id=1', {
+					id: 1,
+					name: 'lilith'
+				}),
+				post('/fouco/2?limit=10&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/unknown/2?limit=10&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/2?limit=a&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/2?limit=10&id=2', {
+					id: '2',
+					name: 'fouco'
+				}),
+				post('/fouco/2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/a?limit=10&id=2', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+		expect(responses[6]).toEqual(422)
+	})
+
+	it('merge plugin', async () => {
+		const plugin = new Elysia().guard({
+			as: 'scoped',
+			schema: 'standalone',
+			response: {
+				404: z.object({
+					id: z.number()
+				}),
+				418: z.object({
+					id: z.number()
+				})
+			}
+		})
+
+		const app = new Elysia().use(plugin).get(
+			'/:name',
+			({ params: { name }, status }) =>
+				name === 'lilith'
+					? status(404, {
+							name,
+							id: 1,
+							extra: false
+						})
+					: status(418, {
+							// @ts-expect-error
+							name,
+							id: 2,
+							extra: false
+						}),
+			{
+				response: {
+					404: t.Object({
+						name: t.Literal('lilith')
+					}),
+					418: t.Object({
+						name: t.Literal('fouco')
+					})
+				}
+			}
+		)
+
+		const lilith = await app.handle(req('/lilith')).then((x) => x.json())
+		const fouco = await app.handle(req('/fouco')).then((x) => x.json())
+
+		expect(lilith).toEqual({ id: 1, name: 'lilith' })
+		expect(fouco).toEqual({ id: 2, name: 'fouco' })
+
+		const invalid = await app.handle(req('/unknown'))
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate non-typebox schema', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				body: z.object({
+					name: z.string()
+				}),
+				query: z.object({
+					id: z.coerce.number()
+				}),
+				params: z.object({
+					id: z.coerce.number()
+				}),
+				response: {
+					404: z.object({
+						id: z.number()
+					}),
+					418: z.object({
+						id: z.number()
+					})
+				}
+			})
+			.post(
+				'/:name/:id',
+				({ params: { name, id }, status }) =>
+					name === 'lilith'
+						? status(404, {
+								name,
+								id,
+								extra: true
+							})
+						: status(418, {
+								name,
+								id,
+								extra: true
+							}),
+				{
+					body: v.object({
+						id: v.number()
+					}),
+					query: v.object({
+						limit: v.pipe(
+							v.string(),
+							v.transform(Number),
+							v.number()
+						)
+					}),
+					params: v.object({
+						name: v.union([v.literal('fouco'), v.literal('lilith')])
+					}),
+					response: {
+						404: v.object({ name: v.literal('lilith') }),
+						418: v.object({ name: v.literal('fouco') })
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith/1?limit=1&id=1', {
+					id: 1,
+					name: 'lilith'
+				}),
+				post('/fouco/2?limit=10&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/unknown/2?limit=10&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/2?limit=a&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/2?limit=10&id=2', {
+					id: '2',
+					name: 'fouco'
+				}),
+				post('/fouco/2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/a?limit=10&id=2', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+		expect(responses[6]).toEqual(422)
+	})
+
+	it('validate 3 schema validators without TypeBox', async () => {
+		const app = new Elysia()
+			.guard({
+				schema: 'standalone',
+				body: z.object({
+					name: z.string()
+				}),
+				query: z.object({
+					id: z.coerce.number()
+				}),
+				params: z.object({
+					id: z.coerce.number()
+				}),
+				response: {
+					404: z.object({
+						id: z.number()
+					}),
+					418: z.object({
+						id: z.number()
+					})
+				}
+			})
+			.guard({
+				schema: 'standalone',
+				body: type({
+					world: '"fantasy"'
+				}),
+				query: type({
+					world: '"fantasy"'
+				}),
+				response: {
+					404: type({
+						world: '"fantasy"'
+					}),
+					418: type({
+						world: '"fantasy"'
+					})
+				}
+			})
+			.post(
+				'/:name/:id',
+				({ params: { name, id }, status }) =>
+					name === 'lilith'
+						? status(404, {
+								name,
+								id,
+								world: 'fantasy'
+							})
+						: status(418, {
+								name,
+								id,
+								world: 'fantasy'
+							}),
+				{
+					body: v.object({
+						id: v.number()
+					}),
+					query: v.object({
+						limit: v.pipe(
+							v.string(),
+							v.transform(Number),
+							v.number()
+						)
+					}),
+					params: v.object({
+						name: v.union([v.literal('fouco'), v.literal('lilith')])
+					}),
+					response: {
+						404: v.object({ name: v.literal('lilith') }),
+						418: v.object({ name: v.literal('fouco') })
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith/1?limit=1&id=1&world=fantasy', {
+					id: 1,
+					name: 'lilith',
+					world: 'fantasy'
+				}),
+				post('/fouco/2?limit=10&id=2&world=fantasy', {
+					id: 2,
+					name: 'fouco',
+					world: 'fantasy'
+				}),
+				post('/unknown/2?limit=10&id=2&world=fantasy', {
+					id: 2,
+					name: 'fouco',
+					world: 'fantasy'
+				}),
+				post('/unknown/2?limit=10&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/2?limit=a&id=2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/2?limit=10&id=2', {
+					id: '2',
+					name: 'fouco'
+				}),
+				post('/fouco/2', {
+					id: 2,
+					name: 'fouco'
+				}),
+				post('/fouco/a?limit=10&id=2', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+		expect(responses[6]).toEqual(422)
+		expect(responses[7]).toEqual(422)
+	})
+})

--- a/test/standard-schema/validate.test.ts
+++ b/test/standard-schema/validate.test.ts
@@ -1,0 +1,302 @@
+import { Elysia } from '../../src'
+import { describe, it, expect } from 'bun:test'
+import { z } from 'zod'
+import { post, req } from '../utils'
+
+describe('Standard Schema Validate', () => {
+	it('validate body', async () => {
+		const app = new Elysia().post('/', ({ body }) => body, {
+			body: z.object({
+				id: z.number()
+			})
+		})
+
+		const value = await app
+			.handle(
+				post('/', {
+					id: 1
+				})
+			)
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(
+			post('/', {
+				id: '1'
+			})
+		)
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate query', async () => {
+		const app = new Elysia().get('/', ({ query }) => query, {
+			query: z.object({
+				id: z.coerce.number()
+			})
+		})
+
+		const value = await app.handle(req('/?id=1')).then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(req('/?id=a'))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate params', async () => {
+		const app = new Elysia().get('/user/:id', ({ params }) => params, {
+			params: z.object({
+				id: z.coerce.number()
+			})
+		})
+
+		const value = await app.handle(req('/user/1')).then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(req('/user/a'))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate headers', async () => {
+		const app = new Elysia().get('/', ({ headers }) => headers, {
+			headers: z.object({
+				id: z.coerce.number()
+			})
+		})
+
+		const value = await app
+			.handle(
+				req('/', {
+					headers: {
+						id: '1'
+					}
+				})
+			)
+			.then((x) => x.json())
+
+		expect(value).toEqual({ id: 1 })
+
+		const invalid = await app.handle(req('/', {}))
+
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate single response', async () => {
+		const app = new Elysia().get(
+			'/:name',
+			// @ts-expect-error
+			({ params: { name } }) => (name === 'lilith' ? undefined : true),
+			{
+				response: z.boolean()
+			}
+		)
+
+		const exists = await app.handle(req('/fouco'))
+		const nonExists = await app.handle(req('/lilith'))
+
+		expect(exists.status).toBe(200)
+		expect(nonExists.status).toBe(422)
+	})
+
+	it('validate multiple response', async () => {
+		const app = new Elysia().get(
+			'/:name',
+			({ params: { name }, status }) =>
+				name === 'lilith'
+					? status(404, 'lilith')
+					: status(418, name as any),
+			{
+				response: {
+					404: z.literal('lilith'),
+					418: z.literal('fouco')
+				}
+			}
+		)
+
+		const exists = await app.handle(req('/fouco'))
+		const nonExists = await app.handle(req('/lilith'))
+
+		expect(exists.status).toBe(418)
+		expect(nonExists.status).toBe(404)
+
+		const invalid = await app.handle(req('/unknown'))
+		expect(invalid.status).toBe(422)
+	})
+
+	it('validate multiple schema together', async () => {
+		const app = new Elysia().post(
+			'/:name',
+			({ params: { name }, status }) =>
+				name === 'lilith'
+					? status(404, 'lilith')
+					: status(418, name as any),
+			{
+				body: z.object({
+					id: z.number()
+				}),
+				query: z.object({
+					limit: z.coerce.number()
+				}),
+				params: z.object({
+					name: z.literal('fouco').or(z.literal('lilith'))
+				}),
+				response: {
+					404: z.literal('lilith'),
+					418: z.literal('fouco')
+				}
+			}
+		)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith?limit=1', {
+					id: 1
+				}),
+				post('/fouco?limit=10', {
+					id: 2
+				}),
+				post('/unknown?limit=10', {
+					id: 2
+				}),
+				post('/fouco?limit=a', {
+					id: 2
+				}),
+				post('/fouco?limit=10', {
+					id: '2'
+				}),
+				post('/fouco', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+	})
+
+	it('merge guard', async () => {
+		const app = new Elysia()
+			.guard({
+				body: z.object({
+					id: z.number()
+				}),
+				query: z.object({
+					limit: z.coerce.number()
+				}),
+				response: {
+					404: z.literal('lilith')
+				}
+			})
+			.post(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, 'lilith')
+						: status(418, name as any),
+				{
+					params: z.object({
+						name: z.literal('fouco').or(z.literal('lilith'))
+					}),
+					response: {
+						418: z.literal('fouco')
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith?limit=1', {
+					id: 1
+				}),
+				post('/fouco?limit=10', {
+					id: 2
+				}),
+				post('/unknown?limit=10', {
+					id: 2
+				}),
+				post('/fouco?limit=a', {
+					id: 2
+				}),
+				post('/fouco?limit=10', {
+					id: '2'
+				}),
+				post('/fouco', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+	})
+
+	it('merge plugin', async () => {
+		const plugin = new Elysia().guard({
+			as: 'scoped',
+			body: z.object({
+				id: z.number()
+			}),
+			query: z.object({
+				limit: z.coerce.number()
+			}),
+			response: {
+				404: z.literal('lilith')
+			}
+		})
+
+		const app = new Elysia()
+			.use(plugin)
+			.post(
+				'/:name',
+				({ params: { name }, status }) =>
+					name === 'lilith'
+						? status(404, 'lilith')
+						: status(418, name as any),
+				{
+					params: z.object({
+						name: z.literal('fouco').or(z.literal('lilith'))
+					}),
+					response: {
+						418: z.literal('fouco')
+					}
+				}
+			)
+
+		const responses = await Promise.all(
+			[
+				post('/lilith?limit=1', {
+					id: 1
+				}),
+				post('/fouco?limit=10', {
+					id: 2
+				}),
+				post('/unknown?limit=10', {
+					id: 2
+				}),
+				post('/fouco?limit=a', {
+					id: 2
+				}),
+				post('/fouco?limit=10', {
+					id: '2'
+				}),
+				post('/fouco', {})
+			].map((x) => app.handle(x).then((x) => x.status))
+		)
+
+		expect(responses[0]).toEqual(404)
+		expect(responses[1]).toEqual(418)
+		expect(responses[2]).toEqual(422)
+		expect(responses[3]).toEqual(422)
+		expect(responses[4]).toEqual(422)
+		expect(responses[5]).toEqual(422)
+	})
+})

--- a/test/sucrose/infer-body-reference.test.ts
+++ b/test/sucrose/infer-body-reference.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { inferBodyReference } from '../../src/sucrose'
+import { inferBodyReference, Sucrose } from '../../src/sucrose'
 
 describe('infer body reference', () => {
 	it('infer dot notation', () => {
@@ -11,12 +11,15 @@ describe('infer body reference', () => {
 			body: false,
 			cookie: false,
 			set: false,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
-		expect(inference.body).toBe(true)
+		expect(inference.body as boolean).toBe(true)
 	})
 
 	it('infer property access', () => {
@@ -28,12 +31,15 @@ describe('infer body reference', () => {
 			body: false,
 			cookie: false,
 			set: false,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
-		expect(inference.body).toBe(true)
+		expect(inference.body as boolean).toBe(true)
 	})
 
 	it('infer multiple query', () => {
@@ -52,8 +58,11 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
@@ -63,7 +72,10 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
+			server: false,
+			path: false,
+			route: false,
+			url: false
 		})
 	})
 
@@ -141,8 +153,11 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
@@ -152,7 +167,10 @@ describe('infer body reference', () => {
 			headers: false,
 			query: true,
 			set: true,
-			server: false
+			server: false,
+			path: false,
+			route: false,
+			url: false
 		})
 	})
 
@@ -167,11 +185,14 @@ describe('infer body reference', () => {
 			body: false,
 			cookie: false,
 			set: false,
-			server: false
-		}
+			server: false,
+			path: false,
+			route: false,
+			url: false
+		} satisfies Sucrose.Inference
 
 		inferBodyReference(code, aliases, inference)
 
-		expect(inference.server).toBe(true)
+		expect(inference.server as boolean).toBe(true)
 	})
 })

--- a/test/tracer/trace.test.ts
+++ b/test/tracer/trace.test.ts
@@ -31,7 +31,7 @@ describe('trace', () => {
 			clearTimeout(timeout)
 		})
 
-		const b = new Elysia({ scoped: true }).get('/scoped', () => 'hi')
+		const b = new Elysia().get('/scoped', () => 'hi')
 
 		const app = new Elysia()
 			.use(a)

--- a/test/type-system/boolean-string.test.ts
+++ b/test/type-system/boolean-string.test.ts
@@ -63,10 +63,10 @@ describe('TypeSystem - BooleanString', () => {
 		expect(() => Value.Decode(schema, null)).toThrow(error)
 	})
 
-	it('Convert', () => {
-		expect(Value.Convert(t.BooleanString(), 'true')).toBe(true)
-		expect(Value.Convert(t.BooleanString(), 'false')).toBe(false)
-	})
+	// it('Convert', () => {
+	// 	expect(Value.Convert(t.BooleanString(), 'true')).toBe(true)
+	// 	expect(Value.Convert(t.BooleanString(), 'false')).toBe(false)
+	// })
 
 	it('Integrate', async () => {
 		const app = new Elysia().get('/', ({ query }) => query, {

--- a/test/type-system/uint8array.test.ts
+++ b/test/type-system/uint8array.test.ts
@@ -63,11 +63,7 @@ describe('TypeSystem - Uint8Array', () => {
 	// })
 
 	it('Integrate', async () => {
-		const app = new Elysia().post('/', ({ body }) => {
-			console.log(body)
-
-			return body
-		}, {
+		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.Uint8Array(),
 			response: t.Uint8Array()
 		})

--- a/test/type-system/union-enum.test.ts
+++ b/test/type-system/union-enum.test.ts
@@ -14,11 +14,10 @@ describe('TypeSystem - UnionEnum', () => {
 	})
 
 	it('Check', () => {
-		const schema = t.UnionEnum(['some', 'data', null])
+		const schema = t.UnionEnum(['some', 'data'])
 
 		expect(Value.Check(schema, 'some')).toBe(true)
 		expect(Value.Check(schema, 'data')).toBe(true)
-		expect(Value.Check(schema, null)).toBe(true)
 
 		expect(Value.Check(schema, { deep: 2 })).toBe(false)
 		expect(Value.Check(schema, 'yay')).toBe(false)
@@ -26,6 +25,7 @@ describe('TypeSystem - UnionEnum', () => {
 		expect(Value.Check(schema, {})).toBe(false)
 		expect(Value.Check(schema, undefined)).toBe(false)
 	})
+
 	it('JSON schema', () => {
 		expect(t.UnionEnum(['some', 'data'])).toMatchObject({
 			type: 'string',
@@ -36,27 +36,21 @@ describe('TypeSystem - UnionEnum', () => {
 			type: 'number',
 			enum: [2, 1]
 		})
-		expect(t.UnionEnum([null])).toMatchObject({
-			type: 'null',
-			enum: [null]
-		})
 	})
+
 	it('Integrate', async () => {
 		const app = new Elysia().post('/', ({ body }) => body, {
 			body: t.Object({
-				value: t.UnionEnum(['some', 1, null])
+				value: t.UnionEnum(['some', 1])
 			})
 		})
 		const res1 = await app.handle(post('/', { value: 1 }))
 		expect(res1.status).toBe(200)
 
-		const res2 = await app.handle(post('/', { value: null }))
+		const res2 = await app.handle(post('/', { value: 'some' }))
 		expect(res2.status).toBe(200)
 
-		const res3 = await app.handle(post('/', { value: 'some' }))
-		expect(res3.status).toBe(200)
-
-		const res4 = await app.handle(post('/', { value: 'data' }))
-		expect(res4.status).toBe(422)
+		const res3 = await app.handle(post('/', { value: 'data' }))
+		expect(res3.status).toBe(422)
 	})
 })

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1329,20 +1329,16 @@ const a = app
 	}>()
 
 	expectTypeOf<app['error']['get']['response']>().toEqualTypeOf<{
-		200: never
 		418: 'a'
 	}>()
 
-	expectTypeOf<app['mirror']['post']['response']>().toEqualTypeOf<{
-		200: unknown
-	}>()
+	expectTypeOf<app['mirror']['post']['response']>().toEqualTypeOf<{}>()
 
 	expectTypeOf<app['immutable']['get']['response']>().toEqualTypeOf<{
 		200: '1'
 	}>()
 
 	expectTypeOf<app['immutable-error']['get']['response']>().toEqualTypeOf<{
-		200: never
 		418: 'a'
 	}>()
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -4,10 +4,10 @@ import {
 	Elysia,
 	RouteSchema,
 	Cookie,
-	error,
 	file,
 	sse,
-	SSEPayload
+	SSEPayload,
+    status
 } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
@@ -67,7 +67,7 @@ app.model({
 
 		// ? unwrap cookie
 		expectTypeOf<
-			Record<string, Cookie<string | undefined>> & {
+			Record<string, Cookie<unknown>> & {
 				username: Cookie<string>
 				password: Cookie<string>
 			}
@@ -1255,14 +1255,13 @@ const a = app
 // ? Handle error status
 {
 	const a = new Elysia()
-		.get('/', ({ error }) => error(418, 'a'), {
+		.get('/', ({ status }) => status(418, 'a'), {
 			response: {
 				200: t.String(),
 				418: t.Literal('a')
 			}
 		})
-		// @ts-expect-error
-		.get('/', ({ error }) => error(418, 'b'), {
+		.get('/', ({ status }) => status(418, 'b' as any), {
 			response: {
 				200: t.String(),
 				418: t.Literal('a')
@@ -1277,18 +1276,18 @@ const a = app
 		.get('/true', () => true)
 		.post('', () => 'a', { response: { 201: t.String() } })
 		.post('/true', () => true, { response: { 202: t.Boolean() } })
-		.get('/error', ({ error }) => error("I'm a teapot", 'a'))
+		.get('/error', ({ status }) => status("I'm a teapot", 'a'))
 		.post('/mirror', ({ body }) => body)
 		.get('/immutable', '1')
-		.get('/immutable-error', ({ error }) => error("I'm a teapot", 'a'))
-		.get('/async', async ({ error }) => {
-			if (Math.random() > 0.5) return error("I'm a teapot", 'Nagisa')
+		.get('/immutable-error', ({ status }) => status("I'm a teapot", 'a'))
+		.get('/async', async ({ status }) => {
+			if (Math.random() > 0.5) return status("I'm a teapot", 'Nagisa')
 
 			return 'Hifumi'
 		})
-		.get('/default-error-code', ({ error }) => {
-			if (Math.random() > 0.5) return error(418, 'Nagisa')
-			if (Math.random() > 0.5) return error(401)
+		.get('/default-error-code', ({ status }) => {
+			if (Math.random() > 0.5) return status(418, 'Nagisa')
+			if (Math.random() > 0.5) return status(401)
 
 			return 'Hifumi'
 		})
@@ -1643,9 +1642,9 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', ({ error }) => {
-				error('Payment Required', 20)
-				return error(401, true)
+			.get('/plugin', ({ status }) => {
+				status('Payment Required', 20)
+				return status(401, true)
 			})
 
 		const app = new Elysia().use(plugin).get('/', () => 'ok')
@@ -1670,7 +1669,7 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', error(401, true))
+			.get('/plugin', status(401, true))
 
 		const app = new Elysia().use(plugin).get('/', 'ok')
 	}
@@ -1905,9 +1904,9 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', ({ error }) => {
-				error('Payment Required', 20)
-				return error(401, true)
+			.get('/plugin', ({ status }) => {
+				status('Payment Required', 20)
+				return status(401, true)
 			})
 
 		const app = new Elysia().use(plugin).get('/', () => 'ok')
@@ -1932,7 +1931,7 @@ type a = keyof {}
 					401: t.Boolean()
 				}
 			})
-			.get('/plugin', error(401, true))
+			.get('/plugin', status(401, true))
 
 		const app = new Elysia().use(plugin).get('/', 'ok')
 	}
@@ -2287,12 +2286,12 @@ type a = keyof {}
 
 				return {
 					beforeHandle({
-						error,
+						status,
 						cookie: { token },
 						store: { session }
 					}) {
 						if (!token.value)
-							return error(401, {
+							return status(401, {
 								success: false,
 								message: 'Unauthorized'
 							})
@@ -2305,7 +2304,7 @@ type a = keyof {}
 							session[token.value as unknown as number]
 
 						if (!username)
-							return error(401, {
+							return status(401, {
 								success: false,
 								message: 'Unauthorized'
 							})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1251,7 +1251,7 @@ const a = app
 							params: {}
 							query: unknown
 							headers: unknown
-       response: {};
+							response: {}
 						}
 					}
 				}

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -7,7 +7,7 @@ import {
 	file,
 	sse,
 	SSEPayload,
-    status
+	status
 } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
@@ -98,14 +98,14 @@ app.model({
 			{
 				username: string
 				password: string
-			}[]
+			}
 		>().toEqualTypeOf<typeof body>()
 
 		return body
 	},
 	{
-		body: 't[]',
-		response: 't[]'
+		body: 't',
+		response: 't'
 	}
 )
 
@@ -219,10 +219,10 @@ app.model({
 				'/',
 				({ body }) => {
 					expectTypeOf<typeof body>().not.toBeUnknown()
-					expectTypeOf<typeof body>().toEqualTypeOf<string[]>()
+					expectTypeOf<typeof body>().toEqualTypeOf<string>()
 				},
 				{
-					body: 'string[]'
+					body: 'string'
 				}
 			)
 			.model({
@@ -460,10 +460,10 @@ const b = app
 	.post(
 		'/',
 		({ body }) => {
-			expectTypeOf<typeof body>().toEqualTypeOf<'c'[]>()
+			expectTypeOf<typeof body>().toEqualTypeOf<'c'>()
 		},
 		{
-			body: 'c[]'
+			body: 'c'
 		}
 	)
 
@@ -553,10 +553,10 @@ app.use(plugin)
 		({ body, decorate, store: { state } }) => {
 			expectTypeOf<typeof decorate>().toBeString()
 			expectTypeOf<typeof state>().toBeString()
-			expectTypeOf<typeof body>().toEqualTypeOf<string[]>()
+			expectTypeOf<typeof body>().toEqualTypeOf<string>()
 		},
 		{
-			body: 'string[]'
+			body: 'string'
 		}
 	)
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,5 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { t, Elysia, Cookie, file, sse, SSEPayload, status, form } from '../../src'
+import {
+	t,
+	Elysia,
+	Cookie,
+	file,
+	sse,
+	SSEPayload,
+	status,
+	form
+} from '../../src'
 import { expectTypeOf } from 'expect-type'
 
 const app = new Elysia()
@@ -722,7 +731,7 @@ app.use(plugin).group(
 	type Route = App['v1']['a']['subscribe']
 	expectTypeOf<Route>().toEqualTypeOf<{
 		body: string
-		params: Record<never, string>
+		params: {}
 		query: {
 			name: string
 		}

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1171,10 +1171,8 @@ const a = app
 	})
 
 {
-	app.macro(() => {
-		return {
-			a(a: string) {}
-		}
+	app.macro({
+		a(a: string) {}
 	})
 		.get('/', () => {}, {
 			// ? Should contains macro
@@ -1185,10 +1183,8 @@ const a = app
 			// @ts-expect-error
 			a: 1
 		})
-		.macro(() => {
-			return {
-				b(a: number) {}
-			}
+		.macro({
+			b(a: number) {}
 		})
 		.get('/', () => {}, {
 			// ? Should merge macro

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -2,7 +2,6 @@
 import {
 	t,
 	Elysia,
-	RouteSchema,
 	Cookie,
 	file,
 	sse,
@@ -94,12 +93,10 @@ app.model({
 	'/',
 	({ body }) => {
 		// ? unwrap body type
-		expectTypeOf<
-			{
-				username: string
-				password: string
-			}
-		>().toEqualTypeOf<typeof body>()
+		expectTypeOf<{
+			username: string
+			password: string
+		}>().toEqualTypeOf<typeof body>()
 
 		return body
 	},

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -690,10 +690,10 @@ app.use(plugin).group(
 	type Route = App['get']
 
 	expectTypeOf<Route>().toEqualTypeOf<{
-		body: {}
+		body: unknown
 		params: {}
-		query: {}
-		headers: {}
+		query: unknown
+		headers: unknown
 		response: {
 			200: number
 		}
@@ -738,7 +738,17 @@ app.use(plugin).group(
 		headers: {
 			authorization: string
 		}
-		response: unknown
+		response: {
+			422: {
+				type: 'validation'
+				on: string
+				summary?: string
+				message?: string
+				found?: unknown
+				property?: string
+				expected?: string
+			}
+		}
 	}>()
 }
 
@@ -750,10 +760,10 @@ app.use(plugin).group(
 	type Route = App['get']
 
 	expectTypeOf<Route>().toEqualTypeOf<{
-		body: {}
+		body: unknown
 		params: {}
-		query: {}
-		headers: {}
+		query: unknown
+		headers: unknown
 		response: {
 			200: string
 		}
@@ -956,10 +966,10 @@ app.group(
 	type Route = App['get']
 
 	expectTypeOf<Route>().toEqualTypeOf<{
-		body: {}
+		body: unknown
 		params: {}
-		query: {}
-		headers: {}
+		query: unknown
+		headers: unknown
 		response: {
 			200: string
 		}
@@ -983,10 +993,10 @@ app.group(
 			app: {
 				test: {
 					get: {
-						body: {}
+						body: unknown
 						params: {}
-						query: {}
-						headers: {}
+						query: unknown
+						headers: unknown
 						response: {
 							200: string
 						}
@@ -1219,10 +1229,10 @@ const a = app
 				'could-be-error': {
 					right: {
 						get: {
-							body: {}
+							body: unknown
 							params: {}
-							query: {}
-							headers: {}
+							query: unknown
+							headers: unknown
 							response: {
 								200: {
 									couldBeError: boolean
@@ -1241,7 +1251,7 @@ const a = app
 							params: {}
 							query: unknown
 							headers: unknown
-							response: unknown
+       response: {};
 						}
 					}
 				}

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1301,7 +1301,7 @@ const a = app
 
 	expectTypeOf<app['post']['response']>().toEqualTypeOf<{
 		200: string
-		readonly 201: string
+		201: string
 		422: {
 			type: 'validation'
 			on: string
@@ -1319,7 +1319,7 @@ const a = app
 
 	expectTypeOf<app['true']['post']['response']>().toEqualTypeOf<{
 		200: boolean
-		readonly 202: boolean
+		202: boolean
 		422: {
 			type: 'validation'
 			on: string
@@ -2014,32 +2014,46 @@ type a = keyof {}
 {
 	new Elysia()
 		.onParse(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.derive(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 
 			return {}
 		})
 		.resolve(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<never>()
 
 			return {}
 		})
 		.onTransform(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.onBeforeHandle(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.onAfterHandle(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.mapResponse(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 		.onAfterResponse(({ params }) => {
-			expectTypeOf<typeof params>().toEqualTypeOf<{}>()
+			expectTypeOf<typeof params>().toEqualTypeOf<
+				Record<string, string>
+			>()
 		})
 }
 
@@ -2442,8 +2456,8 @@ type a = keyof {}
 				expectTypeOf<typeof a>().toEqualTypeOf<string>()
 			},
 			{
-				a: true,
-				beforeHandle: (c) => {}
+				a: true
+				// beforeHandle: (c) => {}
 			}
 		)
 		.ws('/', {
@@ -2567,7 +2581,7 @@ type a = keyof {}
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
 	>().toEqualTypeOf<
-		AsyncGenerator<
+		Generator<
 			| {
 					readonly data: 'a'
 			  }
@@ -2595,7 +2609,7 @@ type a = keyof {}
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
 	>().toEqualTypeOf<
-		AsyncGenerator<
+		Generator<
 			| {
 					readonly data: 'a'
 			  }
@@ -2649,13 +2663,9 @@ type a = keyof {}
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
 	>().toEqualTypeOf<
-		AsyncGenerator<
-			{
-				readonly data: 'a'
-			},
-			void,
-			unknown
-		>
+		ReadableStream<{
+			readonly data: 'a'
+		}>
 	>()
 }
 
@@ -2669,5 +2679,5 @@ type a = keyof {}
 
 	expectTypeOf<
 		(typeof app)['~Routes']['get']['response'][200]
-	>().toEqualTypeOf<AsyncGenerator<'a', void, unknown>>()
+	>().toEqualTypeOf<ReadableStream<'a'>>()
 }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,13 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-	t,
-	Elysia,
-	Cookie,
-	file,
-	sse,
-	SSEPayload,
-	status
-} from '../../src'
+import { t, Elysia, Cookie, file, sse, SSEPayload, status, form } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
 const app = new Elysia()
@@ -1410,12 +1402,12 @@ app.get('/', ({ set }) => {
 	const child = new Elysia().get(
 		'/',
 		() => {
-			return {
+			return form({
 				a: file('test/kyuukurarin.mp4')
-			}
+			})
 		},
 		{
-			response: t.Object({
+			response: t.Form({
 				a: t.File()
 			})
 		}

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -690,10 +690,10 @@ app.use(plugin).group(
 	type Route = App['get']
 
 	expectTypeOf<Route>().toEqualTypeOf<{
-		body: unknown
-		params: Record<never, string>
-		query: unknown
-		headers: unknown
+		body: {}
+		params: {}
+		query: {}
+		headers: {}
 		response: {
 			200: number
 		}
@@ -750,10 +750,10 @@ app.use(plugin).group(
 	type Route = App['get']
 
 	expectTypeOf<Route>().toEqualTypeOf<{
-		body: unknown
-		headers: unknown
-		query: unknown
+		body: {}
 		params: {}
+		query: {}
+		headers: {}
 		response: {
 			200: string
 		}
@@ -956,10 +956,10 @@ app.group(
 	type Route = App['get']
 
 	expectTypeOf<Route>().toEqualTypeOf<{
-		body: unknown
-		headers: unknown
-		query: unknown
-		params: Record<never, string>
+		body: {}
+		params: {}
+		query: {}
+		headers: {}
 		response: {
 			200: string
 		}
@@ -983,10 +983,10 @@ app.group(
 			app: {
 				test: {
 					get: {
-						body: unknown
-						headers: unknown
-						query: unknown
-						params: Record<never, string>
+						body: {}
+						params: {}
+						query: {}
+						headers: {}
 						response: {
 							200: string
 						}
@@ -1219,10 +1219,10 @@ const a = app
 				'could-be-error': {
 					right: {
 						get: {
-							body: unknown
+							body: {}
 							params: {}
-							query: unknown
-							headers: unknown
+							query: {}
+							headers: {}
 							response: {
 								200: {
 									couldBeError: boolean

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -812,3 +812,50 @@ import { Prettify } from '../../../src/types'
 		}
 	>()
 }
+
+// Unwrap ElysiaCustomStatusResponse value in resolve macro automatically
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				resolve({ status }) {
+					if (Math.random() > 0.5) return status(401)
+
+					return { user: 'saltyaom' } as const
+				}
+			}
+		})
+		.get('/', ({ user }) => user, {
+			auth: true
+		})
+
+	expectTypeOf<(typeof app)['~Routes']['get']['response']>().toEqualTypeOf<{
+		200: 'saltyaom'
+		401: 'Unauthorized'
+	}>()
+}
+
+// Unwrap beforeHandle 200 status
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				beforeHandle({ status }) {
+					if (Math.random() > 0.5) return status(401)
+
+					return { user: 'saltyaom' }
+				}
+			}
+		})
+		.get('/', ({ status }) => {}, {
+			auth: true
+		})
+
+	// This could be improve
+	expectTypeOf<(typeof app)['~Routes']['get']['response']>().toEqualTypeOf<{
+		200: void & {
+			user: string
+		}
+		401: 'Unauthorized'
+	}>()
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1734,7 +1734,12 @@ import { Prettify } from '../../../src/types'
 			}
 		})
 		.post('/', ({ body }) => 'b' as const, {
-			a: true
+			a: true,
+			beforeHandle({ body }) {
+				expectTypeOf(body).toEqualTypeOf<{
+					name: 'lilith'
+				}>()
+			}
 		})
 
 	expectTypeOf<(typeof app)['~Routes']['post']>().toEqualTypeOf<{

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -158,15 +158,6 @@ import { Prettify } from '../../../src/types'
 		407: 'Proxy Authentication Required'
 		408: 'Request Timeout'
 		409: 'Conflict'
-		422: {
-			type: 'validation'
-			on: string
-			summary?: string
-			message?: string
-			found?: unknown
-			property?: string
-			expected?: string
-		}
 	}>
 }
 
@@ -234,14 +225,5 @@ import { Prettify } from '../../../src/types'
 		407: 'Proxy Authentication Required'
 		408: 'Request Timeout'
 		409: 'Conflict'
-		422: {
-			type: 'validation'
-			on: string
-			summary?: string
-			message?: string
-			found?: unknown
-			property?: string
-			expected?: string
-		}
 	}>
 }

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1,8 +1,8 @@
-import { Elysia, ElysiaCustomStatusResponse } from '../../../src'
+import { Cookie, Elysia, ElysiaCustomStatusResponse, t } from '../../../src'
 import { expectTypeOf } from 'expect-type'
 import { Prettify } from '../../../src/types'
 
-// Handle resolve property
+// Handle resolve property correctly
 {
 	const app = new Elysia().resolve(({ status }) => {
 		if (Math.random() > 0.05) return status(401)
@@ -14,11 +14,11 @@ import { Prettify } from '../../../src/types'
 
 	type Resolve = (typeof app)['~Volatile']['resolve']
 	expectTypeOf<Resolve>().toEqualTypeOf<{
-		readonly name: 'mokou'
+		name: 'mokou'
 	}>
 }
 
-// Handle resolve property
+// Handle resolve property without any data
 {
 	const app = new Elysia().resolve(({ status }) => {
 		if (Math.random() > 0.05) return status(401)
@@ -226,4 +226,589 @@ import { Prettify } from '../../../src/types'
 		408: 'Request Timeout'
 		409: 'Conflict'
 	}>
+}
+
+// All together now
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				response: {
+					409: t.Literal('Conflict')
+				},
+				beforeHandle({ status }) {
+					if (Math.random() < 0.05) return status(410)
+				},
+				resolve: () => ({ a: 'a' as const })
+			}
+		})
+		.onError(({ status }) => {
+			if (Math.random() < 0.05) return status(400)
+		})
+		.resolve(({ status }) => {
+			if (Math.random() < 0.05) return status(401)
+
+			return {
+				b: 'b' as const
+			}
+		})
+		.onBeforeHandle([
+			({ status }) => {
+				if (Math.random() < 0.05) return status(402)
+			},
+			({ status }) => {
+				if (Math.random() < 0.05) return status(403)
+			}
+		])
+		.guard({
+			beforeHandle: [
+				({ status }) => {
+					if (Math.random() < 0.05) return status(405)
+				},
+				({ status }) => {
+					if (Math.random() < 0.05) return status(406)
+				}
+			],
+			afterHandle({ status }) {
+				if (Math.random() < 0.05) return status(407)
+			},
+			error({ status }) {
+				if (Math.random() < 0.05) return status(408)
+			}
+		})
+		.post(
+			'/',
+			({ status, a, b }) => {
+				if (Math.random() < 0.05) return status(409, 'Conflict')
+
+				expectTypeOf<typeof a>().toEqualTypeOf<'a'>()
+				expectTypeOf<typeof b>().toEqualTypeOf<'b'>()
+
+				return 'Type Soundness'
+			},
+			{
+				auth: true,
+				response: {
+					411: t.Literal('Length Required')
+				}
+			}
+		)
+
+	type Lifecycle = (typeof app)['~Routes']['post']['response']
+
+	expectTypeOf<Lifecycle>().toEqualTypeOf<{
+		200: 'Type Soundness'
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+		409: 'Conflict'
+		410: 'Gone'
+		411: 'Length Required'
+		422: {
+			type: 'validation'
+			on: string
+			summary?: string
+			message?: string
+			found?: unknown
+			property?: string
+			expected?: string
+		}
+	}>()
+}
+
+// Macro without schema should not have 422
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				beforeHandle({ status }) {
+					if (Math.random() < 0.05) return status(410)
+				}
+			}
+		})
+		.get('/', () => 'Hello World' as const, {
+			auth: true
+		})
+
+	type Route = (typeof app)['~Routes']['get']['response']
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		410: 'Gone'
+	}>()
+}
+
+// Macro with schema should have 422
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				response: {
+					401: t.Literal('Unauthorized')
+				},
+				beforeHandle({ status }) {
+					if (Math.random() < 0.05) return status(410)
+				}
+			}
+		})
+		.get('/', () => 'Hello World' as const, {
+			auth: true
+		})
+
+	type Route = (typeof app)['~Routes']['get']['response']
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		401: 'Unauthorized'
+		410: 'Gone'
+		422: {
+			type: 'validation'
+			on: string
+			summary?: string
+			message?: string
+			found?: unknown
+			property?: string
+			expected?: string
+		}
+	}>()
+}
+
+// Macro should inject schema
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				body: t.Object({
+					name: t.Literal('lilith')
+				}),
+				query: t.Object({
+					name: t.Literal('lilith')
+				}),
+				headers: t.Object({
+					name: t.Literal('lilith')
+				}),
+				params: t.Object({
+					name: t.Literal('lilith')
+				}),
+				cookie: t.Object({
+					name: t.Literal('lilith')
+				}),
+				response: {
+					401: t.Literal('Unauthorized')
+				},
+				beforeHandle({ status }) {
+					if (Math.random() < 0.05) return status(410)
+				}
+			}
+		})
+		.get(
+			'/',
+			({ headers, body, cookie, params, query, status }) => {
+				expectTypeOf<typeof headers>().toEqualTypeOf<{
+					name: 'lilith'
+				}>()
+
+				expectTypeOf<typeof body>().toEqualTypeOf<{
+					name: 'lilith'
+				}>()
+
+				expectTypeOf<typeof cookie>().toEqualTypeOf<
+					Record<string, Cookie<unknown>> & {
+						name: Cookie<'lilith'>
+					}
+				>()
+
+				expectTypeOf<typeof params>().toEqualTypeOf<{
+					name: 'lilith'
+				}>()
+
+				expectTypeOf<typeof query>().toEqualTypeOf<{
+					name: 'lilith'
+				}>()
+
+				if (Math.random() > 0.5) return status(401, 'Unauthorized')
+
+				if (Math.random() > 0.5)
+					// @ts-expect-error
+					return status(401, 'Unauthorize')
+
+				return 'Hello World' as const
+			},
+			{
+				auth: true
+			}
+		)
+
+	type Route = (typeof app)['~Routes']['get']['response']
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		401: 'Unauthorized'
+		410: 'Gone'
+		422: {
+			type: 'validation'
+			on: string
+			summary?: string
+			message?: string
+			found?: unknown
+			property?: string
+			expected?: string
+		}
+	}>()
+}
+
+// Macro should inject schema to guard
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				body: t.Object({
+					name: t.Literal('lilith')
+				}),
+				query: t.Object({
+					name: t.Literal('lilith')
+				}),
+				headers: t.Object({
+					name: t.Literal('lilith')
+				}),
+				params: t.Object({
+					name: t.Literal('lilith')
+				}),
+				cookie: t.Object({
+					name: t.Literal('lilith')
+				}),
+				response: {
+					401: t.Literal('Unauthorized')
+				},
+				beforeHandle({ status }) {
+					if (Math.random() < 0.05) return status(410)
+				}
+			}
+		})
+		.guard({
+			auth: true
+		})
+		.get('/', ({ headers, body, cookie, params, query, status }) => {
+			expectTypeOf<typeof headers>().toEqualTypeOf<{
+				name: 'lilith'
+			}>()
+
+			expectTypeOf<typeof body>().toEqualTypeOf<{
+				name: 'lilith'
+			}>()
+
+			expectTypeOf<typeof cookie>().toEqualTypeOf<
+				Record<string, Cookie<unknown>> & {
+					name: Cookie<'lilith'>
+				}
+			>()
+
+			expectTypeOf<typeof params>().toEqualTypeOf<{
+				name: 'lilith'
+			}>()
+
+			expectTypeOf<typeof query>().toEqualTypeOf<{
+				name: 'lilith'
+			}>()
+
+			if (Math.random() > 0.5) return status(401, 'Unauthorized')
+
+			if (Math.random() > 0.5)
+				// @ts-expect-error
+				return status(401, 'Unauthorize')
+
+			return 'Hello World' as const
+		})
+
+	app['~Volatile']['standaloneSchema']['response']['401']
+	type Route = (typeof app)['~Routes']['get']['response']
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		401: 'Unauthorized'
+		410: 'Gone'
+		422: {
+			type: 'validation'
+			on: string
+			summary?: string
+			message?: string
+			found?: unknown
+			property?: string
+			expected?: string
+		}
+	}>()
+}
+
+// Guard should extract possible status 1
+{
+	const app = new Elysia().guard({
+		beforeHandle({ status }) {
+			if (Math.random() < 0.05) return status(410)
+		}
+	})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		410: 'Gone'
+	}>()
+}
+
+// Guard should extract possible status 2
+{
+	const app = new Elysia().guard({
+		afterHandle({ status }) {
+			return status(411)
+		}
+	})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		411: 'Length Required'
+	}>()
+}
+
+// Guard should extract possible status 3
+{
+	const app = new Elysia().guard({
+		error: [
+			({ status }) => {
+				return status(412)
+			},
+			({ status }) => {
+				if (Math.random() > 0.5) return status(413)
+			}
+		]
+	})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		412: 'Precondition Failed'
+		413: 'Payload Too Large'
+	}>()
+}
+
+// Guard should extract possible status 4
+{
+	const app = new Elysia().guard({
+		beforeHandle({ status }) {
+			if (Math.random() < 0.05) return status(410)
+		},
+		error: [
+			({ status }) => {
+				return status(412)
+			},
+			({ status }) => {
+				if (Math.random() > 0.5) return status(413)
+			}
+		]
+	})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<
+		{
+			410: 'Gone'
+		} & {
+			412: 'Precondition Failed'
+			413: 'Payload Too Large'
+		}
+	>()
+}
+
+// Guard should extract possible status 5
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				beforeHandle({ status }) {
+					return status(409)
+				}
+			}
+		})
+		.guard({
+			a: true,
+			beforeHandle({ status }) {
+				if (Math.random() < 0.05) return status(410)
+			},
+			error: [
+				({ status }) => {
+					return status(412)
+				},
+				({ status }) => {
+					if (Math.random() > 0.5) return status(413)
+				}
+			]
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<
+		{
+			409: 'Conflict'
+		} & {
+			410: 'Gone'
+		} & {
+			412: 'Precondition Failed'
+			413: 'Payload Too Large'
+		}
+	>()
+}
+
+// Macro should extract possible status 1
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				beforeHandle({ status }) {
+					if (Math.random() < 0.05) return status(410)
+				}
+			}
+		})
+		.guard({
+			a: true
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		410: 'Gone'
+	}>()
+}
+
+// Macro should extract possible status 2
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				afterHandle({ status }) {
+					return status(411)
+				}
+			}
+		})
+		.guard({
+			a: true
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		411: 'Length Required'
+	}>()
+}
+
+// Macro should extract possible status 3
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				error({ status }) {
+					if (Math.random() > 0.5) return status(412)
+				}
+			}
+		})
+		.guard({
+			a: true
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		412: 'Precondition Failed'
+	}>()
+}
+
+// Macro should extract possible status 4
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				beforeHandle({ status }) {
+					if (Math.random() > 0.5) return status(410)
+				},
+				afterHandle({ status }) {
+					if (Math.random() > 0.5) return status(411)
+				}
+			},
+			b: {
+				error({ status }) {
+					if (Math.random() > 0.5) return status(412)
+				}
+			}
+		})
+		.guard({
+			a: true,
+			b: true
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<
+		{
+			410: 'Gone'
+		} & {
+			411: 'Length Required'
+		} & {
+			412: 'Precondition Failed'
+		}
+	>()
+}
+
+// Guard should cast to scoped
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				beforeHandle({ status }) {
+					if (Math.random() > 0.5) return status(410)
+				},
+				afterHandle({ status }) {
+					if (Math.random() > 0.5) return status(411)
+				}
+			},
+			b: {
+				error({ status }) {
+					if (Math.random() > 0.5) return status(412)
+				}
+			}
+		})
+		.guard({
+			as: 'scoped',
+			a: true,
+			b: true
+		})
+
+	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<
+		{
+			410: 'Gone'
+		} & {
+			411: 'Length Required'
+		} & {
+			412: 'Precondition Failed'
+		}
+	>()
+}
+
+// Guard should cast to global
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				beforeHandle({ status }) {
+					if (Math.random() > 0.5) return status(410)
+				},
+				afterHandle({ status }) {
+					if (Math.random() > 0.5) return status(411)
+				}
+			},
+			b: {
+				error({ status }) {
+					if (Math.random() > 0.5) return status(412)
+				}
+			}
+		})
+		.guard({
+			as: 'global',
+			a: true,
+			b: true
+		})
+
+	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<
+		{
+			410: 'Gone'
+		} & {
+			411: 'Length Required'
+		} & {
+			412: 'Precondition Failed'
+		}
+	>()
 }

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1684,3 +1684,24 @@ import { Prettify } from '../../../src/types'
 		408: 'Request Timeout'
 	}>()
 }
+
+// merge possible path
+{
+	const app = new Elysia()
+		.onBeforeHandle(({ status }) => {
+			if (Math.random() > 0.05) return 'fouco' as const
+			if (Math.random() > 0.05) return 'sartre' as const
+			if (Math.random() > 0.05) return status(404, 'lilith')
+		})
+		.get('/', () => 'lilith' as const)
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		200: 'fouco' | 'sartre'
+		404: 'lilith'
+	}>
+
+	expectTypeOf<(typeof app)['~Routes']['get']['response']>().toEqualTypeOf<{
+		200: 'fouco' | 'sartre' | 'lilith'
+		404: 'lilith'
+	}>()
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1705,3 +1705,65 @@ import { Prettify } from '../../../src/types'
 		404: 'lilith'
 	}>()
 }
+
+// Macro Context should add to output declaration
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				query: t.Object({
+					name: t.Literal('lilith')
+				}),
+				cookie: t.Object({
+					name: t.Literal('lilith')
+				}),
+				params: t.Object({
+					name: t.Literal('lilith')
+				}),
+				body: t.Object({
+					name: t.Literal('lilith')
+				}),
+				headers: t.Object({
+					name: t.Literal('lilith')
+				}),
+				response: {
+					403: t.Object({
+						name: t.Literal('lilith')
+					})
+				}
+			}
+		})
+		.post('/', ({ body }) => 'b' as const, {
+			a: true
+		})
+
+	expectTypeOf<(typeof app)['~Routes']['post']>().toEqualTypeOf<{
+		body: {
+			name: 'lilith'
+		}
+		params: {
+			name: 'lilith'
+		}
+		query: {
+			name: 'lilith'
+		}
+		headers: {
+			name: 'lilith'
+		}
+		response: {
+			200: 'b'
+			403: {
+				name: 'lilith'
+			}
+			422: {
+				type: 'validation'
+				on: string
+				summary?: string
+				message?: string
+				found?: unknown
+				property?: string
+				expected?: string
+			}
+		}
+	}>()
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1834,3 +1834,19 @@ import { Prettify } from '../../../src/types'
 		}
 	}>()
 }
+
+// resolve for lifecycle event
+{
+	new Elysia()
+		.macro('auth', {
+			headers: t.Object({ authorization: t.String() }),
+			resolve: ({ status }) =>
+				Math.random() > 0.5
+					? { role: 'user' }
+					: status(401, 'not authorized')
+		})
+		.post('/', ({ role }) => role, {
+			auth: true,
+			beforeHandle: ({ role }) => {}
+		})
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -158,6 +158,15 @@ import { Prettify } from '../../../src/types'
 		407: 'Proxy Authentication Required'
 		408: 'Request Timeout'
 		409: 'Conflict'
+		422: {
+			type: 'validation'
+			on: string
+			summary?: string
+			message?: string
+			found?: unknown
+			property?: string
+			expected?: string
+		}
 	}>
 }
 
@@ -225,5 +234,14 @@ import { Prettify } from '../../../src/types'
 		407: 'Proxy Authentication Required'
 		408: 'Request Timeout'
 		409: 'Conflict'
+		422: {
+			type: 'validation'
+			on: string
+			summary?: string
+			message?: string
+			found?: unknown
+			property?: string
+			expected?: string
+		}
 	}>
 }

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1466,8 +1466,6 @@ import { Prettify } from '../../../src/types'
 		408: 'Request Timeout'
 	}>()
 
-	type A = keyof (typeof app)['~Routes']['get']['response']
-
 	expectTypeOf<(typeof app)['~Routes']['get']['response']>().toEqualTypeOf<{
 		200: 'NOexistenceN'
 		401: 'Unauthorized'
@@ -1798,6 +1796,9 @@ import { Prettify } from '../../../src/types'
 					name: t.Literal('Lilith')
 				}),
 				withFriends: true,
+				response: {
+					418: t.Literal('Teapot')
+				},
 				beforeHandle({ body }) {
 					expectTypeOf(body).toEqualTypeOf<{
 						name: 'Lilith'
@@ -1820,6 +1821,7 @@ import { Prettify } from '../../../src/types'
 				name: 'Lilith'
 				friends: ['Sartre', 'Fouco']
 			}
+			418: 'Teapot'
 			422: {
 				type: 'validation'
 				on: string

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -364,7 +364,7 @@ import { Prettify } from '../../../src/types'
 
 	expectTypeOf<Route>().toEqualTypeOf<{
 		200: 'Hello World'
-		401: 'Unauthorized'
+		readonly 401: 'Unauthorized'
 		410: 'Gone'
 		422: {
 			type: 'validation'
@@ -842,20 +842,16 @@ import { Prettify } from '../../../src/types'
 			auth: {
 				beforeHandle({ status }) {
 					if (Math.random() > 0.5) return status(401)
-
-					return { user: 'saltyaom' }
 				}
 			}
 		})
-		.get('/', ({ status }) => {}, {
+		.get('/', ({ status }) => 'a' as const, {
 			auth: true
 		})
 
 	// This could be improve
 	expectTypeOf<(typeof app)['~Routes']['get']['response']>().toEqualTypeOf<{
-		200: void & {
-			user: string
-		}
+		200: 'a'
 		401: 'Unauthorized'
 	}>()
 }

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1772,3 +1772,63 @@ import { Prettify } from '../../../src/types'
 		}
 	}>()
 }
+
+// Macro Context schema and inline schema works together even in inline lifecycle
+{
+	const app = new Elysia()
+		.macro({
+			withFriends: {
+				body: t.Object({
+					friends: t.Tuple([t.Literal('Sartre'), t.Literal('Fouco')])
+				})
+			}
+		})
+		.post(
+			'/',
+			({ body }) => {
+				expectTypeOf(body).toEqualTypeOf<{
+					name: 'Lilith'
+					friends: ['Sartre', 'Fouco']
+				}>()
+
+				return body
+			},
+			{
+				body: t.Object({
+					name: t.Literal('Lilith')
+				}),
+				withFriends: true,
+				beforeHandle({ body }) {
+					expectTypeOf(body).toEqualTypeOf<{
+						name: 'Lilith'
+						friends: ['Sartre', 'Fouco']
+					}>()
+				}
+			}
+		)
+
+	expectTypeOf<(typeof app)['~Routes']['post']>().toEqualTypeOf<{
+		body: {
+			name: 'Lilith'
+			friends: ['Sartre', 'Fouco']
+		}
+		params: {}
+		query: {}
+		headers: {}
+		response: {
+			200: {
+				name: 'Lilith'
+				friends: ['Sartre', 'Fouco']
+			}
+			422: {
+				type: 'validation'
+				on: string
+				summary?: string
+				message?: string
+				found?: unknown
+				property?: string
+				expected?: string
+			}
+		}
+	}>()
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1,0 +1,229 @@
+import { Elysia, ElysiaCustomStatusResponse } from '../../../src'
+import { expectTypeOf } from 'expect-type'
+import { Prettify } from '../../../src/types'
+
+// Handle resolve property
+{
+	const app = new Elysia().resolve(({ status }) => {
+		if (Math.random() > 0.05) return status(401)
+
+		return {
+			name: 'mokou'
+		}
+	})
+
+	type Resolve = (typeof app)['~Volatile']['resolve']
+	expectTypeOf<Resolve>().toEqualTypeOf<{
+		readonly name: 'mokou'
+	}>
+}
+
+// Handle resolve property
+{
+	const app = new Elysia().resolve(({ status }) => {
+		if (Math.random() > 0.05) return status(401)
+	})
+
+	type Resolve = (typeof app)['~Volatile']['resolve']
+	expectTypeOf<Resolve>().toEqualTypeOf<{}>
+}
+
+// Type soundness of lifecycle event in local
+{
+	const app = new Elysia()
+		.onError(({ status }) => {
+			if (Math.random() > 0.05) return status(400)
+		})
+		.resolve(({ status }) => {
+			if (Math.random() > 0.05) return status(401)
+		})
+		.onBeforeHandle([
+			({ status }) => {
+				if (Math.random() > 0.05) return status(402)
+			},
+			({ status }) => {
+				if (Math.random() > 0.05) return status(403)
+			}
+		])
+		.guard({
+			beforeHandle: [
+				({ status }) => {
+					if (Math.random() > 0.05) return status(405)
+				},
+				({ status }) => {
+					if (Math.random() > 0.05) return status(406)
+				}
+			],
+			afterHandle({ status }) {
+				if (Math.random() > 0.05) return status(407)
+			},
+			error({ status }) {
+				if (Math.random() > 0.05) return status(408)
+			}
+		})
+		.get('/', ({ body, status }) =>
+			Math.random() > 0.05 ? status(409) : ('Hello World' as const)
+		)
+
+	type Lifecycle = Prettify<(typeof app)['~Volatile']['response']>
+
+	expectTypeOf<Lifecycle>().toEqualTypeOf<{
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+	}>()
+
+	type Route = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+		409: 'Conflict'
+	}>
+}
+
+// Type soundness of lifecycle event in scoped
+{
+	const app = new Elysia()
+		.onError(({ status }) => {
+			if (Math.random() > 0.05) return status(400)
+		})
+		.resolve(({ status }) => {
+			if (Math.random() > 0.05) return status(401)
+		})
+		.onBeforeHandle([
+			({ status }) => {
+				if (Math.random() > 0.05) return status(402)
+			},
+			({ status }) => {
+				if (Math.random() > 0.05) return status(403)
+			}
+		])
+		.guard({
+			beforeHandle: [
+				({ status }) => {
+					if (Math.random() > 0.05) return status(405)
+				},
+				({ status }) => {
+					if (Math.random() > 0.05) return status(406)
+				}
+			],
+			afterHandle({ status }) {
+				if (Math.random() > 0.05) return status(407)
+			},
+			error({ status }) {
+				if (Math.random() > 0.05) return status(408)
+			}
+		})
+		.as('scoped')
+		.get('/', ({ body, status }) =>
+			Math.random() > 0.05 ? status(409) : ('Hello World' as const)
+		)
+
+	type Lifecycle = Prettify<(typeof app)['~Ephemeral']['response']>
+
+	expectTypeOf<Lifecycle>().toEqualTypeOf<{
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+	}>()
+
+	type Route = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+		409: 'Conflict'
+	}>
+}
+
+// Type soundness of lifecycle event in global
+{
+	const app = new Elysia()
+		.onError(({ status }) => {
+			if (Math.random() > 0.05) return status(400)
+		})
+		.resolve(({ status }) => {
+			if (Math.random() > 0.05) return status(401)
+		})
+		.onBeforeHandle([
+			({ status }) => {
+				if (Math.random() > 0.05) return status(402)
+			},
+			({ status }) => {
+				if (Math.random() > 0.05) return status(403)
+			}
+		])
+		.guard({
+			beforeHandle: [
+				({ status }) => {
+					if (Math.random() > 0.05) return status(405)
+				},
+				({ status }) => {
+					if (Math.random() > 0.05) return status(406)
+				}
+			],
+			afterHandle({ status }) {
+				if (Math.random() > 0.05) return status(407)
+			},
+			error({ status }) {
+				if (Math.random() > 0.05) return status(408)
+			}
+		})
+		.as('global')
+		.get('/', ({ body, status }) =>
+			Math.random() > 0.05 ? status(409) : ('Hello World' as const)
+		)
+
+	type Lifecycle = Prettify<(typeof app)['~Metadata']['response']>
+
+	expectTypeOf<Lifecycle>().toEqualTypeOf<{
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+	}>()
+
+	type Route = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Route>().toEqualTypeOf<{
+		200: 'Hello World'
+		400: 'Bad Request'
+		401: 'Unauthorized'
+		402: 'Payment Required'
+		403: 'Forbidden'
+		405: 'Method Not Allowed'
+		406: 'Not Acceptable'
+		407: 'Proxy Authentication Required'
+		408: 'Request Timeout'
+		409: 'Conflict'
+	}>
+}

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -1,4 +1,4 @@
-import { Elysia } from '../../src'
+import { Elysia, t } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
 // guard handle resolve macro
@@ -274,3 +274,21 @@ const app = new Elysia()
 			user: true
 		}
 	)
+
+// A
+{
+	new Elysia()
+		.macro('a', {
+			body: t.Object({ a: t.Literal('A') }),
+			beforeHandle({ body }) {
+				expectTypeOf(body).toEqualTypeOf<{ a: 'A' }>()
+			}
+		})
+		.macro('b', {
+			a: true,
+			body: t.Object({ a: t.Literal('A') }),
+			beforeHandle({ body }) {
+				expectTypeOf(body).toEqualTypeOf<{ a: 'A' }>()
+			}
+		})
+}

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -6,7 +6,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -32,7 +32,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -60,7 +60,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -89,7 +89,7 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => ({
+				resolve: () => ({
 					account: 'A'
 				})
 			})
@@ -116,8 +116,8 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: ({ error }) => {
-					if (Math.random() > 0.5) return error(401)
+				resolve: ({ status }) => {
+					if (Math.random() > 0.5) return status(401)
 
 					return {
 						account: 'A'
@@ -146,8 +146,8 @@ import { expectTypeOf } from 'expect-type'
 	const plugin = new Elysia()
 		.macro({
 			account: (a: boolean) => ({
-				resolve: async ({ error }) => {
-					if (Math.random() > 0.5) return error(401)
+				resolve: async ({ status }) => {
+					if (Math.random() > 0.5) return status(401)
 
 					return {
 						account: 'A'

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -246,6 +246,31 @@ import { expectTypeOf } from 'expect-type'
 			}
 		})
 		.get('/', ({ user }) => user, {
-			auth: true,
+			auth: true
 		})
 }
+
+// retrieve resolve conditionally
+const app = new Elysia()
+	.macro({
+		user: (enabled: true) => ({
+			resolve() {
+				if (!enabled) return
+
+				return {
+					user: 'a'
+				}
+			}
+		})
+	})
+	.get(
+		'/',
+		({ user, status }) => {
+			if (!user) return status(401)
+
+			return { hello: 'hanabi' }
+		},
+		{
+			user: true
+		}
+	)

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -230,3 +230,22 @@ import { expectTypeOf } from 'expect-type'
 			}
 		)
 }
+
+// resolve with custom status
+{
+	const app = new Elysia()
+		.macro({
+			auth: {
+				resolve: [
+					({ status }) => {
+						if (Math.random() > 0.5) return status(401)
+
+						return { user: 'saltyaom' } as const
+					}
+				]
+			}
+		})
+		.get('/', ({ user }) => user, {
+			auth: true,
+		})
+}

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -275,7 +275,7 @@ const app = new Elysia()
 		}
 	)
 
-// A
+// Macro name extends macro
 {
 	new Elysia()
 		.macro('a', {
@@ -286,9 +286,12 @@ const app = new Elysia()
 		})
 		.macro('b', {
 			a: true,
-			body: t.Object({ a: t.Literal('A') }),
+			body: t.Object({ b: t.Literal('B') }),
 			beforeHandle({ body }) {
-				expectTypeOf(body).toEqualTypeOf<{ a: 'A' }>()
+				expectTypeOf(body).toEqualTypeOf<{
+					a: 'A'
+					b: 'B'
+				}>()
 			}
 		})
 }

--- a/test/types/schema-standalone.ts
+++ b/test/types/schema-standalone.ts
@@ -869,7 +869,7 @@ import { expectTypeOf } from 'expect-type'
 					}>()
 
 					expectTypeOf<typeof cookie>().toEqualTypeOf<
-						Record<string, Cookie<string | undefined>> & {
+						Record<string, Cookie<unknown>> & {
 							family: Cookie<string>
 							name: Cookie<string>
 						}
@@ -907,7 +907,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						name: Cookie<string>
 					}
 				>()
@@ -944,7 +944,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						name: Cookie<string>
 					}
 				>()
@@ -1002,7 +1002,7 @@ import { expectTypeOf } from 'expect-type'
 					}>()
 
 					expectTypeOf<typeof cookie>().toEqualTypeOf<
-						Record<string, Cookie<string | undefined>> & {
+						Record<string, Cookie<unknown>> & {
 							family: Cookie<string>
 							name: Cookie<string>
 						}
@@ -1044,7 +1044,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						family: Cookie<string>
 						name: Cookie<string>
 					}
@@ -1082,7 +1082,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						name: Cookie<string>
 					}
 				>()
@@ -1140,7 +1140,7 @@ import { expectTypeOf } from 'expect-type'
 					}>()
 
 					expectTypeOf<typeof cookie>().toEqualTypeOf<
-						Record<string, Cookie<string | undefined>> & {
+						Record<string, Cookie<unknown>> & {
 							family: Cookie<string>
 							name: Cookie<string>
 						}
@@ -1182,7 +1182,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						family: Cookie<string>
 						name: Cookie<string>
 					}
@@ -1224,7 +1224,7 @@ import { expectTypeOf } from 'expect-type'
 				}>()
 
 				expectTypeOf<typeof cookie>().toEqualTypeOf<
-					Record<string, Cookie<string | undefined>> & {
+					Record<string, Cookie<unknown>> & {
 						family: Cookie<string>
 						name: Cookie<string>
 					}

--- a/test/types/standard-schema/index.ts
+++ b/test/types/standard-schema/index.ts
@@ -1,0 +1,505 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Cookie, Elysia, t } from '../../../src'
+
+import z from 'zod'
+
+import { expectTypeOf } from 'expect-type'
+
+// ? handle standard schema
+{
+	new Elysia().post(
+		'/:name',
+		({
+			params,
+			params: { name },
+			body,
+			query,
+			headers,
+			cookie,
+			status
+		}) => {
+			expectTypeOf<typeof params>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof body>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof headers>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof query>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof cookie>().toEqualTypeOf<
+				Record<string, Cookie<unknown>> & {
+					name: Cookie<'fouco' | 'lilith'>
+				}
+			>()
+
+			// @ts-expect-error
+			status(404, 'fouco')
+
+			// @ts-expect-error
+			status(418, 'lilith')
+
+			return name === 'lilith'
+				? status(404, 'lilith')
+				: status(418, name as any)
+		},
+		{
+			body: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			query: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			params: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			headers: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			cookie: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			response: {
+				404: z.literal('lilith'),
+				418: z.literal('fouco')
+			}
+		}
+	)
+}
+
+// ? handle standard schema single response
+{
+	new Elysia()
+		.get('/lilith', () => 'lilith' as const, {
+			response: z.literal('lilith')
+		})
+		.get('/lilith', 'lilith', {
+			response: z.literal('lilith')
+		})
+		// @ts-expect-error
+		.get('/lilith', () => 'focou' as const, {
+			response: z.literal('lilith')
+		})
+}
+
+// ? handle standard schema from reference
+{
+	new Elysia()
+		.model({
+			body: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			query: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			params: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			headers: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			cookie: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			'response.404': z.literal('lilith'),
+			'response.418': z.literal('fouco')
+		})
+		.post(
+			'/:name',
+			({
+				params,
+				params: { name },
+				body,
+				query,
+				headers,
+				cookie,
+				status
+			}) => {
+				expectTypeOf<typeof params>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof body>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof headers>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof query>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof cookie>().toEqualTypeOf<
+					Record<string, Cookie<unknown>> & {
+						name: Cookie<'fouco' | 'lilith'>
+					}
+				>()
+
+				// @ts-expect-error
+				status(404, 'fouco')
+
+				// @ts-expect-error
+				status(418, 'lilith')
+
+				return name === 'lilith'
+					? status(404, 'lilith')
+					: status(418, name as any)
+			},
+			{
+				body: 'body',
+				query: 'query',
+				params: 'params',
+				headers: 'headers',
+				cookie: 'cookie',
+				response: {
+					404: 'response.404',
+					418: 'response.418'
+				}
+			}
+		)
+}
+
+// ? handle standard schema from guard
+{
+	new Elysia()
+		.guard({
+			body: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			query: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			params: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			headers: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			cookie: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			response: {
+				404: z.literal('lilith'),
+				418: z.literal('fouco')
+			}
+		})
+		.post(
+			'/:name',
+			({
+				params,
+				params: { name },
+				body,
+				query,
+				headers,
+				cookie,
+				status
+			}) => {
+				expectTypeOf<typeof params>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof body>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof headers>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof query>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof cookie>().toEqualTypeOf<
+					Record<string, Cookie<unknown>> & {
+						name: Cookie<'fouco' | 'lilith'>
+					}
+				>()
+
+				// @ts-expect-error
+				status(404, 'fouco')
+
+				// @ts-expect-error
+				status(418, 'lilith')
+
+				return name === 'lilith'
+					? status(404, 'lilith')
+					: status(418, name as any)
+			}
+		)
+}
+
+// ? merge standard schema response status from guard
+{
+	new Elysia()
+		.guard({
+			response: {
+				418: z.literal('fouco')
+			}
+		})
+		.get('/lilith', () => 'lilith' as const, {
+			response: z.literal('lilith')
+		})
+		.get('/lilith', 'lilith', {
+			response: z.literal('lilith')
+		})
+		// @ts-expect-error
+		.get('/lilith', () => 'focou' as const, {
+			response: z.literal('lilith')
+		})
+		.get('/fouco', ({ status }) => status(418, 'fouco'), {
+			response: z.literal('lilith')
+		})
+		// @ts-expect-error
+		.get('/fouco', ({ status }) => status(418, 'lilith'), {
+			response: z.literal('lilith')
+		})
+}
+
+// ? merge standalone standard schema
+{
+	new Elysia()
+		.guard({
+			schema: 'standalone',
+			body: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			query: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			params: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			headers: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			cookie: z.object({
+				name: z.literal('fouco').or(z.literal('lilith'))
+			}),
+			response: {
+				404: z.object({
+					name: z.literal('lilith')
+				}),
+				418: z.object({
+					name: z.literal('fouco')
+				})
+			}
+		})
+		.post(
+			'/:name',
+			({
+				params,
+				params: { name },
+				body,
+				query,
+				headers,
+				cookie,
+				status
+			}) => {
+				expectTypeOf<typeof params>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+					q: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof body>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+					q: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof headers>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+					q: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof query>().toEqualTypeOf<{
+					name: 'fouco' | 'lilith'
+					q: 'fouco' | 'lilith'
+				}>()
+
+				expectTypeOf<typeof cookie>().toEqualTypeOf<
+					Record<string, Cookie<unknown>> & {
+						name: Cookie<'fouco' | 'lilith'>
+						q: Cookie<'fouco' | 'lilith'>
+					}
+				>()
+
+				status(404, {
+					// @ts-expect-error
+					name: 'fouco',
+					// @ts-expect-error
+					q: 'fouco'
+				})
+
+				status(418, {
+					// @ts-expect-error
+					name: 'lilith',
+					// @ts-expect-error
+					q: 'lilith'
+				})
+
+				return name === 'lilith'
+					? status(404, {
+							name,
+							q: 'lilith'
+						})
+					: status(418, {
+							name,
+							q: 'fouco'
+						})
+			},
+			{
+				body: t.Object({
+					q: t.UnionEnum(['lilith', 'fouco'])
+				}),
+				query: t.Object({
+					q: t.UnionEnum(['lilith', 'fouco'])
+				}),
+				params: t.Object({
+					q: t.UnionEnum(['lilith', 'fouco'])
+				}),
+				headers: t.Object({
+					q: t.UnionEnum(['lilith', 'fouco'])
+				}),
+				cookie: t.Object({
+					q: t.UnionEnum(['lilith', 'fouco'])
+				}),
+				response: {
+					404: t.Object({
+						q: t.Literal('lilith')
+					}),
+					418: t.Object({
+						q: t.Literal('fouco')
+					})
+				}
+			}
+		)
+}
+
+// ? merge standalone standard schema from plugin
+{
+	const plugin = new Elysia().guard({
+		as: 'scoped',
+		schema: 'standalone',
+		body: z.object({
+			name: z.literal('fouco').or(z.literal('lilith'))
+		}),
+		query: z.object({
+			name: z.literal('fouco').or(z.literal('lilith'))
+		}),
+		params: z.object({
+			name: z.literal('fouco').or(z.literal('lilith'))
+		}),
+		headers: z.object({
+			name: z.literal('fouco').or(z.literal('lilith'))
+		}),
+		cookie: z.object({
+			name: z.literal('fouco').or(z.literal('lilith'))
+		}),
+		response: {
+			404: z.object({
+				name: z.literal('lilith')
+			}),
+			418: z.object({
+				name: z.literal('fouco')
+			})
+		}
+	})
+
+	new Elysia().use(plugin).post(
+		'/:name',
+		({
+			params,
+			params: { name },
+			body,
+			query,
+			headers,
+			cookie,
+			status
+		}) => {
+			expectTypeOf<typeof params>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+				q: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof body>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+				q: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof headers>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+				q: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof query>().toEqualTypeOf<{
+				name: 'fouco' | 'lilith'
+				q: 'fouco' | 'lilith'
+			}>()
+
+			expectTypeOf<typeof cookie>().toEqualTypeOf<
+				Record<string, Cookie<unknown>> & {
+					q: Cookie<'fouco' | 'lilith'>
+					name: Cookie<'fouco' | 'lilith'>
+				}
+			>()
+
+			status(404, {
+				// @ts-expect-error
+				name: 'fouco',
+				// @ts-expect-error
+				q: 'fouco'
+			})
+
+			status(418, {
+				// @ts-expect-error
+				name: 'lilith',
+				// @ts-expect-error
+				q: 'lilith'
+			})
+
+			return name === 'lilith'
+				? status(404, {
+						name,
+						q: 'lilith'
+					})
+				: status(418, {
+						name,
+						q: 'fouco'
+					})
+		},
+		{
+			body: t.Object({
+				q: t.UnionEnum(['lilith', 'fouco'])
+			}),
+			query: t.Object({
+				q: t.UnionEnum(['lilith', 'fouco'])
+			}),
+			params: t.Object({
+				q: t.UnionEnum(['lilith', 'fouco'])
+			}),
+			headers: t.Object({
+				q: t.UnionEnum(['lilith', 'fouco'])
+			}),
+			cookie: t.Object({
+				q: t.UnionEnum(['lilith', 'fouco'])
+			}),
+			response: {
+				404: t.Object({
+					q: t.Literal('lilith')
+				}),
+				418: t.Object({
+					q: t.Literal('fouco')
+				})
+			}
+		}
+	)
+}

--- a/test/validator/encode.test.ts
+++ b/test/validator/encode.test.ts
@@ -34,8 +34,8 @@ describe('Encode response', () => {
 			encodeSchema: true
 		}).get(
 			'/:id',
-			({ error, params: { id } }) =>
-				error(id as any, {
+			({ status, params: { id } }) =>
+				status(id as any, {
 					id: 'hello world'
 				}),
 			{

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -930,7 +930,7 @@ describe('Query Validator', () => {
 			{
 				query: t.Object({
 					id: t
-						.Transform(t.Array(t.UnionEnum(['test', 'foo'])))
+						.Transform(t.UnionEnum(['test', 'foo']))
 						.Decode((id) => ({ value: id }))
 						.Encode((id) => id.value)
 				})
@@ -943,7 +943,7 @@ describe('Query Validator', () => {
 
 		expect(response).toEqual({
 			id: {
-				value: ['test']
+				value: 'test'
 			},
 			type: 'object'
 		})

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -968,19 +968,17 @@ describe('Query Validator', () => {
 	it('handle coerce TransformDecodeError', async () => {
 		let err: Error | undefined
 
-		const app = new Elysia()
-			.get('/', ({ query }) => query, {
-				query: t.Object({
-					year: t.Numeric({ minimum: 1900, maximum: 2160 })
-				}),
-				error({ code, error }) {
-					switch (code) {
-						case 'VALIDATION':
-							err = error
-					}
+		const app = new Elysia().get('/', ({ query }) => query, {
+			query: t.Object({
+				year: t.Numeric({ minimum: 1900, maximum: 2160 })
+			}),
+			error({ code, error }) {
+				switch (code) {
+					case 'VALIDATION':
+						err = error
 				}
-			})
-			.listen(0)
+			}
+		})
 
 		await app.handle(req('?year=3000'))
 

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -330,7 +330,6 @@ describe('Query Validator', () => {
 					check() {
 						const { state } = ctx.query
 
-						// @ts-expect-error
 						if (!checker.check(ctx, name, state ?? ctx.query.state))
 							throw new Error('State mismatch')
 					}

--- a/test/validator/response.test.ts
+++ b/test/validator/response.test.ts
@@ -1,4 +1,4 @@
-import { Elysia, error, t } from '../../src'
+import { Elysia, t } from '../../src'
 
 import { describe, expect, it } from 'bun:test'
 import { post, req, upload } from '../utils'
@@ -295,18 +295,22 @@ describe('Response Validator', () => {
 	})
 
 	it('validate response per status with error()', async () => {
-		const app = new Elysia().get('/', () => error(418, 'I am a teapot'), {
-			response: {
-				200: t.String(),
-				418: t.String()
+		const app = new Elysia().get(
+			'/',
+			({ status }) => status(418, 'I am a teapot'),
+			{
+				response: {
+					200: t.String(),
+					418: t.String()
+				}
 			}
-		})
+		)
 	})
 
 	it('use inline error from handler', async () => {
 		const app = new Elysia().get(
 			'/',
-			({ error }) => error(418, 'I am a teapot'),
+			({ status }) => status(418, 'I am a teapot'),
 			{
 				response: {
 					200: t.String(),
@@ -379,7 +383,7 @@ describe('Response Validator', () => {
 
 	it('return error response with validator', async () => {
 		const app = new Elysia()
-			.get('/ok', ({ error }) => 'ok', {
+			.get('/ok', () => 'ok', {
 				response: {
 					200: t.String(),
 					418: t.Literal('Kirifuji Nagisa'),
@@ -388,7 +392,7 @@ describe('Response Validator', () => {
 			})
 			.get(
 				'/error',
-				({ error }) => error("I'm a teapot", 'Kirifuji Nagisa'),
+				({ status }) => status("I'm a teapot", 'Kirifuji Nagisa'),
 				{
 					response: {
 						200: t.String(),
@@ -399,8 +403,8 @@ describe('Response Validator', () => {
 			)
 			.get(
 				'/validate-error',
-				// @ts-expect-error
-				({ error }) => error("I'm a teapot", 'Nagisa'),
+				// @ts-ignore
+				({ status }) => status("I'm a teapot", 'Nagisa'),
 				{
 					response: {
 						200: t.String(),

--- a/test/ws/aot.test.ts
+++ b/test/ws/aot.test.ts
@@ -10,7 +10,6 @@ describe('WebSocket with AoT disabled', () => {
 			})
 			.listen(0)
 
-		// @ts-expect-error some properties are missing
 		const ws = newWebsocket(app.server!)
 
 		await wsOpen(ws)


### PR DESCRIPTION
Release name: [Supersymmetry](https://youtu.be/NYyjQjtbteA)

Codename: [Weirs (Tone Sphere)](https://tonesphere.fandom.com/wiki/Weirs)

<img src=https://github.com/user-attachments/assets/ea8f7ee5-3107-46f6-93ba-494c817ac3a0 alt=Weirs width=384 height=384 />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard-schema validation support (Zod/Valibot/etc.), OpenAPI example, t.ArrayQuery, exported status helper, and mapResponse now exposes responseValue.
* **Behavior Changes / Refactor**
  * error(...) replaced by status(...); macros use declarative/named configs; improved query parsing/coercion; automatic HEAD responses with Content-Length; cookies auto-parse JSON; file-type validation API renamed/strengthened.
* **Chores**
  * Package version and dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->