### PR TITLE
chore: update actions versions, use frozen bun lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup bun
-              uses: oven-sh/setup-bun@v1
+              uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
 
             - name: Install packages
-              run: bun install
+              run: bun install --frozen-lockfile
 
             - name: Build code
               run: bun run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Setup Bun'
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
           registry-url: "https://registry.npmjs.org"
@@ -35,7 +35,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install packages
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build code
         run: bun run build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the latest versions of GitHub Actions tools and build runners.
  * Implemented deterministic dependency installation to ensure reproducible builds across all environment configurations and prevent unexpected dependency updates during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->