### PR TITLE
fix: wrap onAfterResponse in try/catch to prevent server crashes

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -845,7 +845,7 @@ export const composeHandler = ({
 		let afterResponse = ''
 
 		afterResponse +=
-			`\n${setImmediateFn}(async()=>{` +
+			`\n${setImmediateFn}(async()=>{try{` +
 			`if(c.responseValue){` +
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n` +
 			(hasStream
@@ -875,7 +875,7 @@ export const composeHandler = ({
 
 		reporter.resolve()
 
-		afterResponse += '})\n'
+		afterResponse += '}catch{}})\n'
 
 		return (_afterResponse = afterResponse)
 	}
@@ -2389,7 +2389,7 @@ export const composeGeneralHandler = (
 
 		const prefix = app.event.afterResponse.some(isAsync) ? 'async' : ''
 		afterResponse +=
-			`\n${setImmediateFn}(${prefix}()=>{` +
+			`\n${setImmediateFn}(${prefix}()=>{try{` +
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n`
 
 		for (let i = 0; i < app.event.afterResponse.length; i++) {
@@ -2398,7 +2398,7 @@ export const composeGeneralHandler = (
 			afterResponse += `\n${isAsyncName(fn) ? 'await ' : ''}afterResponse[${i}](c)\n`
 		}
 
-		afterResponse += `})\n`
+		afterResponse += `}catch{}})\n`
 	}
 
 	// @ts-ignore
@@ -2623,7 +2623,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 
 		let afterResponse = ''
 		const prefix = hooks.afterResponse?.some(isAsync) ? 'async' : ''
-		afterResponse += `\n${setImmediateFn}(${prefix}()=>{`
+		afterResponse += `\n${setImmediateFn}(${prefix}()=>{try{`
 
 		const reporter = createReport({
 			context: 'context',
@@ -2649,7 +2649,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 
 		reporter.resolve()
 
-		afterResponse += `})\n`
+		afterResponse += `}catch{}})\n`
 
 		return afterResponse
 	}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -867,8 +867,7 @@ export const composeHandler = ({
 				const endUnit = reporter.resolveChild(
 					hooks.afterResponse[i].fn.name
 				)
-				const prefix = isAsync(hooks.afterResponse[i]) ? 'await ' : ''
-				afterResponse += `\n${prefix}e.afterResponse[${i}](c)\n`
+				afterResponse += `\nawait e.afterResponse[${i}](c)\n`
 				endUnit()
 			}
 		}
@@ -2387,15 +2386,12 @@ export const composeGeneralHandler = (
 	if (app.event.afterResponse?.length && !app.event.error) {
 		afterResponse = '\nc.error=notFound\n'
 
-		const prefix = app.event.afterResponse.some(isAsync) ? 'async' : ''
 		afterResponse +=
-			`\n${setImmediateFn}(${prefix}()=>{try{` +
+			`\n${setImmediateFn}(async()=>{try{` +
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n`
 
 		for (let i = 0; i < app.event.afterResponse.length; i++) {
-			const fn = app.event.afterResponse[i].fn
-
-			afterResponse += `\n${isAsyncName(fn) ? 'await ' : ''}afterResponse[${i}](c)\n`
+			afterResponse += `\nawait afterResponse[${i}](c)\n`
 		}
 
 		afterResponse += `}catch{}})\n`
@@ -2622,8 +2618,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 		if (!hooks.afterResponse?.length && !hasTrace) return ''
 
 		let afterResponse = ''
-		const prefix = hooks.afterResponse?.some(isAsync) ? 'async' : ''
-		afterResponse += `\n${setImmediateFn}(${prefix}()=>{try{`
+		afterResponse += `\n${setImmediateFn}(async()=>{try{`
 
 		const reporter = createReport({
 			context: 'context',
@@ -2638,10 +2633,11 @@ export const composeErrorHandler = (app: AnyElysia) => {
 
 		if (hooks.afterResponse?.length && hooks.afterResponse) {
 			for (let i = 0; i < hooks.afterResponse.length; i++) {
-				const fn = hooks.afterResponse[i].fn
-				const endUnit = reporter.resolveChild(fn.name)
+				const endUnit = reporter.resolveChild(
+					hooks.afterResponse[i].fn.name
+				)
 
-				afterResponse += `\n${isAsyncName(fn) ? 'await ' : ''}afterResponse[${i}](context)\n`
+				afterResponse += `\nawait afterResponse[${i}](context)\n`
 
 				endUnit()
 			}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -867,7 +867,7 @@ export const composeHandler = ({
 				const endUnit = reporter.resolveChild(
 					hooks.afterResponse[i].fn.name
 				)
-				afterResponse += `\nawait e.afterResponse[${i}](c)\n`
+				afterResponse += `\ntry{await e.afterResponse[${i}](c)}catch{}\n`
 				endUnit()
 			}
 		}
@@ -2391,7 +2391,7 @@ export const composeGeneralHandler = (
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n`
 
 		for (let i = 0; i < app.event.afterResponse.length; i++) {
-			afterResponse += `\nawait afterResponse[${i}](c)\n`
+			afterResponse += `\ntry{await afterResponse[${i}](c)}catch{}\n`
 		}
 
 		afterResponse += `}catch{}})\n`
@@ -2637,7 +2637,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 					hooks.afterResponse[i].fn.name
 				)
 
-				afterResponse += `\nawait afterResponse[${i}](context)\n`
+				afterResponse += `\ntry{await afterResponse[${i}](context)}catch{}\n`
 
 				endUnit()
 			}

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -858,13 +858,17 @@ export const createDynamicHandler = (app: AnyElysia) => {
 			if (afterResponses) {
 				if (hasSetImmediate)
 					setImmediate(async () => {
-						for (const afterResponse of afterResponses)
-							await afterResponse.fn(context as any)
+						try {
+							for (const afterResponse of afterResponses)
+								await afterResponse.fn(context as any)
+						} catch {}
 					})
 				else
 					Promise.resolve().then(async () => {
-						for (const afterResponse of afterResponses)
-							await afterResponse.fn(context as any)
+						try {
+							for (const afterResponse of afterResponses)
+								await afterResponse.fn(context as any)
+						} catch {}
 					})
 			}
 		}

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -856,20 +856,15 @@ export const createDynamicHandler = (app: AnyElysia) => {
 				: app.event.afterResponse
 
 			if (afterResponses) {
-				if (hasSetImmediate)
-					setImmediate(async () => {
+				const run = async () => {
+					for (const afterResponse of afterResponses)
 						try {
-							for (const afterResponse of afterResponses)
-								await afterResponse.fn(context as any)
+							await afterResponse.fn(context as any)
 						} catch {}
-					})
-				else
-					Promise.resolve().then(async () => {
-						try {
-							for (const afterResponse of afterResponses)
-								await afterResponse.fn(context as any)
-						} catch {}
-					})
+				}
+
+				if (hasSetImmediate) setImmediate(run)
+				else Promise.resolve().then(run)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Errors thrown inside `onAfterResponse` hooks cause unhandled promise rejections that crash the server process
- These hooks run fire-and-forget via `setImmediate`/`Promise.resolve().then()`, so there's no caller to catch the rejection
- Wraps all 4 afterResponse invocation sites in try/catch

## Problem
```typescript
new Elysia()
  .onAfterResponse(() => {
    throw new Error('boom') // crashes the entire server
  })
  .get('/', () => 'ok')
```

Since `onAfterResponse` runs after the response is already sent, there's no way to handle the error via `onError` — but it shouldn't crash the process either.

## Changes
- `src/compose.ts`: wrap afterResponse codegen in try/catch (route handler, 404 handler, error handler paths)
- `src/dynamic-handle.ts`: wrap afterResponse runtime invocation in try/catch

## Test plan
- [x] Verified error in onAfterResponse no longer crashes the server (AOT and non-AOT modes)
- [x] All existing tests pass (324 pass, 0 fail across core + sucrose)

Fixes #1474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of response processing: afterResponse hooks are now always executed inside try/catch so exceptions are isolated and won’t disrupt request flow.
  * Standardized hook execution: async scheduling and awaiting of afterResponse hooks is unified so hooks run reliably (using an async wrapper and consistent scheduling) across handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->