### PR TITLE
fix: missing context (set) in mapResponse for ElysiaFile

### DIFF
--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -39,7 +39,10 @@ export const mapResponse = (
 				return new Response(JSON.stringify(response), set as any)
 
 			case 'ElysiaFile':
-				return handleFile((response as ElysiaFile).value as File)
+				return handleFile(
+					(response as ElysiaFile).value as File,
+					set as any
+				)
 
 			case 'File':
 				return handleFile(response as File, set as any)


### PR DESCRIPTION
Fix https://github.com/elysiajs/elysia/issues/1427

### Context

In mapResponse, the ElysiaFile case was calling handleFile without passing the current context (set).
Because of that, the response had no access to the headers defined by middleware/plugins, making it impossible for the CORS plugin to apply its headers.

### Fix

Pass the current set object into handleFile in the ElysiaFile case so that headers (including CORS) are applied correctly.

### Test
I didn’t write tests because this fix is very small and only restores the expected behavior (passing the current context to handleFile)

https://github.com/user-attachments/assets/187be91d-0731-451f-b604-092cc7206a69



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File responses now correctly apply response headers and status codes, improving compatibility with downloads and streamed files (e.g., proper Content-Type/Disposition).
  * Resolves cases where file responses could miss expected headers, leading to inconsistent client behavior.

* **Refactor**
  * Internal handling of file responses streamlined to ensure consistent propagation of response metadata, enhancing reliability without changing user-facing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->