### PR TITLE
fix: handle minified arrow functions in hasReturn detection

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -411,11 +411,15 @@ const hasReturn = (v: string | HookContainer<any> | Function) => {
 	const arrowIndex = fnLiteral.indexOf('=>', parenthesisEnd)
 
 	if (arrowIndex !== -1) {
-		// Skip any whitespace after `=>`
+		// Skip any whitespace after `=>` (space, tab, newline, carriage return)
 		let afterArrow = arrowIndex + 2
+		let charCode: number
 		while (
 			afterArrow < fnLiteral.length &&
-			fnLiteral.charCodeAt(afterArrow) === 32
+			((charCode = fnLiteral.charCodeAt(afterArrow)) === 32 || // space
+				charCode === 9 || // tab
+				charCode === 10 || // newline
+				charCode === 13) // carriage return
 		) {
 			afterArrow++
 		}


### PR DESCRIPTION
## Summary
- Fix `hasReturn` function to correctly detect arrow function expressions in minified code
- Add test cases for `beforeHandle` with various arrow function formats

## Problem
The `hasReturn` function in `compose.ts` used hardcoded character positions to detect arrow function expressions:

```typescript
// Old code assumed format: `) => expr`
fnLiteral.charCodeAt(parenthesisEnd + 2) === 61 &&  // '=' at position +2
fnLiteral.charCodeAt(parenthesisEnd + 5) !== 123    // not '{' at position +5
```

This broke when code was minified (e.g., by tsx) to `)=>expr` (no spaces), because:
- In `) => expr`: position +2 is `=` ✓
- In `)=>expr`: position +2 is `>` ✗

This caused `beforeHandle` and other lifecycle hooks to be incorrectly identified as "not having a return", leading to them being **silently removed** during AOT compilation.

## Solution
Use `indexOf('=>')` to find the arrow operator regardless of spacing:

```typescript
const arrowIndex = fnLiteral.indexOf('=>', parenthesisEnd)
if (arrowIndex !== -1) {
    // Skip whitespace after `=>`
    let afterArrow = arrowIndex + 2
    while (fnLiteral.charCodeAt(afterArrow) === 32) afterArrow++
    
    // Check if not a block
    if (fnLiteral.charCodeAt(afterArrow) !== 123) {
        return true  // Direct return expression
    }
}
```

## Test Plan
- [x] Added test file `test/core/before-handle-arrow.test.ts` with 7 test cases
- [x] All existing tests pass (1423 pass, 2 unrelated flaky failures)
- [x] Manually verified with minified function strings

Fixes #1617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for arrow-function beforeHandle hooks, covering async, block-body, expression returns, multiple hooks, minified variants, and end-to-end server behavior.

* **Refactor**
  * Improved detection and handling of direct-return arrow functions in beforeHandle hooks and more robust input coercion for non-object inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->