### PR TITLE
fix: export ExtractErrorFromHandle type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8215,7 +8215,8 @@ export type {
 	ResolveHandler,
 	TransformHandler,
 	HTTPHeaders,
-	EmptyRouteSchema
+	EmptyRouteSchema,
+	ExtractErrorFromHandle
 } from './types'
 
 export { env } from './universal/env'


### PR DESCRIPTION
fixes [#26 in @elysia/bearer](https://github.com/elysiajs/elysia-bearer/issues/26): _destroying types, data is any_

Bundled output before the fix:
```typescript
export declare const bearer: ({ extract: { body, query: queryName, header } }?: BearerOptions) => Elysia<"", {
...
     response: import("elysia/dist/types").ExtractErrorFromHandle<{
        readonly bearer: string | undefined;
    }>;
...
```

After the fix:
```typescript
export declare const bearer: ({ extract: { body, query: queryName, header } }?: BearerOptions) => Elysia<"", {
...
    response: import("elysia").ExtractErrorFromHandle<{
        readonly bearer: string | undefined;
    }>;
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public API to include a new type export for improved type handling and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->