### PR TITLE
Add lifecycle hooks and setImmediate polyfill for cf workers

### DIFF
--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -7,6 +7,22 @@ import type { Sucrose } from '../sucrose'
 import type { Prettify, AnyLocalHook, MaybePromise } from '../types'
 import type { AnyWSLocalHook } from '../ws/types'
 
+/**
+ * ExecutionContext interface for Cloudflare Workers
+ */
+export interface ExecutionContext<Props = unknown> {
+	waitUntil(promise: Promise<any>): void
+	passThroughOnException(): void
+	readonly props: Props
+}
+
+/**
+ * Request context for adapters that need additional runtime information
+ */
+export interface RequestContext {
+	executionContext?: ExecutionContext
+}
+
 export interface ElysiaAdapter {
 	name: string
 	listen(


### PR DESCRIPTION
addreses #1383 

This PR enhances CF Workers support in Elysia, with a particular focus on lifecycle hooks and the `setImmediate` polyfill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Graceful shutdown support on Cloudflare Workers with stop lifecycle handling.
  * Environment-aware background task scheduling (auto-detecting setImmediate + Cloudflare execution context support).

* Bug Fixes
  * After-response hooks run reliably without blocking across Cloudflare Workers, Node.js, and other environments.
  * Start hooks now trigger after routes are compiled for more consistent startup on Cloudflare.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->