### PR TITLE
:wrench: fix: merge set.headers without duplicating Response

### DIFF
--- a/test/response/custom-response.test.ts
+++ b/test/response/custom-response.test.ts
@@ -36,4 +36,29 @@ describe('Custom Response Type', () => {
 
         expect(await response.text()).toBe('Shuba Shuba')
     })
+
+    it('Response headers take precedence, set.headers merge non-conflicting', async () => {
+        const app = new Elysia()
+            .onRequest(({ set }) => {
+                set.headers['Content-Type'] = 'application/json'
+                set.headers['X-Framework'] = 'Elysia'
+            })
+            .get('/', () => {
+                return new Response('{"message":"hello"}', {
+                    headers: {
+                        'Content-Type': 'text/plain',
+                        'X-Custom': 'custom-value'
+                    }
+                })
+            })
+
+        const response = await app.handle(req('/'))
+
+        // Response's Content-Type takes precedence
+        expect(response.headers.get('Content-Type')).toBe('text/plain')
+        // set.headers adds non-conflicting headers
+        expect(response.headers.get('X-Framework')).toBe('Elysia')
+        // Response's own headers are preserved
+        expect(response.headers.get('X-Custom')).toBe('custom-value')
+    })
 })


### PR DESCRIPTION
Fixes #1590

### Problem

When a handler returns a `Response` with custom headers, `set.headers` values were appended using `headers.append()`, causing duplicate header values:

```typescript
.onRequest(({ set }) => {
    set.headers['Content-Type'] = 'application/json'
})
.get('/', () => new Response('data', {
    headers: { 'Content-Type': 'text/plain' }
}))

// Result: "text/plain, application/json" ❌
```

### Solution

- Use `headers.set()` instead of `headers.append()` for regular headers
- Only add header from `set.headers` if Response doesn't already have it (Response takes precedence)
- Keep `append()` for `set-cookie` (multiple cookies are valid)

### Changes

- `src/adapter/utils.ts`: Updated `createResponseHandler()` to check `response.headers.has(key)` before setting
- `test/response/custom-response.test.ts`: Added test for header merge behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header merging to ensure response headers correctly take precedence over configured defaults throughout the system
  * Non-conflicting headers from configuration are now properly merged alongside response headers
  * Cookie headers are handled appropriately in all merging scenarios
  * Improved header precedence logic prevents unintended overwrites and ensures consistent behavior across different header types

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->