### PR TITLE
fix: fails when merging with `t.Optional` schema

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1454,7 +1454,7 @@ export const mergeObjectSchemas = (
 				...newSchema.properties,
 				...schema.properties
 			},
-			required: [...(newSchema?.required ?? []), ...schema.required]
+			required: [...(newSchema?.required ?? []), ...(schema.required ?? [])]
 		} as TObject
 	}
 


### PR DESCRIPTION
See #1282 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when merging schemas by safely combining “required” fields, preventing errors or missing validations when one schema lacks a required list.
  * Enhances stability of validation behavior without altering existing interfaces or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->