### PR TITLE
docs: add JSDoc for status() documenting string and number arguments

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -103,6 +103,28 @@ export class ElysiaCustomStatusResponse<
 	}
 }
 
+/**
+ * Create an HTTP response with a specific status code.
+ *
+ * The status code can be specified as either a number or a string status name.
+ * String status names provide autocompletion and are constrained to valid HTTP statuses.
+ *
+ * @param code - HTTP status code as a number (e.g., `418`) or status name string (e.g., `"I'm a teapot"`)
+ * @param response - Optional response body. If omitted, defaults to the status message.
+ *
+ * @example
+ * // Using numeric status code
+ * status(418, 'I am a teapot')
+ *
+ * @example
+ * // Using string status name (autocompletes in TypeScript)
+ * status("I'm a teapot", 'I am a teapot')
+ *
+ * @example
+ * // Without response body (defaults to status message)
+ * status(204)
+ * status("No Content")
+ */
 export const status = <
 	const Code extends number | keyof StatusMap,
 	const T = Code extends keyof InvertedStatusMap

--- a/src/error.ts
+++ b/src/error.ts
@@ -110,7 +110,9 @@ export class ElysiaCustomStatusResponse<
  * String status names provide autocompletion and are constrained to valid HTTP statuses.
  *
  * @param code - HTTP status code as a number (e.g., `418`) or status name string (e.g., `"I'm a teapot"`)
- * @param response - Optional response body. If omitted, defaults to the status message.
+ * @param response - Optional response body. If omitted, defaults to the status message
+ * for most codes. However, for empty HTTP statuses (101, 204, 205, 304, 307, 308),
+ * the response body is always omitted when using numeric codes.
  *
  * @example
  * // Using numeric status code
@@ -122,8 +124,13 @@ export class ElysiaCustomStatusResponse<
  *
  * @example
  * // Without response body (defaults to status message)
- * status(204)
- * status("No Content")
+ * status(404) // body: "Not Found"
+ * status("Not Found") // body: "Not Found"
+ *
+ * @example
+ * // Empty HTTP statuses: numeric codes have no body
+ * status(204) // body: undefined (no content)
+ * status("No Content") // body: "No Content" (string body)
  */
 export const status = <
 	const Code extends number | keyof StatusMap,


### PR DESCRIPTION
This adds JSDoc documentation to the `status()` function in `src/error.ts` with examples showing both usage patterns: numeric codes (like `418`) and string status names (like `"I'm a teapot"`). The string syntax provides TypeScript autocompletion for all valid HTTP status names, which is a nice DX improvement worth surfacing to developers.

```typescript
// Both of these work identically:
status(418, 'I am a teapot')
status("I'm a teapot", 'I am a teapot')

// Without response body (defaults to status message)
status(204)
status("No Content")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `status()` helper function for creating status responses with flexible input options (numeric or named codes), automatic type inference, and enhanced autocompletion support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->