### PR TITLE
fix: missing cookies in sse

### DIFF
--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -159,6 +159,7 @@ export const createStreamHandler =
 			| IteratorResult<unknown>
 			| undefined
 
+		if (set) handleSet(set)
 		if (init instanceof Promise) init = await init
 
 		// Generator or ReadableStream is returned from a generator function

--- a/test/response/stream.test.ts
+++ b/test/response/stream.test.ts
@@ -96,6 +96,31 @@ describe('Stream', () => {
 		expect(response).toBe('ab')
 	})
 
+	it('include multiple set-cookie headers in streamed response', async () => {
+		const app = new Elysia().get('/', async function* (context) {
+			context.cookie['cookie1'].set({
+				value: 'value1'
+			})
+			context.cookie['cookie2'].set({
+				value: 'value2'
+			})
+
+			yield sse({ event: 'test', data: { count: 1 } })
+			yield sse({ event: 'test', data: { count: 2 } })
+		})
+
+		const response = await app.handle(req('/'))
+
+		const cookieHeaders = response.headers.getSetCookie()
+		expect(cookieHeaders).toHaveLength(2)
+		expect(cookieHeaders.some((h) => h.includes('cookie1=value1'))).toBe(
+			true
+		)
+		expect(cookieHeaders.some((h) => h.includes('cookie2=value2'))).toBe(
+			true
+		)
+	})
+
 	it('mutate set before yield is called', async () => {
 		const expected = ['a', 'b', 'c']
 


### PR DESCRIPTION
Fix https://github.com/elysiajs/elysia/issues/1434 

### Problem
When using generator functions (streaming responses) with cookies in ElysiaJS, the set-cookie headers were not being included in the HTTP response headers. This occurred because cookies set via context.cookie['name'].set() before yielding the first chunk were not processed and added to the response headers.

```
new Elysia().get('/', async function* (context) {
  context.cookie['my-cookie'].set({ value: 'test-value' })
  yield sse({ event: 'my-event', data: { message: 'Hello' } })
})
// The set-cookie header was missing from the response
```

### Root Cause
The createStreamHandler function in src/adapter/utils.ts was not calling handleSet() to process cookies and other context properties before creating the Response object. The handleSet() function is responsible for serializing cookies from context.set.cookie into proper set-cookie headers.

### Solution
Added a call to handleSet(set) in the createStreamHandler function before the generator starts processing, ensuring that cookies are properly serialized and included in the response headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures headers/cookies are applied before the first streamed event, preventing missed mutations at stream start.
  * Preserves multiple Set-Cookie headers in streamed responses (e.g., SSE), improving session and auth reliability.

* **Tests**
  * Added test verifying that streamed responses include multiple Set-Cookie headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->