### PR TITLE
feat: full path and method for macro introspection metadata

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1943,6 +1943,23 @@ export type BaseMacro = Record<
 
 export type MaybeValueOrVoidFunction<T> = T | ((...a: any) => void | T)
 
+export interface MacroIntrospectionMetadata {
+	/**
+	 * Metadata of the unresolved route being introspected.
+	 *
+	 * @example
+	 * '/route/:id'
+	 */
+	path: string
+	/**
+	 * HTTP method of the unresolved route being introspected.
+	 *
+	 * @example
+	 * 'GET'
+	 */
+	method: HTTPMethod
+}
+
 export interface MacroProperty<
 	in out Macro extends BaseMacro = {},
 	in out TypedRoute extends RouteSchema = {},
@@ -1970,9 +1987,13 @@ export interface MacroProperty<
 	/**
 	 * Introspect hook option for documentation generation or analysis
 	 *
-	 * @param option
+	 * @param option The options passed to the macro
+	 * @param context The metadata of the introspection.
 	 */
-	introspect?(option: Prettify<Macro>): unknown
+	introspect?(
+		option: Record<string, any>,
+		context: MacroIntrospectionMetadata
+	): unknown
 }
 
 export interface Macro<


### PR DESCRIPTION

**Goal**: Enable macros to introspect route metadata (path and method) during route registration for documentation generation and analysis.

**Features Added**:

1. **Route metadata in macro introspection**
   - Added `MacroIntrospectionMetadata` with `path` and `method`
   - `introspect` now receives route metadata as a second parameter

2. **Path resolution**
   - Paths are normalized before introspection
   - Prefixes are resolved so metadata uses the final route path
   - Groups defer introspection until routes are added to the parent with fully resolved paths

3. **Guard-level macro introspection**
   - Guard-level macros are introspected per route with the resolved path
   - Introspection runs once per route with complete metadata

**Behavior Changes**:

- `introspect` receives `(introspectOptions, metadata)` where `metadata` contains `{ path: string, method: HTTPMethod }`
- Introspection runs only when route metadata is available
- Paths include prefixes and group paths (e.g., `/prefix/group/route/:id`)
- Works with nested groups, guards, and route combinations

**Use Case**: Enables macros to generate documentation, analyze routes, or perform static analysis using route path and method information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-route macro introspection now receives route context (path and HTTP method) when applicable.
  * Introspection is executed per-route (only when full route metadata is available) and integrates across guards/groups without changing non-macro behavior.
  * MacroIntrospectionMetadata type is exposed in the public API.

* **Tests**
  * Expanded tests covering macro introspection across guards, groups, nested routes, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->