### PR TITLE
fix: default idleTimeout should be 10s to match documentation

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -354,7 +354,7 @@ export const BunAdapter: ElysiaAdapter = {
 					? ({
 							development: !isProduction,
 							reusePort: true,
-							idleTimeout: 30,
+							idleTimeout: 10,
 							...(app.config.serve || {}),
 							...(options || {}),
 							routes,
@@ -368,7 +368,7 @@ export const BunAdapter: ElysiaAdapter = {
 					: ({
 							development: !isProduction,
 							reusePort: true,
-							idleTimeout: 30,
+							idleTimeout: 10,
 							...(app.config.serve || {}),
 							routes,
 							websocket: {


### PR DESCRIPTION
Fixes #1770

## Problem
The documentation states that Elysia's default `idleTimeout` is **10 seconds** (inherited from Bun), but the code was hardcoded to **30 seconds**.

Reference: https://elysiajs.com/patterns/configuration

## Solution
Changed the default `idleTimeout` from 30 to 10 seconds in two locations:
- `src/adapter/bun/index.ts` line 357
- `src/adapter/bun/index.ts` line 371

This now matches the documented behavior.

## Changes
- Modified default `idleTimeout` from 30 to 10 seconds
- Aligns code with documentation
- Consistent with Bun's default timeout behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized server connection handling to improve resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->