### PR TITLE
feat(example): include protocol in startup log URL for clickable terminal links (#1745)

### DIFF
--- a/example/lazy-module.ts
+++ b/example/lazy-module.ts
@@ -2,7 +2,7 @@ import { Elysia } from '../src'
 
 const plugin = (app: Elysia) => app.get('/plugin', () => 'Plugin')
 const asyncPlugin = async (app: Elysia) => app.get('/async', () => 'A')
-const protocol = app.server?.tls ? "https" : "http"
+
 const app = new Elysia()
 	.decorate('a', () => 'hello')
 	.use(plugin)
@@ -12,7 +12,7 @@ const app = new Elysia()
 	.listen(3000)
 
 await app.modules
-
+const protocol = app.server?.tls ? "https" : "http"
 
 
 console.log(


### PR DESCRIPTION


This PR improves developer experience by including the protocol (`http://` or `https://`) in the startup log URL shown in example files.

Previously, the startup message displayed:

🔥 Elysia is running at localhost:3000

This change updates it to:

🔥 Elysia is running at http://localhost:3000/

## Why

Some terminals only create clickable links when the protocol is included in the URL. Adding the protocol:

- Enables clickable URLs directly from terminal output
- Improves developer workflow during local development
- Aligns behavior with other frameworks such as Vite and Next.js

## Implementation

- Updated example startup log to include protocol prefix.
- Default protocol is `http://`.
- Structure allows future enhancement for automatic protocol detection if TLS is enabled.

## Related Issue

Closes #1745

## Testing

- Verified locally using Bun runtime.
- Confirmed startup log displays full clickable URL.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Server URLs now automatically use HTTP or HTTPS based on TLS configuration.
  * Startup/log output updated to show the correct protocol in URLs and uses a fire emoji prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->