### PR TITLE
fix: wrap randomId in try-catch with Math.random fallback for Cloudflare Workers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -978,26 +978,45 @@ export const form = <const T extends Record<keyof any, unknown>>(
 	return formData as any
 }
 
-export const randomId =
-	typeof crypto === 'undefined'
-		? () => {
-				let result = ''
+/**
+ * Generates a random ID using Math.random() fallback.
+ * Used when crypto.randomUUID() is not available or throws an error.
+ */
+const generateRandomIdFallback = (): string => {
+	let result = ''
+	const characters =
+		'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+	const charactersLength = characters.length
 
-				const characters =
-					'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-				const charactersLength = characters.length
+	for (let i = 0; i < 16; i++)
+		result += characters.charAt(Math.floor(Math.random() * charactersLength))
 
-				for (let i = 0; i < 16; i++)
-					result += characters.charAt(
-						Math.floor(Math.random() * charactersLength)
-					)
+	return result
+}
 
-				return result
-			}
-		: () => {
-				const uuid = crypto.randomUUID()
-				return uuid.slice(0, 8) + uuid.slice(24, 32)
-			}
+/**
+ * Generates a random ID for schema identification.
+ *
+ * Uses crypto.randomUUID() when available, with a Math.random() fallback
+ * for environments where crypto.randomUUID() throws an error
+ * (e.g., Cloudflare Workers global scope).
+ *
+ * @see https://developers.cloudflare.com/workers/runtime-apis/handlers/
+ */
+export const randomId = (): string => {
+	if (typeof crypto === 'undefined') {
+		return generateRandomIdFallback()
+	}
+
+	try {
+		const uuid = crypto.randomUUID()
+		return uuid.slice(0, 8) + uuid.slice(24, 32)
+	} catch {
+		// Fallback for environments where crypto.randomUUID() throws
+		// in global scope (e.g., Cloudflare Workers)
+		return generateRandomIdFallback()
+	}
+}
 
 // ! Deduplicate current instance
 export const deduplicateChecksum = <T extends Function>(


### PR DESCRIPTION
## Summary

Fix `Disallowed operation called within global scope` error when deploying to Cloudflare Workers with Elysia 1.4.19+.

## Problem

Since #1604 introduced lazy compilation in v1.4.19, schema validation calls `randomId()` → `crypto.randomUUID()` during module import time (global scope).

When Elysia models are defined at module level (a **very common pattern**), importing them triggers schema validation which calls `crypto.randomUUID()` in global scope.

Cloudflare Workers [prohibits generating random values in global scope](https://developers.cloudflare.com/workers/runtime-apis/handlers/), causing the deployment to fail.

**Error:**
```
Uncaught Error: Disallowed operation called within global scope.
Asynchronous I/O (ex: fetch() or connect()), setting a timeout,
and generating random values are not allowed within global scope.
```

**Stack Trace:**
```
at randomId (elysia/dist/utils.mjs:505:23)
at mapSchema (elysia/dist/schema.mjs:226:261)
at getSchemaValidator (elysia/dist/schema.mjs:237:16)
at createBody (elysia/dist/index.mjs:401:54)
at composeHandler (elysia/dist/compose.mjs:254:15)
at compile (elysia/dist/index.mjs:593:24)
```

## The Problematic Pattern

This pattern is very common in Elysia applications:

```typescript
// src/model.ts - Model defined at module level
import { Elysia, t } from "elysia";

// This triggers randomId() when the module is imported
export const UserModel = new Elysia({ name: "User.Model" }).model({
  "user.create": t.Object({
    name: t.String(),
  }),
});
```

## Solution

Wrap `crypto.randomUUID()` in a try-catch block and fall back to `Math.random()` based ID generation when it throws. This maintains the existing behavior for standard environments while providing a safe fallback for Cloudflare Workers' global scope.

## Minimal Reproduction

https://github.com/dino3616/elysia-on-cloudflare

## Test Plan

- [x] `bun run build` passes
- [x] `bun run test` passes (1450 tests)
- [x] `test/cloudflare` passes
- [x] Verified deployment to Cloudflare Workers succeeds with the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ID generation with safer error handling and a reliable fallback to ensure consistent behavior across environments.

* **Documentation**
  * Added internal documentation describing fallback behavior and usage scenarios for maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->