### PR TITLE
fix: apply macros before merging hooks in group method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4066,20 +4066,29 @@ export default class Elysia<
 											localHook.error,
 											...(sandbox.event.error ?? [])
 										],
-							standaloneValidator: !hasStandaloneSchema
-								? localHook.standaloneValidator
-								: [
-										...(localHook.standaloneValidator ??
-											[]),
-										{
-											body,
-											headers,
-											query,
-											params,
-											cookie,
-											response
-										}
-									]
+							// Merge macro's standaloneValidator with local and group schema
+							standaloneValidator:
+								hook.standaloneValidator ||
+								localHook.standaloneValidator ||
+								hasStandaloneSchema
+									? [
+											...(hook.standaloneValidator ?? []),
+											...(localHook.standaloneValidator ??
+												[]),
+											...(hasStandaloneSchema
+												? [
+														{
+															body,
+															headers,
+															query,
+															params,
+															cookie,
+															response
+														}
+													]
+												: [])
+										]
+									: undefined
 						}),
 						undefined
 					)


### PR DESCRIPTION
## Summary

Fixes #1586 - macro-defined `beforeHandle` hooks were running after nested plugin `resolve` hooks instead of before.

**Root Cause**: The `group` method was merging hooks via `mergeHook(hook, localHook)` before expanding macro options. The macro expansion happened later in `add()`, but by then the nested plugin hooks were already in the array, so macro hooks were appended at the end.

**Fix**: 
1. Call `applyMacro(hook)` before `mergeHook()` in the group method (similar to how `guard` method already does this at line 4504)
2. Properly merge `hook.standaloneValidator` (from macro schema) with `localHook.standaloneValidator` to prevent macro-defined schema validation from being lost

## Test Cases Added

Four test cases in `test/core/macro-lifecycle.test.ts`:

1. **macro beforeHandle runs before nested plugin resolve**: Verifies that when a group uses `{ isSignedIn: true }` macro, the macro's `beforeHandle` runs before any nested plugin's `resolve` hook
2. **hooks run in registration order**: Verifies that `resolve` and `beforeHandle` share the same queue and run in registration order
3. **macro in group with successful auth**: Verifies the correct execution order when auth succeeds
4. **preserve macro schema when merging**: Verifies that macro-defined schema validation is preserved when used with nested plugins

## Before Fix
```
Execution order: [ "auth.resolve", "data.resolve", "requireAuth.beforeHandle" ]
```

## After Fix
```
Execution order: [ "auth.resolve", "requireAuth.beforeHandle", "data.resolve" ]
```

## Test Results
- All existing tests pass (except pre-existing flaky `stop.test.ts`)
- All 4 new tests pass
- All macro and lifecycle related tests verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured macros are expanded before group merging, fixing execution order in grouped routes and improving authorization and dependency resolution.
  * Corrected merging of standalone validators so combined validators from macros, local hooks, and group schemas are applied consistently.

* **Tests**
  * Added comprehensive tests validating macro and hook lifecycle ordering across grouped routes, registration order, and authorization flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->