### PR TITLE
fix(error): use explicit undefined check in status() fallback to support null body

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -89,11 +89,12 @@ export class ElysiaCustomStatusResponse<
 
 	constructor(code: Code, response: T) {
 		const res =
-			response ??
-			(code in InvertedStatusMap
-				? // @ts-expect-error Always correct
-					InvertedStatusMap[code]
-				: code)
+			response === undefined
+				? code in InvertedStatusMap
+					? // @ts-expect-error Always correct
+						InvertedStatusMap[code]
+					: code
+				: response
 
 		// @ts-ignore Trust me bro
 		this.code = StatusMap[code] ?? code

--- a/test/core/status.test.ts
+++ b/test/core/status.test.ts
@@ -121,4 +121,13 @@ describe('Status', () => {
 		expect(response.status).toBe(308)
 		expect(await response.text()).toBe('')
 	})
+
+	it('return empty body when body is explicitly set to null', async () => {
+		const app = new Elysia().get('/', ({ status }) => status(201, null))
+
+		const response = await app.handle(req('/'))
+
+		expect(response.status).toBe(201)
+		expect(await response.arrayBuffer()).toHaveLength(0);
+	})
 })

--- a/test/validator/response.test.ts
+++ b/test/validator/response.test.ts
@@ -582,4 +582,16 @@ describe('Response Validator', () => {
 
 		expect(status).resolves.toBe(200)
 	})
+
+	it('handle empty body', () => {
+		const app = new Elysia().get('/', ({ status }) => status(201, null), {
+			response: {
+				201: t.Null()
+			}
+		})
+
+		const status = app.handle(req('/')).then((x) => x.status)
+
+		expect(status).resolves.toBe(201)
+	})
 })


### PR DESCRIPTION
## Summary

- Fixes #1738 

## Problem

Currently, the `status(code, response)` helper uses the nullish coalescing operator (`??`) to provide a default response body (the status text, e.g., "Created") when the second argument is missing.

https://github.com/elysiajs/elysia/blob/56310be9617b826f862c985eae95ae823d95f097/src/error.ts#L79-L106  

However, this causes an unintended side effect: explicitly passing `null` as the response body is treated the same as passing `undefined`.

This behavior interferes with response validation schemas where `null` is expected body type.

## Solution

This PR changes the fallback logic to strictly check for `undefined` instead of using `??`.

**Changes in `src/error.ts`:**
```typescript
// Before
const res = response ?? (code in InvertedStatusMap ? InvertedStatusMap[code] : code);

// After
const res = response === undefined 
  ? (code in InvertedStatusMap ? InvertedStatusMap[code] : code) 
  : response;
```

## Result

`status(201, null)` now correctly returns `null` (empty body), allowing response validators to pass when the schema expects `null`.

## Test Coverage
- Verified that existing test cases still pass.
- Added two new test cases to verify that `status(201, null)` correctly returns an empty body and passes response validation against a `t.Null()` schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null response bodies in status mapping to ensure consistent behavior across response types.

* **Tests**
  * Added test coverage for null and empty body response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->