### PR TITLE
fix: restore handle() return type to Promise<Response>

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8044,14 +8044,14 @@ export default class Elysia<
 		return this
 	}
 
-	handle = async (request: Request) => this.fetch(request)
+	handle = async (request: Request): Promise<Response> => this.fetch(request)
 
 	/**
 	 * Use handle can be either sync or async to save performance.
 	 *
 	 * Beside benchmark purpose, please use 'handle' instead.
 	 */
-	get fetch() {
+	get fetch(): (request: Request) => Response | Promise<Response> {
 		const fetch = this.config.aot
 			? composeGeneralHandler(this)
 			: createDynamicHandler(this)


### PR DESCRIPTION
## Summary
- Fixes #1630
- Restores the `handle()` method return type from `Promise<any>` to `Promise<Response>`
- Also adds explicit return type to the `fetch` getter

## Problem
The `handle` method was returning `Promise<any>` instead of `Promise<Response>` because:
1. `composeGeneralHandler` creates a function via `Function()` constructor, which returns `any`
2. Neither `handle` nor `fetch` had explicit return type annotations
3. TypeScript inferred the type as `any`

## Solution
Added explicit return types:
- `handle` now returns `Promise<Response>`
- `fetch` getter now returns `(request: Request) => Response | Promise<Response>`

## Test plan
- [x] Build passes
- [x] Existing tests pass (23 pre-existing failures unrelated to this change)
- [ ] Type inference verified with reproduction from #1630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API type signatures with explicit return type annotations to improve type safety and provide clearer contracts for request handling and response processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->