### PR TITLE
Refactor HEAD method handling in compose.ts

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2291,18 +2291,21 @@ export const composeGeneralHandler = (app: AnyElysia) => {
 
 	if (isWebstandard)
 		findDynamicRoute +=
-			`if(r.method==='HEAD'){` +
-			`const route=router.find('GET',p)\n` +
-			'if(route){' +
-			`c.params=route.params\n` +
-			`const _res=route.store.handler?route.store.handler(c):route.store.compile()(c)\n` +
+			`if(r.method==="HEAD"){` +
+			`const route=router.find("GET",p);` +
+			`if(route){` +
+			`c.params=route.params;` +
+			`const _res=route.store.handler?route.store.handler(c):route.store.compile()(c);` +
 			`if(_res)` +
-			'return getResponseLength(_res).then((length)=>{' +
-			`_res.headers.set('content-length', length)\n` +
-			`return new Response(null,{status:_res.status,statusText:_res.statusText,headers:_res.headers})\n` +
-			'})' +
-			'}' +
-			'}'
+			`return Promise.resolve(_res).then((_res)=>{` +
+			`if(!_res.headers)_res.headers=new Headers();` +
+			`return getResponseLength(_res).then((length)=>{` +
+			`_res.headers.set("content-length", length);` +
+			`return new Response(null,{status:_res.status,statusText:_res.statusText,headers:_res.headers});` +
+			`})` +
+			`});` +
+			`}` +
+			`}`
 
 	let afterResponse = `c.error=notFound\n`
 	if (app.event.afterResponse?.length && !app.event.error) {


### PR DESCRIPTION
Fixes https://github.com/elysiajs/elysia/issues/1569

### The Bug
When a `HEAD` request is made to a route that uses **async parameter destructuring** (e.g., `get("/:id", async ({ params: { id } }) => { ... })`), the server crashes with an error: `❌ undefined is not an object (evaluating '_res.headers.set')`.

The root cause was that the code handling `HEAD` requests did not properly account for handlers returning a `Promise`. This led to an attempt to access the `.headers` property on a `Promise` object (which is `undefined`) instead of on the resolved `Response`.

### The Solution
The fix ensures the result of the route handler is properly resolved using `Promise.resolve()` before proceeding. It also includes safeguards to ensure the `headers` object exists on the response before trying to modify it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HEAD requests to ensure proper content-length headers are reliably set.

* **Refactor**
  * Restructured response handling logic for web-standard requests to enhance code clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->