### PR TITLE
Avoid crash after `mapValueError()`

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -458,7 +458,7 @@ export class ValidationError extends Error {
 						on: type,
 						property: accessor,
 						message: error?.message,
-						summary: mapValueError(error).summary,
+						summary: mapValueError(error)?.summary,
 						expected,
 						found: value,
 						errors:


### PR DESCRIPTION
Hit this error when upgrading to Elysia `1.4.22`:

```
Error: undefined is not an object (evaluating 'mapValueError(error).summary')
```

`mapValueError()` returns early if `error` is `undefined`. 

The code above the change line correctly uses `?.` for guarding against that, but this line doesn't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-handling reliability during validation to prevent potential runtime errors when a validation summary is missing, ensuring more robust and stable behavior for edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->