### PR TITLE
Revert "fix: named macros with function syntax now infer previous macro resolve types (#1574)"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5261,126 +5261,6 @@ export default class Elysia<
 		return this
 	}
 
-	// Overload 1: Named macro with function syntax (fixes issue #1574)
-	// This overload handles: .macro("name", (param) => ({ resolve: ... }))
-	// For function syntax, we compute MacroContext from ALL previous macros
-	// because we can't infer which macros are selected before the function returns
-	macro<
-		const Name extends string,
-		// Compute MacroContext from all previous macros, assuming all are enabled
-		const MacroContext extends {} extends Metadata['macroFn']
-			? {}
-			: MacroToContext<
-					Metadata['macroFn'],
-					// Use all macro keys set to true to include all possible resolves
-					{ [K in keyof Metadata['macroFn']]: true },
-					Definitions['typebox']
-				>,
-		const Param,
-		const Property extends Metadata['macro'] &
-			MacroProperty<
-				Metadata['macro'] &
-					InputSchema<keyof Definitions['typebox'] & string> & {
-						[name in Name]?: boolean
-					},
-				MacroContext,
-				Singleton & {
-					derive: Partial<Ephemeral['derive'] & Volatile['derive']>
-					resolve: Partial<
-						Ephemeral['resolve'] & Volatile['resolve']
-					> &
-						// @ts-ignore
-						MacroContext['resolve']
-				},
-				Definitions['error']
-			>
-	>(
-		name: Name,
-		macro: (param: Param) => Property
-	): Elysia<
-		BasePath,
-		Singleton,
-		Definitions,
-		{
-			schema: Metadata['schema']
-			standaloneSchema: Metadata['standaloneSchema']
-			macro: Metadata['macro'] & {
-				[name in Name]?: Param
-			}
-			macroFn: Metadata['macroFn'] & {
-				[name in Name]: (param: Param) => Property
-			}
-			parser: Metadata['parser']
-			response: Metadata['response']
-		},
-		Routes,
-		Ephemeral,
-		Volatile
-	>
-
-	// Overload 2: Named macro with object syntax (original)
-	// This overload handles: .macro("name", { resolve: ... })
-	macro<
-		const Name extends string,
-		const Input extends Metadata['macro'] &
-			InputSchema<keyof Definitions['typebox'] & string>,
-		const Schema extends MergeSchema<
-			UnwrapRoute<Input, Definitions['typebox'], BasePath>,
-			MergeSchema<
-				Volatile['schema'],
-				MergeSchema<Ephemeral['schema'], Metadata['schema']>
-			> &
-				Metadata['standaloneSchema'] &
-				Ephemeral['standaloneSchema'] &
-				Volatile['standaloneSchema']
-		>,
-		const MacroContext extends {} extends Metadata['macroFn']
-			? {}
-			: MacroToContext<
-					Metadata['macroFn'],
-					Omit<Input, NonResolvableMacroKey>,
-					Definitions['typebox']
-				>,
-		const Property extends MacroProperty<
-			Metadata['macro'] &
-				InputSchema<keyof Definitions['typebox'] & string> & {
-					[name in Name]?: boolean
-				},
-			Schema & MacroContext,
-			Singleton & {
-				derive: Partial<Ephemeral['derive'] & Volatile['derive']>
-				resolve: Partial<
-					Ephemeral['resolve'] & Volatile['resolve']
-				> &
-					// @ts-ignore
-					MacroContext['resolve']
-			},
-			Definitions['error']
-		>
-	>(
-		name: Name,
-		macro: (Input extends any ? Input : Prettify<Input>) & Property
-	): Elysia<
-		BasePath,
-		Singleton,
-		Definitions,
-		{
-			schema: Metadata['schema']
-			standaloneSchema: Metadata['standaloneSchema']
-			macro: Metadata['macro'] & {
-				[name in Name]?: boolean
-			}
-			macroFn: Metadata['macroFn'] & {
-				[name in Name]: Property
-			}
-			parser: Metadata['parser']
-			response: Metadata['response']
-		},
-		Routes,
-		Ephemeral,
-		Volatile
-	>
-
 	macro<
 		const Name extends string,
 		const Input extends Metadata['macro'] &
@@ -5535,10 +5415,7 @@ export default class Elysia<
 		Volatile
 	>
 
-	macro(
-		macroOrName: string | Macro,
-		macro?: Macro | ((...args: any[]) => any)
-	) {
+	macro(macroOrName: string | Macro, macro?: Macro) {
 		if (typeof macroOrName === 'string' && !macro)
 			throw new Error('Macro function is required')
 

--- a/test/macro/macro.test.ts
+++ b/test/macro/macro.test.ts
@@ -1438,35 +1438,4 @@ describe('Macro', () => {
 
 		expect(invalid3.status).toBe(422)
 	})
-
-	// Issue #1574: Named macros with function syntax should infer previous macro resolve types
-	it('infer previous macro resolve in function syntax (issue #1574)', async () => {
-		const app = new Elysia()
-			.macro('auth', {
-				resolve: () => ({
-					user: 'authenticated-user' as const
-				})
-			})
-			.macro('permission', (permission: string) => ({
-				auth: true,
-				// The 'user' type should be inferred from the 'auth' macro's resolve
-				resolve: ({ user }) => ({
-					permission,
-					userFromAuth: user
-				})
-			}))
-			.get('/', ({ userFromAuth, permission }) => ({
-				user: userFromAuth,
-				permission
-			}), {
-				permission: 'admin'
-			})
-
-		const response = await app.handle(req('/')).then((x) => x.json())
-
-		expect(response).toEqual({
-			user: 'authenticated-user',
-			permission: 'admin'
-		})
-	})
 })


### PR DESCRIPTION
Reverts elysiajs/elysia#1691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the macro method API with a single unified signature, replacing the previous overload-based approach for more straightforward usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->