### PR TITLE
fix: use cookie schema for cookie noValidate check

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1636,7 +1636,7 @@ export const composeHandler = ({
 				fnLiteral +=
 					`for(const k of Object.keys(cookieValue))` +
 					`c.cookie[k].value=cookieValue[k]\n`
-			} else if (validator.body?.schema?.noValidate !== true) {
+			} else if (validator.cookie?.schema?.noValidate !== true) {
 				fnLiteral +=
 					`if(validator.cookie.Check(cookieValue)===false){` +
 					validation.validate('cookie', 'cookieValue') +


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cookie validation logic to reference the appropriate schema configuration, ensuring cookies are validated according to their intended settings rather than body schema rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->