### PR TITLE
feat: idempotent cookies

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -125,7 +125,7 @@ type Updater<T> = T | ((value: T) => T)
 export class Cookie<T> implements ElysiaCookie {
 	constructor(
 		private name: string,
-		// Modifications here lead to changes in the response headers. Initially empty.
+		// Modifications here lead to changes in the response headers. Empty at the start of a request.
 		private jar: Record<string, ElysiaCookie>,
 		private readonly initial: Partial<ElysiaCookie> = {}
 	) {}

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -291,7 +291,7 @@ export const createCookieJar = (
 	return new Proxy(store, {
 		get(_, key: string) {
 			return new Cookie(key, set.cookie as Record<string, ElysiaCookie>, {
-				...initial,
+				...(initial ?? {}),
 				...(store[key] ?? {})
 			})
 		}

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -127,7 +127,7 @@ export class Cookie<T> implements ElysiaCookie {
 		private name: string,
 		// Modifications here lead to changes in the response headers. Empty at the start of a request.
 		private jar: Record<string, ElysiaCookie>,
-		private readonly initial: Partial<ElysiaCookie> = {}
+		private initial: Partial<ElysiaCookie> = {}
 	) {}
 
 	get cookie() {

--- a/test/cookie/unchanged.test.ts
+++ b/test/cookie/unchanged.test.ts
@@ -108,7 +108,7 @@ describe('Cookie - Unchanged Values', () => {
 		expect(response.headers.getAll('set-cookie').length).toBeGreaterThan(0)
 	})
 
-	it('cookie handling should be idempotent', async () => {
+	it('should idempotently create headers on cookie modifications', async () => {
 		const app = new Elysia().post('/update', ({ cookie: { data } }) => {
 			// Set to same value as incoming cookie
 			data.value = { id: 123, name: 'test' }
@@ -132,7 +132,6 @@ describe('Cookie - Unchanged Values', () => {
 			})
 		)
 
-		// Should not send Set-Cookie since value didn't change
 		expect(secondRes.headers.getAll('set-cookie').length).toBe(1)
 	})
 

--- a/test/cookie/unchanged.test.ts
+++ b/test/cookie/unchanged.test.ts
@@ -132,7 +132,7 @@ describe('Cookie - Unchanged Values', () => {
 			})
 		)
 
-		expect(secondRes.headers.getAll('set-cookie').length).toBe(1)
+		expect(secondRes.headers.get('set-cookie')).toBeTruthy()
 	})
 
 	it('should optimize multiple assignments of same object in single request', async () => {


### PR DESCRIPTION
I explained most of the motivation for PR [here](https://github.com/elysiajs/elysia/pull/1567).
Main points:
- Cookies should be idempotent. This helps with OpenAPI docs a lot.
- Cookie handling should be fast.
- API and behavior should be simple. Caching and validating cache are complications.

This is an [example](https://gist.github.com/akim-bow/d40734355d7d5ea3cad05a6079a7a446) how cookie caching can be implemented via plugin in case someone find this behavior beneficial.

Making decoupled and pluggable architecture ensures that Elysia remains simple and customizable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent Set-Cookie header behavior on cookie updates; repeated updates now produce idempotent header creation.

* **Refactor**
  * Removed internal hash-based change detection; cookie values are now assigned directly for deterministic updates.
  * Cookie value decoding step removed; JSON parsing and signing/unsigning remain unchanged.

* **Tests**
  * Updated tests to expect a Set-Cookie header on subsequent requests and reflect idempotent header creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->