### PR TITLE
bug fix: set content-type header based on response type in mapResponse and mapEarlyResponse

### DIFF
--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -26,8 +26,9 @@ export const mapResponse = (
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
 		if (
-			response?.constructor?.name === 'Object' ||
-			response?.constructor?.name === 'Array'
+			!set.headers['content-type'] &&
+			(response?.constructor?.name === 'Object' ||
+				response?.constructor?.name === 'Array')
 		)
 			set.headers['content-type'] = 'application/json'
 
@@ -183,8 +184,9 @@ export const mapEarlyResponse = (
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
 		if (
-			response?.constructor?.name === 'Object' ||
-			response?.constructor?.name === 'Array'
+			!set.headers['content-type'] &&
+			(response?.constructor?.name === 'Object' ||
+				response?.constructor?.name === 'Array')
 		)
 			set.headers['content-type'] = 'application/json'
 

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -54,15 +54,16 @@ export const mapResponse = (
 	request?: Request
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
-		switch (response?.constructor?.name) {
-			case 'String':
-				set.headers['content-type'] = 'text/plain'
-				break
-			case 'Array':
-			case 'Object':
-				set.headers['content-type'] = 'application/json'
-				break
-		}
+		if (!set.headers['content-type'])
+			switch (response?.constructor?.name) {
+				case 'String':
+					set.headers['content-type'] = 'text/plain'
+					break
+				case 'Array':
+				case 'Object':
+					set.headers['content-type'] = 'application/json'
+					break
+			}
 
 		handleSet(set)
 
@@ -215,15 +216,16 @@ export const mapEarlyResponse = (
 	if (response === undefined || response === null) return
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
-		switch (response?.constructor?.name) {
-			case 'String':
-				set.headers['content-type'] = 'text/plain'
-				break
-			case 'Array':
-			case 'Object':
-				set.headers['content-type'] = 'application/json'
-				break
-		}
+		if (!set.headers['content-type'])
+			switch (response?.constructor?.name) {
+				case 'String':
+					set.headers['content-type'] = 'text/plain'
+					break
+				case 'Array':
+				case 'Object':
+					set.headers['content-type'] = 'application/json'
+					break
+			}
 
 		handleSet(set)
 


### PR DESCRIPTION
[Bug #1379](https://github.com/elysiajs/elysia/issues/1379)

When a route handler sets two or more cookies, the content type header of the response silently becomes `text/plain` instead of `application/json`, the bug is caused by the `handleSet` func in `src/adapter/utils.ts`.

<img width="783" height="280" alt="image" src="https://github.com/user-attachments/assets/059f69dc-44d6-4a53-a92e-9a52a306bd04" />


Here, when the result is an array, `parseSetCookies()` replaces `set.headers` with a Headers instance so that multiple set-cookie entries can be added correctly, but Headers doesn't support index based property assignment, so no `Content-Type` is ever written to the response. My fix is to preset the content-type on `set.headers` before the `handleSet` func is called, when it is guaranteed to still be a plain object. Both `mapResponse` and `mapEarlyResponse` functions in both the bun and web standard adapters are patched.

All existing tests continue to pass.

<img width="1150" height="406" alt="image" src="https://github.com/user-attachments/assets/569616bf-1574-4e6f-bc91-e15c0f9862bb" />

Plus some throwaway test I used to confirm these behaviors also passed

| Scenario | Asserts |
| :--- | :--- |
| **Original bug report** (2 cookies + response schema) | `Content-Type: application/json` |
| **Direct `.value =` assignment syntax** | `Content-Type: application/json` |
| **Three or more cookies** | `Content-Type: application/json` |
| **Array response with multiple cookies** | `Content-Type: application/json` |
| **`mapEarlyResponse` path** | `Content-Type: application/json` |
| **Single cookie** (regression guard) | Still works correctly |
| **String response with multiple cookies** | Not incorrectly set to `application/json` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise Content-Type handling so JSON and text responses are only labeled when appropriate, including preemptive setting when needed to avoid unlabeled responses.
  * Header processing now respects different header container types, avoiding incorrect mutations and ensuring consistent header behavior across response flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->