### PR TITLE
Fix typo in ElysiaTypeCustomErrorCallback: valdation to validation

### DIFF
--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -157,7 +157,7 @@ export type ElysiaTypeCustomErrorCallback = (
 		/**
 		 * Error type
 		 */
-		type: 'valdation'
+		type: 'validation'
 		/**
 		 * Where the error was found
 		 */


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling error in the error object type field from 'valdation' to 'validation', ensuring proper error type matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->