### PR TITLE
fix: mount(handler) with prefix should strip prefix from path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ import type {
 	UnknownRouteSchema,
 	MaybeFunction,
 	InlineHandlerNonMacro,
-	Router,
+	Router
 } from './types'
 import {
 	coercePrimitiveRoot,
@@ -4703,7 +4703,12 @@ export default class Elysia<
 						} = hook
 
 						const hasStandaloneSchema =
-							body || headers || query || params || cookie || response
+							body ||
+							headers ||
+							query ||
+							params ||
+							cookie ||
+							response
 
 						const startIndex = processedUntil
 						processedUntil = instance.router.history.length
@@ -4731,11 +4736,13 @@ export default class Elysia<
 										: Array.isArray(localHook.error)
 											? [
 													...(localHook.error ?? []),
-													...(sandbox.event.error ?? [])
+													...(sandbox.event.error ??
+														[])
 												]
 											: [
 													localHook.error,
-													...(sandbox.event.error ?? [])
+													...(sandbox.event.error ??
+														[])
 												],
 									standaloneValidator: !hasStandaloneSchema
 										? localHook.standaloneValidator
@@ -5655,8 +5662,20 @@ export default class Elysia<
 										throw new Error('Invalid handler')
 									})()
 
+			const prefix = this.config.prefix
+			const prefixLength = prefix?.length ?? 0
 			const handler: Handler = ({ request, path }) =>
-				run(new Request(replaceUrlPath(request.url, path), request))
+				run(
+					new Request(
+						replaceUrlPath(
+							request.url,
+							prefixLength
+								? path.slice(prefixLength) || '/'
+								: path
+						),
+						request
+					)
+				)
 
 			this.route('ALL', '/*', handler as any, {
 				parse: 'none',

--- a/test/core/mount.test.ts
+++ b/test/core/mount.test.ts
@@ -228,4 +228,34 @@ describe('Mount', () => {
 		expect(response.status).toBe(302)
 		expect(response.headers.get('location')).toBe('/redirect')
 	})
+
+	// https://github.com/elysiajs/elysia/issues/1806
+	it('mount(handler) with prefix should strip prefix from path', async () => {
+		const plugin = new Elysia({ prefix: '/api' }).mount((request) => {
+			return Response.json({ path: new URL(request.url).pathname })
+		})
+
+		const app = new Elysia().use(plugin)
+
+		const response = await app
+			.handle(new Request('http://localhost/api/auth/dash/users'))
+			.then((x) => x.json() as Promise<{ path: string }>)
+
+		expect(response.path).toBe('/auth/dash/users')
+	})
+
+	// https://github.com/elysiajs/elysia/issues/1806
+	it('mount(handler) with prefix should handle root path', async () => {
+		const plugin = new Elysia({ prefix: '/api' }).mount((request) => {
+			return Response.json({ path: new URL(request.url).pathname })
+		})
+
+		const app = new Elysia().use(plugin)
+
+		const response = await app
+			.handle(new Request('http://localhost/api/'))
+			.then((x) => x.json() as Promise<{ path: string }>)
+
+		expect(response.path).toBe('/')
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #1806

When using `mount(handler)` without an explicit path on an Elysia instance with a prefix (e.g., `new Elysia({ prefix: '/api' }).mount(handler)`), the mounted handler was receiving the full path including the prefix instead of having the prefix stripped.

## Problem

```typescript
const api = new Elysia({ prefix: '/api' }).mount(authHandler)
const app = new Elysia().use(api)

// Request: /api/auth/dash/users
// Before fix: handler received /api/auth/dash/users
// After fix: handler received /auth/dash/users
```

This caused issues when integrating libraries like Better Auth which expect the path to start from their basePath, not from the full URL path.

## Changes

- Modified the `mount()` method to strip the prefix from the path before passing it to the mounted handler (when no explicit path is provided)
- Added test cases to verify the fix

## Test Results

All 1527 tests pass, including 2 new test cases for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path prefix handling in mounted plugins to correctly strip prefixes from request paths.

* **Tests**
  * Added test cases verifying prefix stripping behavior for mounted routes under different path configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->