### PR TITLE
Allow using static handlers in Bun v1.3

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1078,6 +1078,8 @@ export const encodePath = (path: string, { dynamic = false } = {}) => {
 export const supportPerMethodInlineHandler = (() => {
 	if (typeof Bun === 'undefined') return true
 
+	if (Bun.semver?.satisfies?.(Bun.version, '>=1.2.14')) return true
+
 	const semver = Bun.version.split('.')
 	if (+semver[0] < 1 || +semver[1] < 2 || +semver[2] < 14) return false
 


### PR DESCRIPTION
The version check for `supportPerMethodInlineHandler` started returning false when bumping the version of Bun from Bun v1.2 -> Bun v1.3

This led to [`test/core/native-static.test.ts`](https://github.com/elysiajs/elysia/blob/817a4656cf3330c98f23e425908ca2b090894a46/test/core/native-static.test.ts) failing

<img width="1238" height="886" alt="image" src="https://github.com/user-attachments/assets/ad254c27-2c71-4444-8f08-1be961a3b351" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Bun runtimes (>=1.2.14) by optimizing version detection, preventing incorrect behavior in certain environments while leaving older versions unaffected.
  * Streamlined runtime checks to avoid unnecessary parsing, reducing overhead and stabilizing behavior during startup.
  * Enhances reliability of feature gating across environments. No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->