### PR TITLE
fix: Refactor ValueToResponseSchema type logic to account for return type `something | undefined`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2185,7 +2185,7 @@ export type IsUnknown<T> = [unknown] extends [T]
 
 export type ValueToResponseSchema<Value> = ExtractErrorFromHandle<Value> &
 	(Extract200<Value> extends infer R200
-		? undefined extends R200
+		? Exclude<R200, undefined | void> extends never
 			? {}
 			: IsNever<R200> extends true
 				? {}


### PR DESCRIPTION
Refactor ValueToResponseSchema type to ensure only returning empty 200 schema on `undefined` or `void`. If it is `something | undefined` type response as infered return type.

Should fix #1762 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type handling logic for response schema generation to ensure more precise type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->