### PR TITLE
fix: pass through plain ReadableStream to fix cancel and perf

### DIFF
--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -306,6 +306,52 @@ export const createStreamHandler =
 				}
 			}
 
+		// Plain ReadableStream (not SSE, not a generator) can be passed through
+		// directly. Re-wrapping it would add per-chunk async overhead (#1741)
+		// and break the native cancel callback (#1768).
+		if (
+			!isSSE &&
+			generator instanceof ReadableStream &&
+			typeof (generator as any).next !== 'function'
+		)
+			return new Response(
+				generator.pipeThrough(
+					new TransformStream({
+						transform(chunk, controller) {
+							if (
+								chunk instanceof Uint8Array ||
+								chunk instanceof ArrayBuffer ||
+								typeof chunk === 'string'
+							)
+								controller.enqueue(chunk)
+							else if (ArrayBuffer.isView(chunk))
+								controller.enqueue(
+									new Uint8Array(
+										chunk.buffer,
+										chunk.byteOffset,
+										chunk.byteLength
+									)
+								)
+							else if (chunk instanceof Blob)
+								return chunk
+									.arrayBuffer()
+									.then((buf) =>
+										controller.enqueue(
+											new Uint8Array(buf)
+										)
+									)
+							else
+								controller.enqueue(
+									typeof chunk === 'object'
+										? JSON.stringify(chunk)
+										: String(chunk)
+								)
+						}
+					})
+				),
+				set as any
+			)
+
 		// Get an explicit async iterator so pull() can advance one step at a time.
 		// Generators already implement the iterator protocol directly (.next()),
 		// while ReadableStream (which generator may be reassigned to above) needs

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -341,11 +341,15 @@ export const createStreamHandler =
 										)
 									)
 							else
-								controller.enqueue(
-									typeof chunk === 'object'
-										? JSON.stringify(chunk)
-										: String(chunk)
-								)
+								try {
+									controller.enqueue(
+										typeof chunk === 'object'
+											? JSON.stringify(chunk)
+											: String(chunk)
+									)
+								} catch {
+									controller.enqueue(String(chunk))
+								}
 						}
 					})
 				),


### PR DESCRIPTION
## Summary
- Returning a `ReadableStream` from a handler caused ~100x latency for large payloads (#1741) and the `cancel()` callback never fired on client disconnect (#1768)
- Root cause: Elysia re-wrapped every ReadableStream in a new one with per-chunk async iteration
- Plain ReadableStreams are now piped through a lightweight TransformStream instead

## Problem
```typescript
// #1741: 100x slower than wrapping in new Response()
app.get('/file', () => Bun.file('large.bin').stream())

// #1768: cancel() never called on client disconnect
app.get('/stream', () => new ReadableStream({
  cancel() { /* cleanup resources - never called */ }
}))
```

The re-wrapping added per-chunk async overhead (`iterator.next()` + format + enqueue) and broke the native stream cancel propagation.

## Changes
- `src/adapter/utils.ts`: detect plain ReadableStreams (non-SSE, non-generator) and pipe them through a minimal TransformStream that only normalizes non-standard chunk types (DataView, Blob → Uint8Array) while passing standard chunks through directly

## Test plan
- [x] 10MB stream completes in ~6ms (was 100x+ slower before)
- [x] ReadableStream cancel callback fires on reader cancellation
- [x] Generator streams still work correctly
- [x] Mixed chunk types (DataView, Blob) still normalized properly
- [x] All existing stream tests pass (26 pass, 0 fail)
- [x] All core + response tests pass (273 pass, 0 fail)

Fixes #1741, fixes #1768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stream handling now better detects native readable streams and efficiently passes them through without unnecessary wrapping. Chunks of various types (binary, string, blobs, and array buffers) are normalized on-the-fly to ensure reliable delivery and reduce formatting overhead, improving performance and compatibility with native data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->