### PR TITLE
feat: add `t.NumericEnum()` for numeric enum query handling

### DIFF
--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -238,3 +238,13 @@ export interface TTransform<
 	[TransformKind]: TransformOptions<I, O>
 	[key: string]: any
 }
+
+export type AssertNumericEnum<T extends Record<string, string | number>> = {
+	[K in keyof T]: K extends number
+		? string
+		: K extends `${number}`
+			? string
+			: K extends string
+				? number
+				: never
+}

--- a/test/aot/has-transform.test.ts
+++ b/test/aot/has-transform.test.ts
@@ -98,6 +98,15 @@ describe('Has Transform', () => {
 		expect(hasTransform(schema)).toBe(true)
 	})
 
+	it('Found t.NumericEnum', () => {
+		const schema = t.Object({
+			gender: t.NumericEnum({ UNKNOWN: 0, MALE: 1, FEMALE: 2 }),
+			liyue: t.String()
+		})
+
+		expect(hasTransform(schema)).toBe(true)
+	})
+
 	it('Found t.ObjectString', () => {
 		const schema = t.Object({
 			id: t.String(),

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -142,6 +142,30 @@ describe('Query Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('parse numeric enum', async () => {
+		enum Gender {
+			MALE = 1,
+			FEMALE = 2,
+			UNKNOWN = 3
+		}
+
+		const app = new Elysia().get('/', ({ query }) => query, {
+			query: t.Object({
+				name: t.String(),
+				gender: t.NumericEnum(Gender)
+			})
+		})
+		const res = await app.handle(
+			req(`/?name=sucrose&gender=${Gender.MALE}`)
+		)
+
+		expect(await res.json()).toEqual({
+			name: 'sucrose',
+			gender: Gender.MALE
+		})
+		expect(res.status).toBe(200)
+	})
+
 	it('parse single integer', async () => {
 		const app = new Elysia().get('/', ({ query: { limit } }) => limit, {
 			query: t.Object({


### PR DESCRIPTION
The existing t.Enum() has limitations when handling numeric enums in query parameters: since query values are inherently strings, direct use with numeric enums causes type mismatches (string vs. number) during validation.

But using t.Numeric() loses enum-specific type hints.


This PR adds t.NumericEnum() , transform 'string' to 'number' and validate, as `t.Numeric()` does.

```typescript
enum Gender {
  MALE = 1,
  FEMALE = 2,
  UNKNOWN = 3,
}

const app = new Elysia().get("/", ({ query }) => query, {
  query: t.Object({
    // using t.Numeric() will lost enum type info
    gender: t.Numeric(),

    // using t.Enum() can not pass the validation
    gender: t.Enum(Gender),

    // using t.NumericEnum() keep type info and pass the validation
    gender: t.NumericEnum(Gender),
  }),
});

const res = await app.handle(req(`/?name=sucrose&gender=${Gender.MALE}`));
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numeric enum support to the type system for validating numeric enumeration values in schemas and query parameters, accepting both numeric values and their string representations.

* **Tests**
  * Added comprehensive test coverage for numeric enum validation in query parameters and schema transform detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->