### PR TITLE
fix: resolve "Body already used" when accessing request in derive/resolve hooks

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -919,7 +919,10 @@ export const composeHandler = ({
 		// Skip if custom parse hooks exist - they'll read the request themselves
 		// Note: FormData requests cannot be cloned for reuse - derive/resolve cannot
 		// re-read the body for multipart/form-data requests (protocol limitation)
-		if (inference.request && !hooks.parse?.length) {
+		const hasCustomParseHook = hooks.parse?.some(
+			(h: any) => typeof h !== 'string' && typeof h.fn !== 'string'
+		)
+		if (inference.request && !hasCustomParseHook) {
 			fnLiteral +=
 				`const _ct=c.request.headers.get('content-type')\n` +
 				`if(!_ct||!_ct.includes('multipart/form-data')){` +

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -914,6 +914,18 @@ export const composeHandler = ({
 
 		fnLiteral += '\ntry{'
 
+		// When hooks access request.body/arrayBuffer, preserve raw body before parsing
+		// Clone request first so hooks can still read from it
+		// Skip if custom parse hooks exist - they'll read the request themselves
+		// Note: FormData requests cannot be cloned for reuse - derive/resolve cannot
+		// re-read the body for multipart/form-data requests (protocol limitation)
+		if (inference.request && !hooks.parse?.length) {
+			fnLiteral +=
+				`const _ct=c.request.headers.get('content-type')\n` +
+				`if(!_ct||!_ct.includes('multipart/form-data')){` +
+				`c.rawBody=await c.request.clone().arrayBuffer()}\n`
+		}
+
 		let parser: string | undefined =
 			typeof hooks.parse === 'string'
 				? hooks.parse
@@ -944,55 +956,108 @@ export const composeHandler = ({
 
 			const isOptionalBody = !!validator.body?.isOptional
 
-			switch (parser) {
-				case 'json':
-				case 'application/json':
-					fnLiteral += adapter.parser.json(isOptionalBody)
-					break
+			// When inference.request is true and rawBody exists, parse from it
+			// For FormData (no rawBody), use standard parser
+			if (inference.request) {
+				switch (parser) {
+					case 'json':
+					case 'application/json':
+						if (isOptionalBody)
+							fnLiteral += 'if(c.rawBody){try{c.body=JSON.parse(new TextDecoder().decode(c.rawBody))}catch{}}else{try{c.body=await c.request.json()}catch{}}\n'
+						else
+							fnLiteral += 'c.body=c.rawBody?JSON.parse(new TextDecoder().decode(c.rawBody)):await c.request.json()\n'
+						break
 
-				case 'text':
-				case 'text/plain':
-					fnLiteral += adapter.parser.text(isOptionalBody)
+					case 'text':
+					case 'text/plain':
+						fnLiteral += 'c.body=c.rawBody?new TextDecoder().decode(c.rawBody):await c.request.text()\n'
+						break
 
-					break
+					case 'urlencoded':
+					case 'application/x-www-form-urlencoded':
+						fnLiteral += 'c.body=c.rawBody?parseQuery(new TextDecoder().decode(c.rawBody)):parseQuery(await c.request.text())\n'
+						break
 
-				case 'urlencoded':
-				case 'application/x-www-form-urlencoded':
-					fnLiteral += adapter.parser.urlencoded(isOptionalBody)
+					case 'arrayBuffer':
+					case 'application/octet-stream':
+						fnLiteral += 'c.body=c.rawBody??await c.request.arrayBuffer()\n'
+						break
 
-					break
+					case 'formdata':
+					case 'multipart/form-data':
+						// FormData reads from original request (cannot be cloned for reuse)
+						fnLiteral += adapter.parser.formData(isOptionalBody)
+						break
 
-				case 'arrayBuffer':
-				case 'application/octet-stream':
-					fnLiteral += adapter.parser.arrayBuffer(isOptionalBody)
+					default:
+						// Custom parser - let it access rawBody via context
+						if (parser in app['~parser']) {
+							fnLiteral += hasHeaders
+								? `let contentType = c.headers['content-type']`
+								: `let contentType = c.request.headers.get('content-type')`
 
-					break
+							fnLiteral +=
+								`\nif(contentType){` +
+								`const index=contentType.indexOf(';')\n` +
+								`if(index!==-1)contentType=contentType.substring(0,index)}\n` +
+								`else{contentType=''}` +
+								`c.contentType=contentType\n` +
+								`let result=parser['${parser}'](c, contentType)\n` +
+								`if(result instanceof Promise)result=await result\n` +
+								`if(result instanceof ElysiaCustomStatusResponse)throw result\n` +
+								`if(result!==undefined)c.body=result\n` +
+								'delete c.contentType\n'
+						}
+				}
+			} else {
+				switch (parser) {
+					case 'json':
+					case 'application/json':
+						fnLiteral += adapter.parser.json(isOptionalBody)
+						break
 
-				case 'formdata':
-				case 'multipart/form-data':
-					fnLiteral += adapter.parser.formData(isOptionalBody)
-					break
+					case 'text':
+					case 'text/plain':
+						fnLiteral += adapter.parser.text(isOptionalBody)
 
-				default:
-					if (parser in app['~parser']) {
-						fnLiteral += hasHeaders
-							? `let contentType = c.headers['content-type']`
-							: `let contentType = c.request.headers.get('content-type')`
+						break
 
-						fnLiteral +=
-							`\nif(contentType){` +
-							`const index=contentType.indexOf(';')\n` +
-							`if(index!==-1)contentType=contentType.substring(0,index)}\n` +
-							`else{contentType=''}` +
-							`c.contentType=contentType\n` +
-							`let result=parser['${parser}'](c, contentType)\n` +
-							`if(result instanceof Promise)result=await result\n` +
-							`if(result instanceof ElysiaCustomStatusResponse)throw result\n` +
-							`if(result!==undefined)c.body=result\n` +
-							'delete c.contentType\n'
-					}
+					case 'urlencoded':
+					case 'application/x-www-form-urlencoded':
+						fnLiteral += adapter.parser.urlencoded(isOptionalBody)
 
-					break
+						break
+
+					case 'arrayBuffer':
+					case 'application/octet-stream':
+						fnLiteral += adapter.parser.arrayBuffer(isOptionalBody)
+
+						break
+
+					case 'formdata':
+					case 'multipart/form-data':
+						fnLiteral += adapter.parser.formData(isOptionalBody)
+						break
+
+					default:
+						if (parser in app['~parser']) {
+							fnLiteral += hasHeaders
+								? `let contentType = c.headers['content-type']`
+								: `let contentType = c.request.headers.get('content-type')`
+
+							fnLiteral +=
+								`\nif(contentType){` +
+								`const index=contentType.indexOf(';')\n` +
+								`if(index!==-1)contentType=contentType.substring(0,index)}\n` +
+								`else{contentType=''}` +
+								`c.contentType=contentType\n` +
+								`let result=parser['${parser}'](c, contentType)\n` +
+								`if(result instanceof Promise)result=await result\n` +
+								`if(result instanceof ElysiaCustomStatusResponse)throw result\n` +
+								`if(result!==undefined)c.body=result\n` +
+								'delete c.contentType\n'
+						}
+				}
 			}
 
 			reporter.resolve()
@@ -1017,31 +1082,62 @@ export const composeHandler = ({
 				hasDefaultParser = true
 				const isOptionalBody = !!validator.body?.isOptional
 
-				fnLiteral +=
-					`if(contentType)` +
-					`switch(contentType.charCodeAt(12)){` +
-					`\ncase 106:` +
-					adapter.parser.json(isOptionalBody) +
-					'break' +
-					`\n` +
-					`case 120:` +
-					adapter.parser.urlencoded(isOptionalBody) +
-					`break` +
-					`\n` +
-					`case 111:` +
-					adapter.parser.arrayBuffer(isOptionalBody) +
-					`break` +
-					`\n` +
-					`case 114:` +
-					adapter.parser.formData(isOptionalBody) +
-					`break` +
-					`\n` +
-					`default:` +
-					`if(contentType.charCodeAt(0)===116){` +
-					adapter.parser.text(isOptionalBody) +
-					`}` +
-					`break\n` +
-					`}`
+				// When rawBody is preserved, parse from it; for FormData use cloned request
+				if (inference.request) {
+					fnLiteral +=
+						`if(contentType)` +
+						`switch(contentType.charCodeAt(12)){` +
+						`\ncase 106:` + // application/json
+						(isOptionalBody
+							? 'if(c.rawBody){try{c.body=JSON.parse(new TextDecoder().decode(c.rawBody))}catch{}}else{try{c.body=await c.request.json()}catch{}}\n'
+							: 'c.body=c.rawBody?JSON.parse(new TextDecoder().decode(c.rawBody)):await c.request.json()\n') +
+						'break' +
+						`\n` +
+						`case 120:` + // application/x-www-form-urlencoded
+						'c.body=c.rawBody?parseQuery(new TextDecoder().decode(c.rawBody)):parseQuery(await c.request.text())\n' +
+						`break` +
+						`\n` +
+						`case 111:` + // application/octet-stream
+						'c.body=c.rawBody??await c.request.arrayBuffer()\n' +
+						`break` +
+						`\n` +
+						`case 114:` + // multipart/form-data
+						adapter.parser.formData(isOptionalBody) +
+						`break` +
+						`\n` +
+						`default:` +
+						`if(contentType.charCodeAt(0)===116){` + // text/plain
+						'c.body=c.rawBody?new TextDecoder().decode(c.rawBody):await c.request.text()\n' +
+						`}` +
+						`break\n` +
+						`}`
+				} else {
+					fnLiteral +=
+						`if(contentType)` +
+						`switch(contentType.charCodeAt(12)){` +
+						`\ncase 106:` +
+						adapter.parser.json(isOptionalBody) +
+						'break' +
+						`\n` +
+						`case 120:` +
+						adapter.parser.urlencoded(isOptionalBody) +
+						`break` +
+						`\n` +
+						`case 111:` +
+						adapter.parser.arrayBuffer(isOptionalBody) +
+						`break` +
+						`\n` +
+						`case 114:` +
+						adapter.parser.formData(isOptionalBody) +
+						`break` +
+						`\n` +
+						`default:` +
+						`if(contentType.charCodeAt(0)===116){` +
+						adapter.parser.text(isOptionalBody) +
+						`}` +
+						`break\n` +
+						`}`
+				}
 			}
 
 			const reporter = report('parse', {

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -265,28 +265,31 @@ export const createDynamicHandler = (app: AnyElysia) => {
 
 			let body: string | Record<string, any> | undefined
 			if (request.method !== 'GET' && request.method !== 'HEAD') {
+				// clone before parsing so handlers/hooks can still read from original
+				const parseRequest = request.clone()
+
 				if (content) {
 					switch (content) {
 						case 'application/json':
-							body = (await request.json()) as any
+							body = (await parseRequest.json()) as any
 							break
 
 						case 'text/plain':
-							body = await request.text()
+							body = await parseRequest.text()
 							break
 
 						case 'application/x-www-form-urlencoded':
-							body = parseQuery(await request.text())
+							body = parseQuery(await parseRequest.text())
 							break
 
 						case 'application/octet-stream':
-							body = await request.arrayBuffer()
+							body = await parseRequest.arrayBuffer()
 							break
 
 						case 'multipart/form-data': {
 							body = {}
 
-							const form = await request.formData()
+							const form = await parseRequest.formData()
 							const grouped = new Map<string, any[]>()
 							form.forEach((v, k) => {
 								const list = grouped.get(k)
@@ -327,31 +330,31 @@ export const createDynamicHandler = (app: AnyElysia) => {
 									switch (hook) {
 										case 'json':
 										case 'application/json':
-											body = (await request.json()) as any
+											body = (await parseRequest.json()) as any
 											break
 
 										case 'text':
 										case 'text/plain':
-											body = await request.text()
+											body = await parseRequest.text()
 											break
 
 										case 'urlencoded':
 										case 'application/x-www-form-urlencoded':
 											body = parseQuery(
-												await request.text()
+												await parseRequest.text()
 											)
 											break
 
 										case 'arrayBuffer':
 										case 'application/octet-stream':
-											body = await request.arrayBuffer()
+											body = await parseRequest.arrayBuffer()
 											break
 
 										case 'formdata':
 										case 'multipart/form-data': {
 											body = {}
 
-											const form = await request.formData()
+											const form = await parseRequest.formData()
 											const grouped = new Map<string, any[]>()
 											form.forEach((v, k) => {
 												const list = grouped.get(k)
@@ -408,25 +411,25 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						if (body === undefined) {
 							switch (contentType) {
 								case 'application/json':
-									body = (await request.json()) as any
+									body = (await parseRequest.json()) as any
 									break
 
 								case 'text/plain':
-									body = await request.text()
+									body = await parseRequest.text()
 									break
 
 								case 'application/x-www-form-urlencoded':
-									body = parseQuery(await request.text())
+									body = parseQuery(await parseRequest.text())
 									break
 
 								case 'application/octet-stream':
-									body = await request.arrayBuffer()
+									body = await parseRequest.arrayBuffer()
 									break
 
 								case 'multipart/form-data': {
 									body = {}
 
-									const form = await request.formData()
+									const form = await parseRequest.formData()
 									const grouped = new Map<string, any[]>()
 									form.forEach((v, k) => {
 										const list = grouped.get(k)

--- a/src/sucrose.ts
+++ b/src/sucrose.ts
@@ -16,6 +16,8 @@ export namespace Sucrose {
 		route: boolean
 		url: boolean
 		path: boolean
+		/** Whether code accesses request.body, request.arrayBuffer, etc. */
+		request: boolean
 	}
 
 	export interface LifeCycle extends Partial<LifeCycleStore> {
@@ -290,6 +292,7 @@ export const findParameterReference = (
 	if (parameters.route) inference.route = true
 	if (parameters.url) inference.url = true
 	if (parameters.path) inference.path = true
+	if (parameters.request) inference.request = true
 
 	if (hasParenthesis) return `{ ${Object.keys(parameters).join(', ')} }`
 
@@ -470,6 +473,7 @@ export const inferBodyReference = (
 			if (parameters.url) inference.url = true
 			if (parameters.route) inference.route = true
 			if (parameters.path) inference.path = true
+			if (parameters.request) inference.request = true
 
 			continue
 		}
@@ -497,6 +501,8 @@ export const inferBodyReference = (
 		if (!inference.route && access('route', alias)) inference.route = true
 		if (!inference.url && access('url', alias)) inference.url = true
 		if (!inference.path && access('path', alias)) inference.path = true
+		if (!inference.request && access('request', alias))
+			inference.request = true
 
 		if (
 			inference.query &&
@@ -507,7 +513,8 @@ export const inferBodyReference = (
 			inference.server &&
 			inference.route &&
 			inference.url &&
-			inference.path
+			inference.path &&
+			inference.request
 		)
 			break
 	}
@@ -646,7 +653,8 @@ export const mergeInference = (a: Sucrose.Inference, b: Sucrose.Inference) => {
 		server: a.server || b.server,
 		url: a.url || b.url,
 		route: a.route || b.route,
-		path: a.path || b.path
+		path: a.path || b.path,
+		request: a.request || b.request
 	}
 }
 
@@ -661,7 +669,8 @@ export const sucrose = (
 		server: false,
 		url: false,
 		route: false,
-		path: false
+		path: false,
+		request: false
 	},
 	settings: Sucrose.Settings = {}
 ): Sucrose.Inference => {
@@ -675,6 +684,8 @@ export const sucrose = (
 	if (lifeCycle.afterHandle?.length) events.push(...lifeCycle.afterHandle)
 	if (lifeCycle.mapResponse?.length) events.push(...lifeCycle.mapResponse)
 	if (lifeCycle.afterResponse?.length) events.push(...lifeCycle.afterResponse)
+	if (lifeCycle.derive?.length) events.push(...lifeCycle.derive)
+	if (lifeCycle.resolve?.length) events.push(...lifeCycle.resolve)
 
 	if (lifeCycle.handler && typeof lifeCycle.handler === 'function')
 		events.push(lifeCycle.handler as Handler)
@@ -711,7 +722,8 @@ export const sucrose = (
 			server: false,
 			url: false,
 			route: false,
-			path: false
+			path: false,
+			request: false
 		}
 
 		const [parameter, body] = separateFunction(content)
@@ -754,7 +766,8 @@ export const sucrose = (
 			inference.server &&
 			inference.url &&
 			inference.route &&
-			inference.path
+			inference.path &&
+			inference.request
 		)
 			break
 	}

--- a/src/sucrose.ts
+++ b/src/sucrose.ts
@@ -292,7 +292,6 @@ export const findParameterReference = (
 	if (parameters.route) inference.route = true
 	if (parameters.url) inference.url = true
 	if (parameters.path) inference.path = true
-	if (parameters.request) inference.request = true
 
 	if (hasParenthesis) return `{ ${Object.keys(parameters).join(', ')} }`
 
@@ -444,6 +443,38 @@ export const extractMainParameter = (parameter: string) => {
 	return parameter.slice(spreadIndex + 3).trimEnd()
 }
 
+const bodyConsumingMethods = /\.(json|text|arrayBuffer|formData|blob|body)\b/
+
+// check if request body is accessed (not just headers/method/url)
+const accessRequestBody = (alias: string, code: string) => {
+	const requestAccess = new RegExp(
+		`${alias}\\.request`,
+		'g'
+	)
+
+	let match
+	while ((match = requestAccess.exec(code)) !== null) {
+		const rest = code.slice(match.index + match[0].length)
+		if (bodyConsumingMethods.test(rest.slice(0, 20)))
+			return true
+	}
+
+	// for destructured request variable
+	if (alias === 'request') {
+		const directAccess = new RegExp(
+			`\\brequest\\b`,
+			'g'
+		)
+		while ((match = directAccess.exec(code)) !== null) {
+			const rest = code.slice(match.index + match[0].length)
+			if (bodyConsumingMethods.test(rest.slice(0, 20)))
+				return true
+		}
+	}
+
+	return false
+}
+
 /**
  * Analyze if context is mentioned in body
  */
@@ -473,7 +504,6 @@ export const inferBodyReference = (
 			if (parameters.url) inference.url = true
 			if (parameters.route) inference.route = true
 			if (parameters.path) inference.path = true
-			if (parameters.request) inference.request = true
 
 			continue
 		}
@@ -501,7 +531,10 @@ export const inferBodyReference = (
 		if (!inference.route && access('route', alias)) inference.route = true
 		if (!inference.url && access('url', alias)) inference.url = true
 		if (!inference.path && access('path', alias)) inference.path = true
-		if (!inference.request && access('request', alias))
+		if (
+			!inference.request &&
+			accessRequestBody(alias, code)
+		)
 			inference.request = true
 
 		if (
@@ -581,6 +614,7 @@ export const isContextPassToFunction = (
 				inference.url = true
 				inference.route = true
 				inference.path = true
+				inference.request = true
 
 				return true
 			}
@@ -605,6 +639,7 @@ export const isContextPassToFunction = (
 			inference.url = true
 			inference.route = true
 			inference.path = true
+			inference.request = true
 
 			return true
 		}
@@ -751,6 +786,22 @@ export const sucrose = (
 				code.includes('return ' + mainParameter + '.query')
 			)
 				fnInference.query = true
+		} else if (
+			!fnInference.request &&
+			rootParameters.charCodeAt(0) === 123
+		) {
+			// single destructured param without spread — extractMainParameter
+			// returns undefined but we still need to check body consumption
+			let code = body
+			if (
+				code.charCodeAt(0) === 123 &&
+				code.charCodeAt(body.length - 1) === 125
+			)
+				code = code.slice(1, -1).trim()
+
+			const params = retrieveRootparameters(rootParameters).parameters
+			if (params.request && bodyConsumingMethods.test(code))
+				fnInference.request = true
 		}
 
 		if (!caches[key]) caches[key] = fnInference

--- a/test/sucrose/sucrose.test.ts
+++ b/test/sucrose/sucrose.test.ts
@@ -44,7 +44,8 @@ describe('sucrose', () => {
 			server: false,
 			path: false,
 			url: false,
-			route: false
+			route: false,
+			request: false
 		})
 	})
 
@@ -76,7 +77,8 @@ describe('sucrose', () => {
 			server: false,
 			path: false,
 			url: false,
-			route: false
+			route: false,
+			request: false
 		})
 	})
 
@@ -160,7 +162,8 @@ describe('sucrose', () => {
 			server: false,
 			path: false,
 			url: false,
-			route: false
+			route: false,
+			request: false
 		})
 	})
 
@@ -191,7 +194,8 @@ describe('sucrose', () => {
 			server: true,
 			path: true,
 			url: true,
-			route: true
+			route: true,
+			request: false
 		})
 	})
 
@@ -222,7 +226,8 @@ describe('sucrose', () => {
 			server: true,
 			path: true,
 			url: true,
-			route: true
+			route: true,
+			request: false
 		})
 	})
 
@@ -253,7 +258,8 @@ describe('sucrose', () => {
 			server: true,
 			path: false,
 			url: false,
-			route: false
+			route: false,
+			request: false
 		})
 	})
 
@@ -304,7 +310,8 @@ describe('sucrose', () => {
 			server: false,
 			path: true,
 			url: true,
-			route: true
+			route: true,
+			request: false
 		})
 	})
 
@@ -325,7 +332,8 @@ describe('sucrose', () => {
 			server: true,
 			path: true,
 			url: true,
-			route: true
+			route: true,
+			request: false
 		})
 	})
 })

--- a/test/sucrose/sucrose.test.ts
+++ b/test/sucrose/sucrose.test.ts
@@ -195,7 +195,7 @@ describe('sucrose', () => {
 			path: true,
 			url: true,
 			route: true,
-			request: false
+			request: true
 		})
 	})
 
@@ -227,7 +227,7 @@ describe('sucrose', () => {
 			path: true,
 			url: true,
 			route: true,
-			request: false
+			request: true
 		})
 	})
 
@@ -333,7 +333,7 @@ describe('sucrose', () => {
 			path: true,
 			url: true,
 			route: true,
-			request: false
+			request: true
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Fixes #1628 - "Body already used" error when calling `request.arrayBuffer()` in derive hooks
- Adds `request` tracking to Sucrose inference to detect when hooks access the request body
- Clones request before parsing so derive/resolve hooks can still read from it
- Adds missing derive and resolve hooks to sucrose analysis

## Problem
When a derive() hook tries to access `request.arrayBuffer()`, `request.text()`, or `request.json()`, it fails with "Body already used" because Elysia parses the body BEFORE running derive hooks:

```typescript
.derive(async ({ request }) => {
  const rawBody = await request.arrayBuffer() // Error: Body already used
  return { rawBody }
})
```

## Solution
1. Detect when hooks access `request` via Sucrose inference
2. When detected, clone the request before body parsing
3. Parse body from the cloned request's rawBody
4. Keep original request available for derive/resolve hooks

## Test plan
- [x] Verified fix resolves the issue from #1628
- [x] All existing tests pass (1403 pass, 23 pre-existing failures unrelated to this change)
- [x] Verified inline parse hooks still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve the raw request body when inference-based request handling is enabled and prefer it for decoding JSON, text, urlencoded and binary payloads; multipart/form-data remains handled specially.
  * Ensure custom parsers receive normalized content-type and surface parsing errors consistently.

* **Chores**
  * Added a new inference flag to track explicit request access.

* **Tests**
  * Updated tests to include the new request-inference flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->