### PR TITLE
feat: allow extending TypeBox errors

### DIFF
--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -146,6 +146,20 @@ export type TForm<T extends TProperties = TProperties> = TUnsafe<
 	ElysiaFormData<TObject<T>['static']>
 >
 
+/**
+ * Augment this interface to extend allowed values for SchemaOptions['error'].
+ * Defining custom string templates will add autocomplete while allowing any arbitrary string, number, etc.
+ *
+ * ```ts
+ * declare module 'elysia/type-system/types' {
+ *   interface ElysiaTypeCustomErrors {
+ *     myPlugin: 'my.plugin.error' | `my.plugin.${string}`
+ *   }
+ * }
+ *
+ * const schema = t.String({ error: 'my.plugin.hello' })
+ * ```
+ */
 export interface ElysiaTypeCustomErrors {
   string: (string & {})
   boolean: boolean

--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -146,11 +146,14 @@ export type TForm<T extends TProperties = TProperties> = TUnsafe<
 	ElysiaFormData<TObject<T>['static']>
 >
 
-export type ElysiaTypeCustomError =
-	| string
-	| boolean
-	| number
-	| ElysiaTypeCustomErrorCallback
+export interface ElysiaTypeCustomErrors {
+  string: (string & {})
+  boolean: boolean
+  number: number
+  ElysiaTypeCustomErrorCallback: ElysiaTypeCustomErrorCallback
+}
+
+export type ElysiaTypeCustomError = ElysiaTypeCustomErrors[keyof ElysiaTypeCustomErrors]
 
 export type ElysiaTypeCustomErrorCallback = (
 	error: {

--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -166,9 +166,9 @@ export interface ElysiaTypeCustomErrors {
   /**
    * The default error types that the library supports.
    *
-   * `string & {}` is used to allow defining custom string template errors.
+   * `string & {}` `number & {}` are used to allow string templates and numbers respectively.
    */
-  default: (string & {}) | boolean | number | ElysiaTypeCustomErrorCallback
+  default: (string & {}) | boolean | (number & {}) | ElysiaTypeCustomErrorCallback
 }
 
 export type ElysiaTypeCustomError = ElysiaTypeCustomErrors[keyof ElysiaTypeCustomErrors]

--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -150,6 +150,8 @@ export type TForm<T extends TProperties = TProperties> = TUnsafe<
  * Augment this interface to extend allowed values for SchemaOptions['error'].
  * Defining custom string templates will add autocomplete while allowing any arbitrary string, number, etc.
  *
+ * The names of keys only used to map to the values, unless you globally augment a specific key.
+ *
  * ```ts
  * declare module 'elysia/type-system/types' {
  *   interface ElysiaTypeCustomErrors {
@@ -161,10 +163,12 @@ export type TForm<T extends TProperties = TProperties> = TUnsafe<
  * ```
  */
 export interface ElysiaTypeCustomErrors {
-  string: (string & {})
-  boolean: boolean
-  number: number
-  ElysiaTypeCustomErrorCallback: ElysiaTypeCustomErrorCallback
+  /**
+   * The default error types that the library supports.
+   *
+   * `string & {}` is used to allow defining custom string template errors.
+   */
+  default: (string & {}) | boolean | number | ElysiaTypeCustomErrorCallback
 }
 
 export type ElysiaTypeCustomError = ElysiaTypeCustomErrors[keyof ElysiaTypeCustomErrors]


### PR DESCRIPTION
Solves #1612 by exposing a globally augmentable interface for adding custom error messages, and using `string & {}` to allow any string while preserving autocomplete for string templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Made custom error typings extensible and more type-safe, improving TypeScript inference and compatibility for custom error templates.

* **Documentation**
  * Added guidance and examples for extending allowed error values via module augmentation and aligned schema option typings with the new extensible error type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->