### PR TITLE
fix: align JIT/dynamic mode with AOT for parse errors and status codes

### DIFF
--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -5,6 +5,7 @@ import {
 	ElysiaCustomStatusResponse,
 	type ElysiaErrors,
 	NotFoundError,
+	ParseError,
 	status,
 	ValidationError
 } from './error'
@@ -264,25 +265,31 @@ export const createDynamicHandler = (app: AnyElysia) => {
 				return await hooks.config.mount(request)
 
 			let body: string | Record<string, any> | undefined
+			try {
 			if (request.method !== 'GET' && request.method !== 'HEAD') {
 				if (content) {
 					switch (content) {
+						case 'json':
 						case 'application/json':
 							body = (await request.json()) as any
 							break
 
+						case 'text':
 						case 'text/plain':
 							body = await request.text()
 							break
 
+						case 'urlencoded':
 						case 'application/x-www-form-urlencoded':
 							body = parseQuery(await request.text())
 							break
 
+						case 'arrayBuffer':
 						case 'application/octet-stream':
 							body = await request.arrayBuffer()
 							break
 
+						case 'formdata':
 						case 'multipart/form-data': {
 							body = {}
 
@@ -315,95 +322,97 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						const index = contentType.indexOf(';')
 						if (index !== -1)
 							contentType = contentType.slice(0, index)
+					}
 
-						// @ts-expect-error
-						context.contentType = contentType
+					// @ts-expect-error
+					context.contentType = contentType ?? ''
 
-						if (hooks.parse)
-							for (let i = 0; i < hooks.parse.length; i++) {
-								const hook = hooks.parse[i].fn
+					if (hooks.parse)
+						parse: for (let i = 0; i < hooks.parse.length; i++) {
+							const hook = hooks.parse[i].fn
 
-								if (typeof hook === 'string')
-									switch (hook) {
-										case 'json':
-										case 'application/json':
-											body = (await request.json()) as any
-											break
+							if (typeof hook === 'string')
+								switch (hook) {
+									case 'json':
+									case 'application/json':
+										body = (await request.json()) as any
+										break parse
 
-										case 'text':
-										case 'text/plain':
-											body = await request.text()
-											break
+									case 'text':
+									case 'text/plain':
+										body = await request.text()
+										break parse
 
-										case 'urlencoded':
-										case 'application/x-www-form-urlencoded':
-											body = parseQuery(
-												await request.text()
-											)
-											break
+									case 'urlencoded':
+									case 'application/x-www-form-urlencoded':
+										body = parseQuery(
+											await request.text()
+										)
+										break parse
 
-										case 'arrayBuffer':
-										case 'application/octet-stream':
-											body = await request.arrayBuffer()
-											break
+									case 'arrayBuffer':
+									case 'application/octet-stream':
+										body = await request.arrayBuffer()
+										break parse
 
-										case 'formdata':
-										case 'multipart/form-data': {
-											body = {}
+									case 'formdata':
+									case 'multipart/form-data': {
+										body = {}
 
-											const form = await request.formData()
-											const grouped = new Map<string, any[]>()
-											form.forEach((v, k) => {
-												const list = grouped.get(k)
-												if (list) list.push(v)
-												else grouped.set(k, [v])
-											})
-											for (const [key, value] of grouped) {
-												if (body[key]) continue
+										const form = await request.formData()
+										const grouped = new Map<string, any[]>()
+										form.forEach((v, k) => {
+											const list = grouped.get(k)
+											if (list) list.push(v)
+											else grouped.set(k, [v])
+										})
+										for (const [key, value] of grouped) {
+											if (body[key]) continue
 
-												const finalValue = normalizeFormValue(value)
+											const finalValue = normalizeFormValue(value)
 
-												if (key.includes('.') || key.includes('['))
-													setNestedValue(body, key, finalValue)
-												else body[key] = finalValue
-											}
-
-											break
+											if (key.includes('.') || key.includes('['))
+												setNestedValue(body, key, finalValue)
+											else body[key] = finalValue
 										}
 
-										default: {
-											const parser = app['~parser'][hook]
-											if (parser) {
-												let temp = parser(
-													context as any,
-													contentType
-												)
-												if (temp instanceof Promise)
-													temp = await temp
-
-												if (temp) {
-													body = temp
-													break
-												}
-											}
-											break
-										}
+										break parse
 									}
-								else {
-									let temp = hook(context as any, contentType)
-									if (temp instanceof Promise)
-										temp = await temp
 
-									if (temp) {
-										body = temp
+									default: {
+										const parser = app['~parser'][hook]
+										if (parser) {
+											let temp = parser(
+												context as any,
+												contentType
+											)
+											if (temp instanceof Promise)
+												temp = await temp
+
+											if (temp) {
+												body = temp
+												break parse
+											}
+										}
 										break
 									}
 								}
+							else {
+								let temp = hook(context as any, contentType)
+								if (temp instanceof Promise)
+									temp = await temp
+
+								if (temp) {
+									body = temp
+									break parse
+								}
 							}
+						}
 
-						// @ts-expect-error
-						delete context.contentType
+					// @ts-expect-error
+					delete context.contentType
 
+					if (contentType) {
 						// body might be empty string thus can't use !body
 						if (body === undefined) {
 							switch (contentType) {
@@ -449,6 +458,9 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						}
 					}
 				}
+			}
+			} catch (error) {
+				throw new ParseError(error instanceof Error ? error : undefined)
 			}
 
 			context.route = route
@@ -895,6 +907,13 @@ export const createDynamicErrorHandler = (app: AnyElysia) => {
 		},
 		error: ElysiaErrors
 	) => {
+		if (error instanceof ElysiaCustomStatusResponse) {
+			const statusResponse = error as any
+			context.set.status = error.code
+			statusResponse.status = error.code
+			statusResponse.message = error.response
+		}
+
 		const errorContext = Object.assign(context, { error, code: error.code })
 		errorContext.set = context.set
 
@@ -927,6 +946,12 @@ export const createDynamicErrorHandler = (app: AnyElysia) => {
 						context.set
 					))
 			}
+
+		if (
+			context.response === undefined &&
+			error instanceof ElysiaCustomStatusResponse
+		)
+			context.response = error.response
 
 		if (context.response) {
 			if (app.event.mapResponse)

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -176,6 +176,28 @@ describe('error', () => {
 		}
 	)
 
+	it('runs error and mapResponse hooks for thrown status in dynamic mode', async () => {
+		let onErrorCalled = false
+
+		const app = new Elysia({ aot: false })
+			.onError(({ code }) => {
+				onErrorCalled = code === 418
+			})
+			.mapResponse(({ response }) => {
+				if ((response as { message?: string })?.message === 'meow')
+					return 'mapped'
+			})
+			.get('/', ({ status }) => {
+				throw status(418, { message: 'meow' })
+			})
+
+		const response = await app.handle(req('/'))
+
+		expect(await response.text()).toBe('mapped')
+		expect(response.status).toBe(418)
+		expect(onErrorCalled).toBe(true)
+	})
+
 	it('handle error in order', async () => {
 		let order = <string[]>[]
 

--- a/test/lifecycle/parser.test.ts
+++ b/test/lifecycle/parser.test.ts
@@ -288,6 +288,32 @@ describe('Parser', () => {
 		expect(response).toEqual({ name: 'Aru' })
 	})
 
+	it('stops after named parser in parse array', async () => {
+		let called = false
+
+		const app = new Elysia({ aot: false }).post('/json', ({ body }) => body, {
+			parse: [
+				'json',
+				() => {
+					called = true
+					return { name: 'Mutsuki' }
+				}
+			]
+		})
+
+		const response = await app
+			.handle(
+				new Request('http://localhost:3000/json', {
+					method: 'POST',
+					body: JSON.stringify({ name: 'Aru' })
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response).toEqual({ name: 'Aru' })
+		expect(called).toBe(false)
+	})
+
 	it('handle custom parser then fallback to named default', async () => {
 		const app = new Elysia()
 			.parser('custom', ({ contentType, request }) => {


### PR DESCRIPTION
## Summary
Multiple behavioral inconsistencies between AOT and JIT (`aot: false`) modes, all in `src/dynamic-handle.ts`.

## Problems fixed

### 1. `ElysiaCustomStatusResponse` not handled in dynamic error handler
Throwing `status(401)` from `onRequest` returned 500 instead of 401.

### 2. Body parsing errors not wrapped in `ParseError`
Errors during body parsing returned raw 500 instead of 400 Bad Request (AOT wraps in `ParseError`).

### 3. Parse hooks skipped without Content-Type header
Parse hooks (including string parsers like `"text"`) were nested inside `if (contentType)`, so they never ran when the Content-Type header was missing. AOT runs them unconditionally.

### 4. Short parser aliases not matched
Route-level `parse: "text"` stored `content = undefined` and `hooks.parse = ["text"]`, but the dynamic handler's switch only matched full MIME types like `"text/plain"`. Added short aliases (`"json"`, `"text"`, `"urlencoded"`, `"arrayBuffer"`, `"formdata"`).

## Before/After

| Test case | AOT | JIT (before) | JIT (after) |
|-----------|-----|-------------|-------------|
| onParse throw 413, no Content-Type | 400 | 200 "echoing undefined" | 400 |
| onParse throw 413, with Content-Type | 400 | 500 | 400 |
| onRequest throw 401, no Content-Type | 401 | 500 | 401 |
| onRequest throw 401, with Content-Type | 401 | 500 | 401 |

## Test plan
- [x] All 4 discrepancies from the issue now match AOT behavior
- [x] Full test suite passes (1525 pass, 0 fail)

Fixes #1753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request body parsing error conversion, with consistent handling of missing/varied content-type inputs.
  * Expanded support for shorthand content indicators during parsing and hook execution, alongside standard MIME types.
  * Enhanced dynamic-mode error/status response handling to preserve correct status codes and message behavior.
* **Tests**
  * Added coverage for dynamic-mode status throwing with `onError` and `mapResponse` mapping.
  * Added coverage ensuring parser chains stop after the first successful named parser match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->