### PR TITLE
fix: add seen weakset during mergeDeep

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,6 +107,8 @@ export const mergeDeep = <
 			} catch {}
 	}
 
+	seen.delete(source)
+
 	return target as A & B
 }
 export const mergeCookie = <const A extends Object, const B extends Object>(


### PR DESCRIPTION
Attempt to resolve: https://github.com/elysiajs/elysia/issues/1587

This doesn't handle the plugin deduplication for plugins of plugins which the above issue also points out, but this tries to fix the recursion in `mergeDeep` by maintaining a seen set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented infinite recursion when merging objects with circular references; merging now safely detects and short-circuits already-seen sources and preserves shared circular structures.

* **Tests**
  * Added comprehensive tests for circular reference handling, covering nested cycles, shared references across branches, and deduplication in plugin-like scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->