### PR TITLE
Decode single values in ArrayQuery

### DIFF
--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -425,7 +425,7 @@ export const ElysiaType = {
 			if (value.indexOf(',') !== -1)
 				return compiler.Decode(value.split(','))
 
-			return [value]
+			return compiler.Decode([value])
 		}
 
 		return t


### PR DESCRIPTION
If we have a `t.Transform(t.Array())` in a query param and only pass one value, the value is never Decoded.

minimal repro:

```typescript
import { Elysia, t } from "elysia";

new Elysia()
	.get(
		"/",
		({ query }) => {
			return query;
		},
		{
			query: t.Object({
				a: t
					.Transform(t.Array(t.String()))
					.Decode((x) => {
						return { decoded: x };
					})
					.Encode((x) => {
						throw new Error("nop");
					}),
				b: t.Optional(
					t
						.Transform(t.String())
						.Decode((x) => {
							return { decoded: x };
						})
						.Encode((x) => {
							throw new Error("nop");
						}),
				),
			}),
		},
	)
   .listen(3000);
```

doing `curl http://localhost:3000?a=toto,tata` we get the expected decoded value:
```json
{
  "a": {
    "decoded": [
      "toto",
      "taat"
    ]
  }
}
```

doing it with a single value also works `curl http://localhost:3000?a=toto`
```json
{
  "a": {
    "decoded": [
      "toto"
    ]
  }
}
```

but adding another transformed query params break it for a single value: `curl http://localhost:3000?a=toto&b=toto`
```json
{
  "a": [
    "toto"
  ],
  "b": {
    "decoded": "toto"
  }
}
```

while adding a second value works:  `curl http://localhost:3000?a=toto,tata&b=toto`

```json
{
  "a": {
    "decoded": [
      "toto",
      "tata"
    ]
  },
  "b": {
    "decoded": "toto"
  }
}
```


After this patch is applied, this works too! `curl 'http://localhost:8901?a=toto&b=toto' `

```json
{
  "a": {
    "decoded": [
      "toto"
    ]
  },
  "b": {
    "decoded": "toto"
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in array query decoding for single-value string inputs. String values are now processed through the same validation pipeline as comma-separated values, ensuring uniform handling across all input types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->