### PR TITLE
docs: fix typos and update test runner reference

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,9 +27,9 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Maintaners are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Mainteiners have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The Elysia.js repo is using [bun](https://bun.sh). Make sure you have the [lates
 
 ### Unit Testing
 
-In Elysia.js, all of the test files are located inside the [`test/`](test/) directory. Unit testing are powered by [bun's test](https://github.com/oven-sh/bun/tree/main/packages/bun-internal-test).
+In Elysia.js, all of the test files are located inside the [`test/`](test/) directory. Unit testing are powered by [bun's test runner](https://bun.sh/docs/test).
 
 -   `bun test` to run all the test inside the [`test/`](test/) directory
 


### PR DESCRIPTION
Fix spelling errors in CODE_OF_CONDUCT.md and update bun test runner reference in CONTRIBUTING.md. (bun test link was broken)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Fixed spelling errors in governance documentation
* Updated unit testing documentation with revised descriptions and refreshed reference links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->