### PR TITLE
Fix: set content-type header based on response type in mapResponse and mapEarlyResponse

### DIFF
--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -26,9 +26,8 @@ export const mapResponse = (
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
 		if (
-			!set.headers['content-type'] &&
-			(response?.constructor?.name === 'Object' ||
-				response?.constructor?.name === 'Array')
+			response?.constructor?.name === 'Object' ||
+			response?.constructor?.name === 'Array'
 		)
 			set.headers['content-type'] = 'application/json'
 
@@ -184,9 +183,8 @@ export const mapEarlyResponse = (
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
 		if (
-			!set.headers['content-type'] &&
-			(response?.constructor?.name === 'Object' ||
-				response?.constructor?.name === 'Array')
+			response?.constructor?.name === 'Object' ||
+			response?.constructor?.name === 'Array'
 		)
 			set.headers['content-type'] = 'application/json'
 

--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -25,6 +25,12 @@ export const mapResponse = (
 	request?: Request
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
+		if (
+			response?.constructor?.name === 'Object' ||
+			response?.constructor?.name === 'Array'
+		)
+			set.headers['content-type'] = 'application/json'
+
 		handleSet(set)
 
 		switch (response?.constructor?.name) {
@@ -33,7 +39,6 @@ export const mapResponse = (
 
 			case 'Array':
 			case 'Object':
-				set.headers['content-type'] = 'application/json'
 				return new Response(JSON.stringify(response), set as any)
 
 			case 'ElysiaFile':
@@ -141,7 +146,10 @@ export const mapResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
+						if (set.headers instanceof Headers) {
+							if (!set.headers.has('Content-Type'))
+								set.headers.set('Content-Type', 'application/json')
+						} else if (!set.headers['Content-Type'])
 							set.headers['Content-Type'] = 'application/json'
 
 						return new Response(
@@ -174,6 +182,12 @@ export const mapEarlyResponse = (
 	if (response === undefined || response === null) return
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
+		if (
+			response?.constructor?.name === 'Object' ||
+			response?.constructor?.name === 'Array'
+		)
+			set.headers['content-type'] = 'application/json'
+
 		handleSet(set)
 
 		switch (response?.constructor?.name) {
@@ -182,7 +196,6 @@ export const mapEarlyResponse = (
 
 			case 'Array':
 			case 'Object':
-				set.headers['content-type'] = 'application/json'
 				return new Response(JSON.stringify(response), set as any)
 
 			case 'ElysiaFile':
@@ -289,7 +302,10 @@ export const mapEarlyResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
+						if (set.headers instanceof Headers) {
+							if (!set.headers.has('Content-Type'))
+								set.headers.set('Content-Type', 'application/json')
+						} else if (!set.headers['Content-Type'])
 							set.headers['Content-Type'] = 'application/json'
 
 						return new Response(

--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -26,8 +26,9 @@ export const mapResponse = (
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
 		if (
-			response?.constructor?.name === 'Object' ||
-			response?.constructor?.name === 'Array'
+			!set.headers['content-type'] &&
+			(response?.constructor?.name === 'Object' ||
+				response?.constructor?.name === 'Array')
 		)
 			set.headers['content-type'] = 'application/json'
 
@@ -183,8 +184,9 @@ export const mapEarlyResponse = (
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
 		if (
-			response?.constructor?.name === 'Object' ||
-			response?.constructor?.name === 'Array'
+			!set.headers['content-type'] &&
+			(response?.constructor?.name === 'Object' ||
+				response?.constructor?.name === 'Array')
 		)
 			set.headers['content-type'] = 'application/json'
 

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -54,16 +54,15 @@ export const mapResponse = (
 	request?: Request
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
-		if (!set.headers['content-type'])
-			switch (response?.constructor?.name) {
-				case 'String':
-					set.headers['content-type'] = 'text/plain'
-					break
-				case 'Array':
-				case 'Object':
-					set.headers['content-type'] = 'application/json'
-					break
-			}
+		switch (response?.constructor?.name) {
+			case 'String':
+				set.headers['content-type'] = 'text/plain'
+				break
+			case 'Array':
+			case 'Object':
+				set.headers['content-type'] = 'application/json'
+				break
+		}
 
 		handleSet(set)
 
@@ -216,16 +215,15 @@ export const mapEarlyResponse = (
 	if (response === undefined || response === null) return
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
-		if (!set.headers['content-type'])
-			switch (response?.constructor?.name) {
-				case 'String':
-					set.headers['content-type'] = 'text/plain'
-					break
-				case 'Array':
-				case 'Object':
-					set.headers['content-type'] = 'application/json'
-					break
-			}
+		switch (response?.constructor?.name) {
+			case 'String':
+				set.headers['content-type'] = 'text/plain'
+				break
+			case 'Array':
+			case 'Object':
+				set.headers['content-type'] = 'application/json'
+				break
+		}
 
 		handleSet(set)
 

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -54,15 +54,16 @@ export const mapResponse = (
 	request?: Request
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
-		switch (response?.constructor?.name) {
-			case 'String':
-				set.headers['content-type'] = 'text/plain'
-				break
-			case 'Array':
-			case 'Object':
-				set.headers['content-type'] = 'application/json'
-				break
-		}
+		if (!set.headers['content-type'])
+			switch (response?.constructor?.name) {
+				case 'String':
+					set.headers['content-type'] = 'text/plain'
+					break
+				case 'Array':
+				case 'Object':
+					set.headers['content-type'] = 'application/json'
+					break
+			}
 
 		handleSet(set)
 
@@ -215,15 +216,16 @@ export const mapEarlyResponse = (
 	if (response === undefined || response === null) return
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
-		switch (response?.constructor?.name) {
-			case 'String':
-				set.headers['content-type'] = 'text/plain'
-				break
-			case 'Array':
-			case 'Object':
-				set.headers['content-type'] = 'application/json'
-				break
-		}
+		if (!set.headers['content-type'])
+			switch (response?.constructor?.name) {
+				case 'String':
+					set.headers['content-type'] = 'text/plain'
+					break
+				case 'Array':
+				case 'Object':
+					set.headers['content-type'] = 'application/json'
+					break
+			}
 
 		handleSet(set)
 

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -54,16 +54,24 @@ export const mapResponse = (
 	request?: Request
 ): Response => {
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
+		switch (response?.constructor?.name) {
+			case 'String':
+				set.headers['content-type'] = 'text/plain'
+				break
+			case 'Array':
+			case 'Object':
+				set.headers['content-type'] = 'application/json'
+				break
+		}
+
 		handleSet(set)
 
 		switch (response?.constructor?.name) {
 			case 'String':
-				set.headers['content-type'] = 'text/plain'
 				return new Response(response as string, set as any)
 
 			case 'Array':
 			case 'Object':
-				set.headers['content-type'] = 'application/json'
 				return new Response(JSON.stringify(response), set as any)
 
 			case 'ElysiaFile':
@@ -171,7 +179,10 @@ export const mapResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
+						if (set.headers instanceof Headers) {
+							if (!set.headers.has('Content-Type'))
+								set.headers.set('Content-Type', 'application/json')
+						} else if (!set.headers['Content-Type'])
 							set.headers['Content-Type'] = 'application/json'
 
 						return new Response(
@@ -204,16 +215,24 @@ export const mapEarlyResponse = (
 	if (response === undefined || response === null) return
 
 	if (isNotEmpty(set.headers) || set.status !== 200 || set.cookie) {
+		switch (response?.constructor?.name) {
+			case 'String':
+				set.headers['content-type'] = 'text/plain'
+				break
+			case 'Array':
+			case 'Object':
+				set.headers['content-type'] = 'application/json'
+				break
+		}
+
 		handleSet(set)
 
 		switch (response?.constructor?.name) {
 			case 'String':
-				set.headers['content-type'] = 'text/plain'
 				return new Response(response as string, set as any)
 
 			case 'Array':
 			case 'Object':
-				set.headers['content-type'] = 'application/json'
 				return new Response(JSON.stringify(response), set as any)
 
 			case 'ElysiaFile':
@@ -320,7 +339,10 @@ export const mapEarlyResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
+						if (set.headers instanceof Headers) {
+							if (!set.headers.has('Content-Type'))
+								set.headers.set('Content-Type', 'application/json')
+						} else if (!set.headers['Content-Type'])
 							set.headers['Content-Type'] = 'application/json'
 
 						return new Response(


### PR DESCRIPTION
[Bug #1379](https://github.com/elysiajs/elysia/issues/1379)

When a route handler sets two or more cookies, the content type header of the response silently becomes `text/plain` instead of `application/json`, the bug is caused by the `handleSet` func in `src/adapter/utils.ts`.

<img width="783" height="280" alt="image" src="https://github.com/user-attachments/assets/059f69dc-44d6-4a53-a92e-9a52a306bd04" />


Here, when the result is an array, `parseSetCookies()` replaces `set.headers` with a Headers instance so that multiple set-cookie entries can be added correctly, but Headers doesn't support index based property assignment, so no `Content-Type` is ever written to the response. My fix is to preset the content-type on `set.headers` before the `handleSet` func is called, when it is guaranteed to still be a plain object. Both `mapResponse` and `mapEarlyResponse` functions in both the bun and web standard adapters are patched.

All existing tests continue to pass.

<img width="1150" height="406" alt="image" src="https://github.com/user-attachments/assets/569616bf-1574-4e6f-bc91-e15c0f9862bb" />

Plus some throwaway test I used to confirm these behaviors also passed

| Scenario | Asserts |
| :--- | :--- |
| **Original bug report** (2 cookies + response schema) | `Content-Type: application/json` |
| **Direct `.value =` assignment syntax** | `Content-Type: application/json` |
| **Three or more cookies** | `Content-Type: application/json` |
| **Array response with multiple cookies** | `Content-Type: application/json` |
| **`mapEarlyResponse` path** | `Content-Type: application/json` |
| **Single cookie** (regression guard) | Still works correctly |
| **String response with multiple cookies** | Not incorrectly set to `application/json` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed automatic Content-Type header detection and assignment for API responses: JSON objects and arrays are now correctly labeled as application/json, while text and string responses are marked as text/plain
* Enhanced header handling compatibility and robustness to ensure proper Content-Type assignment across different response types and runtime configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->