### PR TITLE
fix: sync set.status with actual response status in onAfterResponse

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -848,6 +848,7 @@ export const composeHandler = ({
 			`\n${setImmediateFn}(async()=>{` +
 			`if(c.responseValue){` +
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n` +
+			`else if(c.responseValue instanceof Response) c.set.status=c.responseValue.status\n` +
 			(hasStream
 				? `if(typeof afterHandlerStreamListener!=='undefined')for await(const v of afterHandlerStreamListener){}\n`
 				: '') +
@@ -2390,7 +2391,8 @@ export const composeGeneralHandler = (
 		const prefix = app.event.afterResponse.some(isAsync) ? 'async' : ''
 		afterResponse +=
 			`\n${setImmediateFn}(${prefix}()=>{` +
-			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n`
+			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n` +
+			`else if(c.responseValue instanceof Response) c.set.status=c.responseValue.status\n`
 
 		for (let i = 0; i < app.event.afterResponse.length; i++) {
 			const fn = app.event.afterResponse[i].fn

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -851,6 +851,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 			// @ts-expect-error private
 			return app.handleError(context, reportedError)
 		} finally {
+			if (context.response instanceof Response)
+				set.status = context.response.status
+			else if (context.response instanceof ElysiaCustomStatusResponse)
+				set.status = (context.response as any).code
+
 			const afterResponses = hooks!
 				? hooks.afterResponse
 				: app.event.afterResponse

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -851,10 +851,10 @@ export const createDynamicHandler = (app: AnyElysia) => {
 			// @ts-expect-error private
 			return app.handleError(context, reportedError)
 		} finally {
-			if (context.response instanceof Response)
-				set.status = context.response.status
-			else if (context.response instanceof ElysiaCustomStatusResponse)
+			if (context.response instanceof ElysiaCustomStatusResponse)
 				set.status = (context.response as any).code
+			else if (context.response instanceof Response)
+				set.status = context.response.status
 
 			const afterResponses = hooks!
 				? hooks.afterResponse


### PR DESCRIPTION
## Summary
`set.status` in `onAfterResponse` always showed `200` even when the actual response had a different status code. This broke logging/monitoring middleware.

## Problem
```typescript
new Elysia()
  .onAfterResponse(({ set }) => {
    console.log(set.status) // always 200, even for 401/404/etc
  })
  .get('/test', () => new Response('unauthorized', { status: 401 }))
```

The handler returns a 401 Response, the client gets 401, but `set.status` in `onAfterResponse` was never updated from the response.

## Changes
- `src/compose.ts`: in the afterResponse codegen, sync `c.set.status` from `c.responseValue.status` when it's a Response object (route handler + 404 handler paths)
- `src/dynamic-handle.ts`: in the finally block, sync `set.status` from `context.response` before running afterResponse hooks

## Test plan
- [x] Handler returning `Response` with non-200 status → `set.status` reflects actual status
- [x] Handler using `status()` helper → still works correctly
- [x] Both AOT and dynamic modes tested
- [x] Full test suite passes (1525 pass, 0 fail)

Fixes #1445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure HTTP status codes from native responses and custom-status responses are propagated consistently across request and cleanup flows.
  * Synchronize response status before running post-response hooks so final status is always reflected in downstream handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->