### PR TITLE
1.4.7 patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.4.7
 Change:
 - do not prettify routes when using `guard`, `group`
-- use `process.getBuiltinModule` instead of dynamic import
+- use `process.getBuiltinModule` instead of dynamic import for file
 
 # 1.4.6 - 18 Sep 2025
 Improvement:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # 1.4.7 - 22 Sep 2025
+Feature:
+- experimental `adapter/cloudflare-worker`
+- add `ElysiaAdapter.beforeCompile`
+
 Change:
 - do not prettify routes when using `guard`, `group`
 - use `process.getBuiltinModule` instead of dynamic import for file
-- experimental `adapter/cloudflare-worker`
-- add `ElysiaAdapter.beforeCompile`
 
 # 1.4.6 - 18 Sep 2025
 Improvement:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Feature:
 Change:
 - do not prettify routes when using `guard`, `group`
 - use `process.getBuiltinModule` instead of dynamic import for file
+- `Elysia.file.value` on Web Standard Adapter now is not a promise
 
 # 1.4.6 - 18 Sep 2025
 Improvement:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.7
+Change:
+- do not prettify routes when using `guard`, `group`
+
 # 1.4.6 - 18 Sep 2025
 Improvement:
 - [#1406](https://github.com/elysiajs/elysia/issues/1406) strictly check for 200 inline status code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.4.7
 Change:
 - do not prettify routes when using `guard`, `group`
+- use `process.getBuiltinModule` instead of dynamic import
 
 # 1.4.6 - 18 Sep 2025
 Improvement:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Change:
 - do not prettify routes when using `guard`, `group`
 - use `process.getBuiltinModule` instead of dynamic import for file
+- experimental `adapter/cloudflare-worker`
+- add `ElysiaAdapter.beforeCompile`
 
 # 1.4.6 - 18 Sep 2025
 Improvement:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.4.7
+# 1.4.7 - 22 Sep 2025
 Change:
 - do not prettify routes when using `guard`, `group`
 - use `process.getBuiltinModule` instead of dynamic import for file

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,8 +1,30 @@
 import { Elysia, t } from '../src'
+import { req } from '../test/utils'
 
-const app = new Elysia().get('/สวัสดี', 'สบายดีไหม').listen(0)
+const app = new Elysia()
+	.wrap((fn, request) => {
+		const _request = request.clone()
 
-const response = await fetch(`http://localhost:${app.server!.port}/สวัสดี`)
-const text = await response.text()
+		return () => {
+			try {
+				return fn(request.clone())
+			} catch {
+				console.log('ER')
+			}
+		}
+	})
+	.onError(({ error }) => {
+		if (error) throw error
+	})
+	.get('/', () => {
+		throw new Error('A')
 
-console.log(text)
+		return 'Hello World!'
+	})
+	.listen(3000)
+
+// console.log(app.fetch.toString())
+
+app.handle(req('/'))
+	.then((x) => x.text())
+	.then(console.log)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,12 +1,8 @@
 import { Elysia, t } from '../src'
 
-new Elysia({ prefix: "/a" })
-	.get(
-    "/todo/:id",
-    ({ params }) => {
-        // O `params.id` aqui já é totalmente tipado!
-      return {
-        id: params.id,
-      };
-    }
-  )
+const app = new Elysia().get('/สวัสดี', 'สบายดีไหม').listen(0)
+
+const response = await fetch(`http://localhost:${app.server!.port}/สวัสดี`)
+const text = await response.text()
+
+console.log(text)

--- a/example/a.ts
+++ b/example/a.ts
@@ -1,18 +1,12 @@
 import { Elysia, t } from '../src'
 
-new Elysia()
-	.macro({
-		token: {
-			resolve: () => {
-				return {
-					__token: '123'
-				}
-			}
-		}
-	})
-	.macro('some', {
-		token: true,
-		beforeHandle: ({ __token }) => {
-			console.log('__token', __token)
-		}
-	})
+new Elysia({ prefix: "/a" })
+	.get(
+    "/todo/:id",
+    ({ params }) => {
+        // O `params.id` aqui já é totalmente tipado!
+      return {
+        id: params.id,
+      };
+    }
+  )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.7-beta.0",
+	"version": "1.4.7",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",
@@ -127,6 +127,11 @@
 			"types": "./dist/adapter/bun/compose.d.ts",
 			"import": "./dist/adapter/bun/compose.mjs",
 			"require": "./dist/cjs/adapter/bun/compose.js"
+		},
+		"./adapter/cloudflare-worker": {
+			"types": "./dist/adapter/cloudflare-worker/index.d.ts",
+			"import": "./dist/adapter/cloudflare-worker/index.mjs",
+			"require": "./dist/cjs/adapter/cloudflare-worker/index.js"
 		},
 		"./adapter/web-standard": {
 			"types": "./dist/adapter/web-standard/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "elysia",
 	"description": "Ergonomic Framework for Human",
-	"version": "1.4.6",
+	"version": "1.4.7-beta.0",
 	"author": {
 		"name": "saltyAom",
 		"url": "https://github.com/SaltyAom",

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -95,13 +95,15 @@ const mapRoutes = (app: AnyElysia) => {
 		},
 		handler: Function
 	) => {
-		if (routes[route.path]) {
+		const path = encodeURI(route.path)
+
+		if (routes[path]) {
 			// @ts-ignore
-			if (!routes[route.path][route.method])
+			if (!routes[path][route.method])
 				// @ts-ignore
-				routes[route.path][route.method] = handler
+				routes[path][route.method] = handler
 		} else
-			routes[route.path] = {
+			routes[path] = {
 				[route.method]: handler
 			}
 	}
@@ -249,7 +251,9 @@ export const BunAdapter: ElysiaAdapter = {
 				>{}
 				const ops = <Promise<any>[]>[]
 
-				for (const [path, route] of Object.entries(iterator)) {
+				for (let [path, route] of Object.entries(iterator)) {
+					path = encodeURI(path)
+
 					if (supportPerMethodInlineHandler) {
 						if (!route) continue
 
@@ -505,7 +509,7 @@ export const BunAdapter: ElysiaAdapter = {
 					)
 				].filter((x) => x)
 
-                const hasCustomErrorHandlers = errorHandlers.length > 0
+				const hasCustomErrorHandlers = errorHandlers.length > 0
 
 				const handleErrors = !hasCustomErrorHandlers
 					? () => {}
@@ -561,18 +565,20 @@ export const BunAdapter: ElysiaAdapter = {
 								const message = await parseMessage(ws, _message)
 
 								if (validateMessage?.Check(message) === false) {
-                                    const validationError = new ValidationError(
-                                        'message',
-                                        validateMessage,
-                                        message
-                                    )
+									const validationError = new ValidationError(
+										'message',
+										validateMessage,
+										message
+									)
 
-                                    if (!hasCustomErrorHandlers) {
-                                        return void ws.send(validationError.message as string)
-                                    }
+									if (!hasCustomErrorHandlers) {
+										return void ws.send(
+											validationError.message as string
+										)
+									}
 
-                                    return handleErrors(ws, validationError)
-                                }
+									return handleErrors(ws, validationError)
+								}
 
 								try {
 									await handleResponse(

--- a/src/adapter/cloudflare-worker/index.ts
+++ b/src/adapter/cloudflare-worker/index.ts
@@ -1,0 +1,76 @@
+import { ElysiaAdapter } from '../..'
+import { WebStandardAdapter } from '../web-standard/index'
+
+export function isCloudflareWorker() {
+	try {
+		// Check for the presence of caches.default, which is a global in Workers
+		if (
+			// @ts-ignore
+			typeof caches !== 'undefined' &&
+			// @ts-ignore
+			typeof caches.default !== 'undefined'
+		)
+			return true
+
+		// @ts-ignore
+		if (typeof WebSocketPair !== 'undefined') return true
+	} catch {
+		return false
+	}
+
+	return false
+}
+
+/**
+ * Experimental Cloudflare Adapter
+ * @see https://elysiajs.com/integrations/cloudflare-worker
+ *
+ * @example
+ * ```ts
+ * import { Elysia } from 'elysia'
+ * import { CloudflareAdapter } from 'elysia/adapter/cloudflare-worker'
+ *
+ * const app = new Elysia({
+ * 	  adapter: CloudflareAdapter,
+ * })
+ * 	  .get('/', () => 'Hello Elysia')
+ * 	  .compile()
+ *
+ * export default app
+ * ```
+ */
+export const CloudflareAdapter: ElysiaAdapter = {
+	...WebStandardAdapter,
+	name: 'cloudflare-worker',
+	composeGeneralHandler: {
+		...WebStandardAdapter.composeGeneralHandler,
+		error404(hasEventHook, hasErrorHook, afterHandle) {
+			const { code } = WebStandardAdapter.composeGeneralHandler.error404(
+				hasEventHook,
+				hasErrorHook,
+				afterHandle
+			)
+
+			return {
+				code,
+				declare: hasErrorHook
+					? ''
+					: // This only work because Elysia only clone the Response via .clone()
+						`const error404Message=notFound.message.toString()\n` +
+						`const error404={clone:()=>new Response(error404Message,{status:404})}\n`
+			}
+		}
+	},
+	beforeCompile(app) {
+		for (const route of app.routes) route.compile()
+	},
+	listen(app) {
+		return (options, callback) => {
+			console.warn(
+				'Cloudflare Worker does not support listen method. Please export default Elysia instance instead.'
+			)
+
+			app.compile()
+		}
+	}
+}

--- a/src/adapter/cloudflare-worker/index.ts
+++ b/src/adapter/cloudflare-worker/index.ts
@@ -22,7 +22,7 @@ export function isCloudflareWorker() {
 }
 
 /**
- * Experimental Cloudflare Adapter
+ * Cloudflare Adapter (Experimental)
  * @see https://elysiajs.com/integrations/cloudflare-worker
  *
  * @example

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -162,4 +162,9 @@ export interface ElysiaAdapter {
 		hook: AnyLocalHook,
 		app: AnyElysia
 	): void
+
+	/**
+	 * Call thing before compile
+	 */
+	beforeCompile?(app: AnyElysia): void
 }

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -127,9 +127,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
 		},
 		error404(hasEventHook, hasErrorHook, afterHandle = '') {
 			let findDynamicRoute =
-				`if(route===null){` +
-				afterHandle +
-				'\nreturn '
+				`if(route===null){` + afterHandle + '\nreturn '
 
 			if (hasErrorHook)
 				findDynamicRoute += `app.handleError(c,notFound,false,${this.parameters})`

--- a/src/index.ts
+++ b/src/index.ts
@@ -5400,11 +5400,7 @@ export default class Elysia<
 			Input,
 			IntersectIfObjectSchema<
 				MergeSchema<
-					UnwrapRoute<
-						Input,
-						Definitions['typebox'],
-						BasePath
-					>,
+					UnwrapRoute<Input, Definitions['typebox'], BasePath>,
 					MergeSchema<
 						Volatile['schema'],
 						MergeSchema<Ephemeral['schema'], Metadata['schema']>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8039,6 +8039,8 @@ export default class Elysia<
 	}
 
 	compile() {
+		this['~adapter'].beforeCompile?.(this)
+
 		if (this['~adapter'].isWebStandard) {
 			this.fetch = this.config.aot
 				? composeGeneralHandler(this)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3873,7 +3873,7 @@ export default class Elysia<
 		Singleton,
 		Definitions,
 		Metadata,
-		Prettify<Routes & NewElysia['~Routes']>,
+		Routes & NewElysia['~Routes'],
 		Ephemeral,
 		Volatile
 	>
@@ -4505,7 +4505,7 @@ export default class Elysia<
 		Singleton,
 		Definitions,
 		Metadata,
-		Prettify<Routes & NewElysia['~Routes']>,
+		Routes & NewElysia['~Routes'],
 		Ephemeral,
 		{
 			derive: Volatile['derive']

--- a/src/universal/file.ts
+++ b/src/universal/file.ts
@@ -4,7 +4,6 @@ import { type stat as Stat } from 'fs/promises'
 import type { BunFile } from 'bun'
 
 import { isBun } from './utils'
-import type { MaybePromise } from '../types'
 
 export const mime = {
 	aac: 'audio/aac',

--- a/src/universal/file.ts
+++ b/src/universal/file.ts
@@ -1,9 +1,9 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { type createReadStream as CreateReadStream } from 'fs'
 import { type stat as Stat } from 'fs/promises'
+import type { BunFile } from 'bun'
 
 import { isBun } from './utils'
-import type { BunFile } from 'bun'
 import type { MaybePromise } from '../types'
 
 export const mime = {
@@ -98,7 +98,7 @@ let createReadStream: typeof CreateReadStream
 let stat: typeof Stat
 
 export class ElysiaFile {
-	readonly value: MaybePromise<unknown>
+	readonly value: unknown
 	readonly stats: ReturnType<typeof Stat> | undefined
 
 	constructor(public path: string) {
@@ -106,29 +106,49 @@ export class ElysiaFile {
 		else {
 			// Browser
 			// @ts-ignore
-			if (typeof window !== 'undefined') {
-				console.warn('Browser environment does not support file')
-			} else {
-				if (!createReadStream || !stat) {
-					try {
-						this.value = import('fs').then((fs) => {
-							createReadStream = fs.createReadStream
-
-							return fs.createReadStream(path)
-						})
-						this.stats = import('fs/promises').then((fs) => {
-							stat = fs.stat
-
-							return fs.stat(path)
-						})
-					} catch {
-						// not empty
-					}
-				} else {
-					this.value = createReadStream(path)
-					this.stats = stat(path)!
+			if (!createReadStream || !stat) {
+				// @ts-ignore
+				if (typeof window !== 'undefined') {
+					console.warn('Browser environment does not support file')
+					return
 				}
+
+				const warnMissing = (name?: string) =>
+					console.warn(
+						new Error(
+							`[elysia] \`file\` require \`fs${name ? '.' + name : ''}\` ${name?.includes('.') ? 'module ' : ''}which is not available in this environment`
+						)
+					)
+
+				if (
+					typeof process === 'undefined' ||
+					typeof process.getBuiltinModule !== 'function'
+				) {
+					warnMissing()
+					return
+				}
+
+				const fs = process.getBuiltinModule('fs')
+				if (!fs) {
+					warnMissing()
+					return
+				}
+
+				if (typeof fs.createReadStream !== 'function') {
+					warnMissing()
+					return
+				}
+				if (typeof fs.promises?.stat !== 'function') {
+					warnMissing()
+					return
+				}
+
+				createReadStream = fs.createReadStream
+				stat = fs.promises.stat
 			}
+
+			this.value = createReadStream(path)
+			this.stats = stat(path)!
 		}
 	}
 

--- a/test/adapter/bun/index.test.ts
+++ b/test/adapter/bun/index.test.ts
@@ -76,4 +76,14 @@ describe('Bun adapter', () => {
 		expect(response.headers.get('x-header')).toBe('test')
 		expect(caughtError!.message).toBe('A')
 	})
+
+	it('handle non-ASCII path', async () => {
+		const app = new Elysia().get('/สวัสดี', 'สบายดีไหม').listen(0)
+
+		const response = await fetch(
+			`http://localhost:${app.server!.port}/สวัสดี`
+		)
+		const text = await response.text()
+		expect(text).toBe('สบายดีไหม')
+	})
 })


### PR DESCRIPTION
Feature:
- experimental `adapter/cloudflare-worker`
- add `ElysiaAdapter.beforeCompile`

Change:
- do not prettify routes when using `guard`, `group`
- use `process.getBuiltinModule` instead of dynamic import for file
- `Elysia.file.value` on Web Standard Adapter now is not a promise
