### PR TITLE
fix: ElysiaTransformEncodeBuilder.Encode return type

### DIFF
--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -220,7 +220,7 @@ export declare class ElysiaTransformEncodeBuilder<
 	private EncodeSchema
 	Encode<E extends TransformFunction<ReturnType<D>, StaticDecode<T>>>(
 		encode: E
-	): TTransform<T, ReturnType<D>>
+	): TTransform<T, ReturnType<E>>
 }
 export type TransformFunction<T = any, U = any> = (value: T) => U
 export interface TransformOptions<


### PR DESCRIPTION
Fixes #1286 
**Before**
Both `Decode` and `Encode` resolve to the same type using Elysia's `t.Transform`.
The values are decoded and encoded correctly its just the ReturnType of `Encode` is wrong.
```typescript
const T = t
    .Transform(t.Number())
    .Decode(value => new Date(value)) // decode: number to Date
    .Encode(value => value.getTime()); // encode: Date to number

const D = TypeCompiler.Compile(T).Decode(0); // typeof D = Date
const E = TypeCompiler.Compile(T).Encode(D); // typeof E = Date <------- should be number

console.log('Decoded:', D); // Decoded: 1970-01-01T00:00:00.000Z
console.log('Encoded:', E); // Encoded: 0
```

**Fix**
Changing this line:
https://github.com/elysiajs/elysia/blob/a4193a3240cd1046c23e713cd5b0bc6887ec87ba/src/type-system/types.ts#L223

to  `): TTransform<T, ReturnType<E>>` 


**After**
```typescript
const T = t
    .Transform(t.Number())
    .Decode(value => new Date(value)) // decode: number to Date
    .Encode(value => value.getTime()); // encode: Date to number

const D = TypeCompiler.Compile(T).Decode(0); // typeof D = Date
const E = TypeCompiler.Compile(T).Encode(D); // typeof E = number <------ now is correct

console.log('Decoded:', D); // Decoded: 1970-01-01T00:00:00.000Z
console.log('Encoded:', E); // Encoded: 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type definitions so encoder output types are accurately propagated through transforms, improving type safety and autocompletion for developers.
  * Reduces mismatches between encoder functions and resulting transform types, preventing downstream type errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->