### PR TITLE
fix: add WebSocketConfig type for constructor options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ import type {
 } from './error'
 
 import type { AnyWSLocalHook } from './ws/types'
-import type { WebSocketHandler } from './ws/bun'
+import type { WebSocketHandler, WebSocketConfig } from './ws/bun'
 
 import type { Instruction as ExactMirrorInstruction } from 'exact-mirror'
 import { BunHTMLBundlelike } from './universal/types'
@@ -171,10 +171,7 @@ export interface ElysiaConfig<in out Prefix extends string | undefined> {
 	 *
 	 * @see https://bun.sh/docs/api/websockets
 	 */
-	websocket?: Omit<
-		WebSocketHandler<any>,
-		'open' | 'close' | 'message' | 'drain'
-	>
+	websocket?: WebSocketConfig
 	cookie?: CookieOptions & {
 		/**
 		 * Specified cookie name to be signed globally

--- a/src/universal/server.ts
+++ b/src/universal/server.ts
@@ -1,5 +1,6 @@
 import { Serve as BunServe, type Server as BunServer } from 'bun'
 import type { Equal, MaybePromise } from '../types'
+import type { WebSocketConfig } from '../ws/bun'
 
 export interface ErrorLike extends Error {
 	code?: string
@@ -120,6 +121,13 @@ export interface ServeOptions extends GenericServeOptions {
 		string,
 		Function | Response | Record<string, Function | Response>
 	>
+
+	/**
+	 * WebSocket configuration options
+	 *
+	 * @see https://bun.sh/docs/api/websockets
+	 */
+	websocket?: WebSocketConfig
 }
 
 export type Serve =

--- a/src/ws/bun.ts
+++ b/src/ws/bun.ts
@@ -317,6 +317,61 @@ export interface ServerWebSocket<T = undefined> {
 }
 
 /**
+ * WebSocket configuration options (without handler methods).
+ * Use this type when you only need to configure WebSocket behavior
+ * without defining message handlers.
+ */
+export type WebSocketConfig = {
+	/**
+	 * Sets the maximum size of messages in bytes.
+	 * @default 16 MB (1024 * 1024 * 16)
+	 */
+	maxPayloadLength?: number
+
+	/**
+	 * Sets the maximum number of bytes that can be buffered on a single connection.
+	 * @default 16 MB (1024 * 1024 * 16)
+	 */
+	backpressureLimit?: number
+
+	/**
+	 * Sets if the connection should be closed if `backpressureLimit` is reached.
+	 * @default false
+	 */
+	closeOnBackpressureLimit?: boolean
+
+	/**
+	 * Sets the number of seconds to wait before timing out a connection
+	 * due to no messages or pings.
+	 * @default 120 (2 minutes)
+	 */
+	idleTimeout?: number
+
+	/**
+	 * Should `ws.publish()` also send a message to `ws` (itself), if it is subscribed?
+	 * @default false
+	 */
+	publishToSelf?: boolean
+
+	/**
+	 * Should the server automatically send and respond to pings to clients?
+	 * @default true
+	 */
+	sendPings?: boolean
+
+	/**
+	 * Sets the compression level for messages, for clients that support it.
+	 * @default false (disabled)
+	 */
+	perMessageDeflate?:
+		| boolean
+		| {
+				compress?: WebSocketCompressor | boolean
+				decompress?: WebSocketCompressor | boolean
+		  }
+}
+
+/**
  * Compression options for WebSocket messages.
  */
 export type WebSocketCompressor =
@@ -371,7 +426,7 @@ export type WebSocketCompressor =
  * });
  * ```
  */
-export interface WebSocketHandler<in out T = undefined> {
+export interface WebSocketHandler<in out T = undefined> extends WebSocketConfig {
 	/**
 	 * Called when the server receives an incoming message.
 	 *
@@ -431,65 +486,4 @@ export interface WebSocketHandler<in out T = undefined> {
 	 * @param data The data sent with the ping
 	 */
 	pong?(ws: ServerWebSocket<T>, data: Buffer): void | Promise<void>
-
-	/**
-	 * Sets the maximum size of messages in bytes.
-	 *
-	 * Default is 16 MB, or `1024 * 1024 * 16` in bytes.
-	 */
-	maxPayloadLength?: number
-
-	/**
-	 * Sets the maximum number of bytes that can be buffered on a single connection.
-	 *
-	 * Default is 16 MB, or `1024 * 1024 * 16` in bytes.
-	 */
-	backpressureLimit?: number
-
-	/**
-	 * Sets if the connection should be closed if `backpressureLimit` is reached.
-	 *
-	 * Default is `false`.
-	 */
-	closeOnBackpressureLimit?: boolean
-
-	/**
-	 * Sets the the number of seconds to wait before timing out a connection
-	 * due to no messages or pings.
-	 *
-	 * Default is 2 minutes, or `120` in seconds.
-	 */
-	idleTimeout?: number
-
-	/**
-	 * Should `ws.publish()` also send a message to `ws` (itself), if it is subscribed?
-	 *
-	 * Default is `false`.
-	 */
-	publishToSelf?: boolean
-
-	/**
-	 * Should the server automatically send and respond to pings to clients?
-	 *
-	 * Default is `true`.
-	 */
-	sendPings?: boolean
-
-	/**
-	 * Sets the compression level for messages, for clients that supports it. By default, compression is disabled.
-	 *
-	 * Default is `false`.
-	 */
-	perMessageDeflate?:
-		| boolean
-		| {
-				/**
-				 * Sets the compression level.
-				 */
-				compress?: WebSocketCompressor | boolean
-				/**
-				 * Sets the decompression level.
-				 */
-				decompress?: WebSocketCompressor | boolean
-		  }
 }

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -4,8 +4,11 @@ import type {
 	ServerWebSocket,
 	ServerWebSocketSendStatus,
 	BufferSource,
-	WebSocketHandler
+	WebSocketHandler,
+	WebSocketConfig
 } from './bun'
+
+export type { WebSocketConfig }
 
 import type { TSchema } from '@sinclair/typebox'
 import type { TypeCheck } from '../type-system'


### PR DESCRIPTION
## Summary
- Adds new `WebSocketConfig` type that includes only WebSocket configuration options (idleTimeout, maxPayloadLength, etc.)
- Updates `ElysiaConfig.websocket` to use `WebSocketConfig` instead of `Omit<WebSocketHandler, ...>`
- Exports `WebSocketConfig` from `ws/index.ts`

## Problem
Users couldn't pass WebSocket config to the Elysia constructor without TypeScript errors:

```typescript
const app = new Elysia({
  websocket: {
    idleTimeout: 30  // TS error: missing 'message' handler
  }
})
```

This happened because `WebSocketHandler` requires the `message` handler method.

## Solution
Created a separate `WebSocketConfig` type that only includes configuration options without handler methods. This allows users to configure WebSocket behavior at the app level without needing `@ts-expect-error`.

## Test plan
- [x] Build passes (`bun run build`)
- [x] No new type errors introduced in modified files

Fixes #1517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a public WebSocketConfig type to customize server WebSocket behavior (payload limits, backpressure, idle timeout, ping, compression).
  * Exposed the WebSocketConfig type for consumers to import and reuse.
  * Added an optional server configuration option to pass WebSocketConfig when starting the server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->