### PR TITLE
fix: update the type of a customError property

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -320,7 +320,7 @@ export class ValidationError extends Error {
 	/**
 	 * Custom error if provided
 	 */
-	customError?: string
+	customError?: unknown
 
 	constructor(
 		public type: string,


### PR DESCRIPTION
Fixes #1571 

Theoretically `error` function can return anything (marked as `unknown` in `ElysiaTypeCustomErrorCallback` type) so specifiying type of `customError` as `unknown` should be justified.

P.S.
I tried to improve this with declaration merging so user could narrow `customError`'s type based on his or her usecase, but TS does not support declaration merging with class instance properties so it's not achievable without code restructuring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling to support a wider range of error information types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->