### PR TITLE
Always convert dates to iso string

### DIFF
--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -246,14 +246,12 @@ export const ElysiaType = {
 			.Encode((value) => {
 				if (value instanceof Date) return value.toISOString()
 				if (typeof value === 'string') {
-					if (
-						isNaN(
-							new Date(parseDateTimeEmptySpace(value)).getTime()
-						)
-					)
+					const parsed = new Date(parseDateTimeEmptySpace(value))
+
+					if (isNaN(parsed.getTime()))
 						throw new ValidationError('property', schema, value)
 
-					return value
+					return parsed.toISOString()
 				}
 
 				if (!compiler.Check(value)) throw compiler.Error(value)


### PR DESCRIPTION
When `t.Date()` is containing a string, we still want to ensure the string is in iso format.
Since we are already parsing the date, we can just use the `.toISOString()` method of `Date`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date encoding behavior: string date inputs are now properly parsed, validated, and normalized to ISO format instead of being returned unchanged. This ensures consistent date formatting throughout the system. Invalid dates continue to be properly rejected with validation errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->