### PR TITLE
:tada: feat: specialize response mapping via AOT for known schema types

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -220,7 +220,28 @@ export const BunAdapter: ElysiaAdapter = {
 			? 'c.headers=c.request.headers.toJSON()\n'
 			: 'c.headers={}\n' +
 				'for(const [k,v] of c.request.headers.entries())' +
-				'c.headers[k]=v\n'
+				'c.headers[k]=v\n',
+		specializedResponse(kind, r, hasSet, saveResponse) {
+			// Bun's Response.json() is faster than new Response(JSON.stringify())
+			switch (kind) {
+				case 'Object':
+				case 'Array':
+					return hasSet
+						? `Response.json(${saveResponse}${r},c.set)`
+						: `Response.json(${saveResponse}${r})`
+				case 'String':
+					return hasSet
+						? `new Response(${saveResponse}${r},c.set)`
+						: `new Response(${saveResponse}${r})`
+				case 'Number':
+				case 'Boolean':
+					return hasSet
+						? `new Response(${saveResponse}''+${r},c.set)`
+						: `new Response(${saveResponse}''+${r})`
+				default:
+					return undefined
+			}
+		}
 	},
 	listen(app) {
 		return (options, callback) => {

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -114,6 +114,25 @@ export interface ElysiaAdapter {
 				declare?: string
 			}
 		>
+		/**
+		 * Generate specialized inline response code for a known schema type kind.
+		 *
+		 * When the response schema type is known at compile time (e.g. Object, String),
+		 * this generates optimized inline code that bypasses the generic mapResponse
+		 * dispatch chain, eliminating 10+ type checks on the hot path.
+		 *
+		 * @param kind - The TypeBox schema Kind ('Object', 'Array', 'String', 'Number', 'Boolean')
+		 * @param r - Variable name holding the response value
+		 * @param hasSet - Whether set (headers/status/cookie) is active
+		 * @param saveResponse - Code prefix for saving response to context
+		 * @returns Generated fnLiteral string, or undefined to fall back to generic
+		 */
+		specializedResponse?: (
+			kind: string,
+			r: string,
+			hasSet: boolean,
+			saveResponse: string
+		) => string | undefined
 	}
 	composeGeneralHandler: {
 		parameters?: string

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -19,6 +19,26 @@ export const WebStandardAdapter: ElysiaAdapter = {
 	composeHandler: {
 		mapResponseContext: 'c.request',
 		preferWebstandardHeaders: true,
+		specializedResponse(kind, r, hasSet, saveResponse) {
+			switch (kind) {
+				case 'Object':
+				case 'Array':
+					return hasSet
+						? `new Response(JSON.stringify(${saveResponse}${r}),c.set)`
+						: `new Response(JSON.stringify(${saveResponse}${r}),{headers:{'content-type':'application/json'}})`
+				case 'String':
+					return hasSet
+						? `new Response(${saveResponse}${r},c.set)`
+						: `new Response(${saveResponse}${r})`
+				case 'Number':
+				case 'Boolean':
+					return hasSet
+						? `new Response(${saveResponse}''+${r},c.set)`
+						: `new Response(${saveResponse}''+${r})`
+				default:
+					return undefined
+			}
+		},
 		// @ts-ignore Bun specific
 		headers:
 			'c.headers={}\n' +

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -24,11 +24,11 @@ export const WebStandardAdapter: ElysiaAdapter = {
 				case 'Object':
 				case 'Array':
 					return hasSet
-						? `new Response(JSON.stringify(${saveResponse}${r}),c.set)`
+						? `(c.set.headers['content-type']||(c.set.headers['content-type']='application/json'),new Response(JSON.stringify(${saveResponse}${r}),c.set))`
 						: `new Response(JSON.stringify(${saveResponse}${r}),{headers:{'content-type':'application/json'}})`
 				case 'String':
 					return hasSet
-						? `new Response(${saveResponse}${r},c.set)`
+						? `(c.set.headers['content-type']||(c.set.headers['content-type']='text/plain'),new Response(${saveResponse}${r},c.set))`
 						: `new Response(${saveResponse}${r})`
 				case 'Number':
 				case 'Boolean':

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -69,6 +69,50 @@ import { coercePrimitiveRoot } from './replace-schema'
 const allocateIf = (value: string, condition: unknown) =>
 	condition ? value : ''
 
+/**
+ * Detect the TypeBox schema Kind for single-status-code response schemas.
+ *
+ * Used for specialized response code generation during AOT compilation.
+ * When the response type is known at compile time, we can generate inline
+ * code that bypasses the generic mapResponse dispatch chain (10+ type checks),
+ * leveraging:
+ * - Monomorphic inline caches (V8/JSC optimize single-type call sites)
+ * - Reduced branch misprediction (fewer conditional branches on hot path)
+ * - Partial evaluation (specialize code for known input types)
+ *
+ * Returns null for unsupported schemas (Union, Intersect, multiple status codes,
+ * Standard Schema providers), falling back to the generic path.
+ */
+const getResponseSchemaKind = (
+	validator: SchemaValidator
+): string | null => {
+	if (!validator.response) return null
+
+	const keys = Object.keys(validator.response)
+	if (keys.length !== 1) return null
+
+	const check = validator.response[keys[0]]
+	if (check.provider === 'standard') return null
+
+	const schema = check.schema
+	if (!schema?.[Kind]) return null
+
+	switch (schema[Kind]) {
+		case 'Object':
+			return 'Object'
+		case 'String':
+			return 'String'
+		case 'Number':
+			return 'Number'
+		case 'Boolean':
+			return 'Boolean'
+		case 'Array':
+			return 'Array'
+		default:
+			return null
+	}
+}
+
 const defaultParsers = [
 	'json',
 	'text',
@@ -880,6 +924,13 @@ export const composeHandler = ({
 		return (_afterResponse = afterResponse)
 	}
 
+	const responseKind = getResponseSchemaKind(validator)
+	const canSpecialize =
+		responseKind !== null &&
+		!maybeStream &&
+		!hooks.mapResponse?.length &&
+		adapter.specializedResponse
+
 	const mapResponse = (r = 'r') => {
 		const after = afterResponse()
 		// When maybeStream is true, mapResponse may return a Promise (from handleStream)
@@ -887,6 +938,48 @@ export const composeHandler = ({
 		// can properly catch the rejection and route it to error handling.
 		// Only add await if the function is async (maybeAsync), otherwise it would be a syntax error.
 		const awaitStream = maybeStream && maybeAsync ? 'await ' : ''
+
+		if (canSpecialize) {
+			const fast = adapter.specializedResponse!(
+				responseKind!,
+				r,
+				hasSet,
+				saveResponse
+			)
+
+			if (fast) {
+				const fallback = `${awaitStream}${hasSet ? 'mapResponse' : 'mapCompactResponse'}(${saveResponse}${r}${hasSet ? ',c.set' : ''}${mapResponseContext})`
+
+				let guard: string
+				switch (responseKind) {
+					case 'Object':
+						guard = `${r}!==null&&${r}!==undefined&&${r}.constructor===Object`
+						break
+					case 'Array':
+						guard = `Array.isArray(${r})`
+						break
+					case 'String':
+						guard = `typeof ${r}==='string'`
+						break
+					case 'Number':
+						guard = `typeof ${r}==='number'`
+						break
+					case 'Boolean':
+						guard = `typeof ${r}==='boolean'`
+						break
+					default:
+						guard = ''
+				}
+
+				if (guard) {
+					const response = `(${guard}?${fast}:${fallback})`
+
+					if (!after) return `return ${response}\n`
+					return `const _res=${response}\n` + after + `return _res`
+				}
+			}
+		}
+
 		const response = `${awaitStream}${hasSet ? 'mapResponse' : 'mapCompactResponse'}(${saveResponse}${r}${hasSet ? ',c.set' : ''}${mapResponseContext})\n`
 
 		if (!after) return `return ${response}`


### PR DESCRIPTION
## Summary

When a route declares a response schema (e.g. `response: t.Object({...})`), the return type is already known at compile time. Yet after validation, the response still goes through the generic `mapResponse`/`mapCompactResponse` chain which performs 10+ type checks (`constructor.name` switch, `instanceof` for Response, Blob, ReadableStream, Error, Promise, etc.).

This PR extends the existing Sucrose AOT compilation to the **response path** — generating specialized inline response code that bypasses the generic dispatch when the schema Kind is known.

### What changed

- **`getResponseSchemaKind()`** in `compose.ts` — detects TypeBox schema Kind (Object, Array, String, Number, Boolean) for single-status-code response schemas
- **`specializedResponse()`** adapter method in `adapter/types.ts` — lets each adapter generate optimized inline code per type
- **Bun adapter** — uses `Response.json()` for Object/Array (native fast path), `new Response()` for primitives
- **Web Standard adapter** — uses `JSON.stringify()` + content-type header for Object/Array
- **`mapResponse` closure** in `compose.ts` — emits a type guard with fast path + fallback to generic

### Why it helps

- Eliminates 10+ conditional branches on the hot path for typed routes
- Creates monomorphic call sites that V8/JSC can optimize with inline caches (the generic path is megamorphic)
- Completes the partial evaluation pattern Elysia already applies to the request path (Sucrose) — now the response path is specialized too

### Safety

Every specialized path has a runtime type guard that falls back to the generic `mapResponse` if the value doesn't match:

```js
r !== null && r !== undefined && r.constructor === Object
  ? Response.json(r)        // fast path
  : mapResponse(r, c.set)   // fallback
```

Specialization is **disabled** when:
- No response schema declared
- Multiple status codes in schema
- Union/Intersect types (Kind not whitelisted)
- `mapResponse` hooks are present (could change type)
- `maybeStream` is true (generators/streams)
- Standard Schema provider (no Kind property)

### Test plan

- [x] All 1508 existing tests pass (`bun test`) — zero regressions
- [ ] Benchmark typed vs untyped routes with `autocannon` / `bun bench`
- [ ] Inspect generated `fnLiteral` to verify inline `Response.json()` appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced optimized fast-path response handling across adapters and core composition to return JSON, text, number, or boolean responses more directly, improving runtime routing and performance while preserving existing behavior and fallbacks.
  * Adapter interfaces extended to optionally support these specialized response paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->