### PR TITLE
fix: add null check for object properties

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -213,6 +213,7 @@ export const hasElysiaMeta = (meta: string, _schema: TAnySchema): boolean => {
 
 	if (schema.type === 'object') {
 		const properties = schema.properties as Record<string, TAnySchema>
+		if (!properties) return false
 
 		for (const key of Object.keys(properties)) {
 			const property = properties[key]


### PR DESCRIPTION
Bug: `hasElysiaMeta` crashes with `TypeError: undefined is not an object (evaluating 'Object.keys(properties)')` when schemas contain t.Record.

 Why it happens:
  - t.Record(t.String(), t.String()) creates an object schema with patternProperties instead of properties
  - hasElysiaMeta assumes all type: "object" schemas have properties and iterates without checking
  - When recursively checking nested schemas (e.g., t.Union containing t.Array(t.Record(...))), it hits t.Record and crashes
  
  The fix: Add a null guard before iterating:
  `if (!properties) return false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema validation robustness by adding proper handling for edge cases, preventing potential errors during certain validation operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->