### PR TITLE
fix: prevent arbitrary error .code from leaking into onError handler

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2058,8 +2058,8 @@ export const composeHandler = ({
 				'c.code="VALIDATION"\n' +
 				'c.set.status=422' +
 				'}else{' +
-				`c.code=error.code??error[ERROR_CODE]??"UNKNOWN"}`
-		else fnLiteral += `c.code=error.code??error[ERROR_CODE]??"UNKNOWN"\n`
+				`c.code=error[ERROR_CODE]??"UNKNOWN"}`
+		else fnLiteral += `c.code=error[ERROR_CODE]??"UNKNOWN"\n`
 
 		fnLiteral += `let er\n`
 		// Mapped error Response
@@ -2657,7 +2657,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 	fnLiteral +=
 		`const set=context.set\n` +
 		`let _r\n` +
-		`if(!context.code)context.code=error.code??error[ERROR_CODE]\n` +
+		`if(!context.code)context.code=error[ERROR_CODE]??"UNKNOWN"\n` +
 		`if(!(context.error instanceof Error))context.error=error\n` +
 		`if(error instanceof ElysiaCustomStatusResponse){` +
 		`set.status=error.status=error.code\n` +

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -4,6 +4,7 @@ import { parseCookie } from './cookies'
 import {
 	ElysiaCustomStatusResponse,
 	type ElysiaErrors,
+	ERROR_CODE,
 	NotFoundError,
 	status,
 	ValidationError
@@ -880,7 +881,10 @@ export const createDynamicErrorHandler = (app: AnyElysia) => {
 		},
 		error: ElysiaErrors
 	) => {
-		const errorContext = Object.assign(context, { error, code: error.code })
+		const errorContext = Object.assign(context, {
+			error,
+			code: (error as any)[ERROR_CODE] ?? 'UNKNOWN'
+		})
 		errorContext.set = context.set
 
 		if (

--- a/src/error.ts
+++ b/src/error.ts
@@ -118,7 +118,8 @@ export const status = <
 ) => new ElysiaCustomStatusResponse<Code, T>(code, response as T)
 
 export class InternalServerError extends Error {
-	code = 'INTERNAL_SERVER_ERROR'
+	code = 'INTERNAL_SERVER_ERROR';
+	[ERROR_CODE] = 'INTERNAL_SERVER_ERROR' as const
 	status = 500
 
 	constructor(message?: string) {
@@ -127,7 +128,8 @@ export class InternalServerError extends Error {
 }
 
 export class NotFoundError extends Error {
-	code = 'NOT_FOUND'
+	code = 'NOT_FOUND';
+	[ERROR_CODE] = 'NOT_FOUND' as const
 	status = 404
 
 	constructor(message?: string) {
@@ -136,7 +138,8 @@ export class NotFoundError extends Error {
 }
 
 export class ParseError extends Error {
-	code = 'PARSE'
+	code = 'PARSE';
+	[ERROR_CODE] = 'PARSE' as const
 	status = 400
 
 	constructor(cause?: Error) {
@@ -147,7 +150,8 @@ export class ParseError extends Error {
 }
 
 export class InvalidCookieSignature extends Error {
-	code = 'INVALID_COOKIE_SIGNATURE'
+	code = 'INVALID_COOKIE_SIGNATURE';
+	[ERROR_CODE] = 'INVALID_COOKIE_SIGNATURE' as const
 	status = 400
 
 	constructor(
@@ -287,7 +291,8 @@ export class InvalidFileType extends Error {
 }
 
 export class ValidationError extends Error {
-	code = 'VALIDATION'
+	code = 'VALIDATION';
+	[ERROR_CODE] = 'VALIDATION' as const
 	status = 422
 
 	/**


### PR DESCRIPTION
## Summary
- Errors with a `.code` property (e.g. AxiosError, node:fs errors) leaked their `.code` into `onError` handler instead of `"UNKNOWN"`
- Root cause: codegen checked `error.code` before `error[ERROR_CODE]` (Elysia's symbol)

## Problem
```typescript
new Elysia()
  .onError(({ code }) => {
    console.log(code) // "ECONNREFUSED" instead of "UNKNOWN"
  })
  .post('/api', async () => {
    await axios.get('http://unreachable') // throws AxiosError with code: "ECONNREFUSED"
  })
```

This breaks error handling for anyone using libraries that throw errors with a `.code` property (axios, node:fs, undici, etc).

## Changes
- `src/error.ts`: add `[ERROR_CODE]` symbol to all built-in error classes (`NotFoundError`, `ValidationError`, `ParseError`, `InternalServerError`, `InvalidCookieSignature`)
- `src/compose.ts`: use only `error[ERROR_CODE] ?? "UNKNOWN"` in codegen (drop `error.code` fallback)
- `src/dynamic-handle.ts`: same change for dynamic/JIT handler path

## Test plan
- [x] AxiosError-like errors with `.code` now correctly show `"UNKNOWN"` in onError
- [x] Built-in Elysia errors (`NOT_FOUND`, `VALIDATION`, `PARSE`, etc.) still work correctly
- [x] Custom errors registered via `Elysia.error()` still work correctly
- [x] Both AOT and dynamic (`aot: false`) modes tested
- [x] All existing tests pass (324 pass, 0 fail)

Fixes #1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error code resolution mechanisms to enhance resilience when handling different error object structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->