### PR TITLE
feat: add `createElysia` factory helper to preserve prefix literal types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8297,6 +8297,31 @@ export type {
 	ExtractErrorFromHandle
 } from './types'
 
+/**
+ * Type-safe factory function for creating Elysia instances.
+ *
+ * Unlike `new Elysia(options)` wrapped in a plain function, this
+ * preserves the **literal** prefix type through TypeScript's `const`
+ * generic inference — preventing route-type intersections when
+ * multiple factory-created sub-apps are composed via `.use()`.
+ *
+ * @example
+ * ```typescript
+ * import { createElysia, t } from 'elysia'
+ *
+ * // ✅ Prefix literal '/sessions' is preserved in the type
+ * const sessionsApp = createElysia({ prefix: '/sessions' })
+ *   .get('/', () => ({ sessions: [] }), {
+ *     response: t.Object({ sessions: t.Array(t.String()) })
+ *   })
+ * ```
+ *
+ * @see https://github.com/elysiajs/elysia/issues/1725
+ */
+export const createElysia = <const BasePath extends string = ''>(
+	config?: ElysiaConfig<BasePath>
+): Elysia<BasePath> => new Elysia<BasePath>(config)
+
 export { env } from './universal/env'
 export { file, ElysiaFile } from './universal/file'
 export type { ElysiaAdapter } from './adapter'


### PR DESCRIPTION
## Summary

- Add `createElysia<const P>()` — a type-safe factory function that preserves the literal prefix type via `const` generic inference
- Add type-level test verifying that factory-created sub-apps produce independent response types when composed via `.group()` + `.use()`

Closes #1725

## Motivation

When multiple Elysia sub-apps are created via a plain (non-generic) factory function and composed under `.group()` via `.use()`, the `BasePath` generic widens to `string`. This causes `CreateEden` to produce index signatures (`{ [x: string]: ... }`) instead of literal keys, and TypeScript's `&` intersection merges all response types together.

`createElysia` is a thin wrapper that preserves the literal type:

```typescript
import { createElysia, t } from 'elysia'

// ✅ Prefix literal '/sessions' is preserved — no type intersection
const sessionsApp = createElysia({ prefix: '/sessions' })
  .get('/', () => ({ sessions: [] }), {
    response: t.Object({ sessions: t.Array(t.String()) })
  })
```

See issue #1725 for the full root cause analysis.

## Test plan

- [x] `tsc --project tsconfig.test.json` passes (including the new type test)
- [ ] Verify the new export is available: `import { createElysia } from 'elysia'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a factory function that simplifies creation of Elysia sub-applications with improved type safety. Using const generics, it preserves literal base path type information, enabling type-safe composition of multiple sub-apps while maintaining response type independence.

* **Tests**
  * Added comprehensive tests verifying type safety and response type independence when composing factory-created sub-applications with different base paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->