### PR TITLE
Fix dynamic imports inside `.guard()` not registering routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4685,6 +4685,77 @@ export default class Elysia<
 			}
 		)
 
+		// Handle dynamic imports (Promises) used inside guard callback
+		if (instance.promisedModules.size > 0) {
+			const syncCount = instance.router.history.length
+
+			for (const promise of instance.promisedModules.promises) {
+				this.promisedModules.add(
+					promise.then(() => {
+						const {
+							body,
+							headers,
+							query,
+							params,
+							cookie,
+							response,
+							...guardHook
+						} = hook
+
+						const hasStandaloneSchema =
+							body || headers || query || params || cookie || response
+
+						for (
+							let i = syncCount;
+							i < instance.router.history.length;
+							i++
+						) {
+							const {
+								method,
+								path,
+								handler,
+								hooks: localHook
+							} = instance.router.history[i]
+
+							this.add(
+								method,
+								path,
+								handler,
+								mergeHook(guardHook as AnyLocalHook, {
+									...((localHook || {}) as AnyLocalHook),
+									error: !localHook.error
+										? sandbox.event.error
+										: Array.isArray(localHook.error)
+											? [
+													...(localHook.error ?? []),
+													...(sandbox.event.error ?? [])
+												]
+											: [
+													localHook.error,
+													...(sandbox.event.error ?? [])
+												],
+									standaloneValidator: !hasStandaloneSchema
+										? localHook.standaloneValidator
+										: [
+												...(localHook.standaloneValidator ??
+													[]),
+												{
+													body,
+													headers,
+													query,
+													params,
+													cookie,
+													response
+												}
+											]
+								})
+							)
+						}
+					})
+				)
+			}
+		}
+
 		return this as any
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4687,7 +4687,7 @@ export default class Elysia<
 
 		// Handle dynamic imports (Promises) used inside guard callback
 		if (instance.promisedModules.size > 0) {
-			const syncCount = instance.router.history.length
+			let processedUntil = instance.router.history.length
 
 			for (const promise of instance.promisedModules.promises) {
 				this.promisedModules.add(
@@ -4705,8 +4705,11 @@ export default class Elysia<
 						const hasStandaloneSchema =
 							body || headers || query || params || cookie || response
 
+						const startIndex = processedUntil
+						processedUntil = instance.router.history.length
+
 						for (
-							let i = syncCount;
+							let i = startIndex;
 							i < instance.router.history.length;
 							i++
 						) {

--- a/test/core/modules.test.ts
+++ b/test/core/modules.test.ts
@@ -263,6 +263,24 @@ describe('Modules', () => {
 		expect(await res.text()).toBe('lazy-instance')
 	})
 
+	it('register multiple dynamic import routes inside guard', async () => {
+		const lazyA = Promise.resolve(new Elysia().get('/a', () => 'a'))
+		const lazyB = Promise.resolve(new Elysia().get('/b', () => 'b'))
+
+		let hookCalls = 0
+
+		const app = new Elysia().guard(
+			{ beforeHandle: () => { hookCalls++ } },
+			(app) => app.use(lazyA).use(lazyB)
+		)
+
+		await app.modules
+
+		expect((await app.handle(req('/a'))).status).toBe(200)
+		expect((await app.handle(req('/b'))).status).toBe(200)
+		expect(hookCalls).toBe(2)
+	})
+
 	it('register dynamic import routes inside guard with hook', async () => {
 		let called = false
 

--- a/test/core/modules.test.ts
+++ b/test/core/modules.test.ts
@@ -248,4 +248,37 @@ describe('Modules', () => {
 		const text = await response.text()
 		expect(text).toEqual('GET /plugin')
 	})
+
+	it('register dynamic import routes inside guard', async () => {
+		const app = new Elysia().guard(
+			{},
+			(app) => app.use(import('../modules').then((m) => m.lazyInstance))
+		)
+
+		await app.modules
+
+		const res = await app.handle(req('/lazy-instance'))
+
+		expect(res.status).toBe(200)
+		expect(await res.text()).toBe('lazy-instance')
+	})
+
+	it('register dynamic import routes inside guard with hook', async () => {
+		let called = false
+
+		const app = new Elysia().guard(
+			{
+				beforeHandle: () => {
+					called = true
+				}
+			},
+			(app) => app.use(import('../modules').then((m) => m.lazyInstance))
+		)
+
+		await app.modules
+
+		await app.handle(req('/lazy-instance'))
+
+		expect(called).toBe(true)
+	})
 })

--- a/test/modules.ts
+++ b/test/modules.ts
@@ -2,4 +2,6 @@ import { Elysia } from '../src'
 
 export const lazy = async (app: Elysia) => app.get('/lazy', () => 'lazy')
 
+export const lazyInstance = new Elysia().get('/lazy-instance', () => 'lazy-instance')
+
 export default lazy


### PR DESCRIPTION
Fixes #1774

## Root cause

`guard()` creates a sandbox `Elysia` instance, passes it to the user's callback, then synchronously iterates `instance.router.history` to re-register each route on the parent with the guard hooks applied.

When the callback uses a dynamic import — `app.use(import('./plugin'))` — `use()` recognises the `Promise` and defers resolution into `instance.promisedModules`, returning synchronously. By the time the `forEach` runs, `router.history` is empty and the routes are never registered. The sandbox's `promisedModules` are also never propagated to the parent, so the promises are abandoned.

## Fix

After the synchronous route iteration, check whether the sandbox has pending promised modules. For each one, add a corresponding promise to `this.promisedModules` that — once the dynamic import settles and its routes have been pushed into `instance.router.history` — registers the newly added routes on the parent with the guard hooks applied.

A shared `processedUntil` marker (rather than a fixed `syncCount`) ensures each callback only processes its own slice of `router.history`. Because JS is single-threaded, each `.then()` callback atomically snapshots `startIndex = processedUntil` and advances the marker before iterating — so even if multiple dynamic imports resolve in the same microtask drain, every route is registered exactly once.

## Tests

- Routes from a dynamic import inside `guard` are reachable
- Guard lifecycle hooks (`beforeHandle`) are applied to dynamically imported routes
- Multiple dynamic imports inside a single `guard` are each reachable and their shared guard hook fires exactly once per request
    
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for dynamic imports inside route guards, allowing asynchronous registration of routes while preserving guard hooks and validators

* **Bug Fixes / Improvements**
  * Smoother integration between synchronous and asynchronous guard-based route registration and error/validator handling

* **Tests**
  * Added tests validating dynamic import route registration and guard hook invocation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->