### PR TITLE
Fix: stream reference should point to teed value

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1757,6 +1757,9 @@ export const composeHandler = ({
 					(maybeAsync ? '' : `(async()=>{`) +
 					`const stream=await tee(r,3)\n` +
 					`r=stream[0]\n` +
+					(hooks.afterHandle?.length
+						? `c.response=c.responseValue=r\n`
+						: '') +
 					`const listener=stream[1]\n` +
 					(hasTrace || hooks.afterResponse?.length
 						? `afterHandlerStreamListener=stream[2]\n`

--- a/test/response/stream.test.ts
+++ b/test/response/stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
 
 import { Elysia, sse } from '../../src'
@@ -559,5 +559,40 @@ describe('Stream', () => {
 
 		expect(result).toEqual(['Elysia', 'Eden'].map((x) => `data: ${x}\n\n`))
 		expect(response.headers.get('content-type')).toBe('text/event-stream')
+	})
+
+	it('handle sse with plugin global hooks and trace', async () => {
+		const PluginA = () =>
+			new Elysia({ name: 'PluginA' })
+				.onBeforeHandle(() => {})
+				.onAfterHandle(() => {})
+				.onParse(() => {})
+				.onTransform(() => {})
+				.onError(() => {})
+				.onAfterResponse(() => {})
+				.onStart(() => {})
+				.onStop(() => {})
+				.onRequest(() => {})
+				.trace(() => {})
+				.as('global')
+
+		const app = new Elysia().use(PluginA()).get('/sse', async function* () {
+			yield sse({ event: 'message', data: { meow: '1' } })
+			yield sse({ event: 'message', data: { meow: '2' } })
+			yield sse({ event: 'message', data: { meow: '3' } })
+		})
+
+		const response = await app.handle(req('/sse'))
+		expect(response.headers.get('content-type')).toBe('text/event-stream')
+
+		const result = []
+
+		for await (const chunk of streamResponse(response)) result.push(chunk)
+		expect(result).toHaveLength(3)
+		expect(result).toEqual([
+			'event: message\ndata: {"meow":"1"}\n\n',
+			'event: message\ndata: {"meow":"2"}\n\n',
+			'event: message\ndata: {"meow":"3"}\n\n'
+		])
 	})
 })


### PR DESCRIPTION
When using a stream with a trace and onAfterHandle handler, the stream still pointed to the stream object before `tee` is called in `reportHandler`. This PR updates it so that response and reponseValue don't point to the main generator.

The minimal POC for this is this:

```ts
import { Elysia } from './src'
import { req } from './test/utils'

const PluginA = () =>
	new Elysia({ name: 'PluginA' })
		.onAfterHandle(() => {})
		.trace(() => {})
		.as('global')

const app = new Elysia().use(PluginA()).get('/', async function* () {
	yield '1\n'
	yield '2\n'
	yield '3\n'
})

const response = await app.handle(req('/'))
console.log(await response.text())
process.exit(0)
```

this will print just "2". since the other values from the generator are getting captured by the trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed response handling for Server-Sent Events (SSE) when using plugin global hooks with trace enabled.

* **Tests**
  * Added test coverage for SSE functionality with plugin global hooks and trace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->