### PR TITLE
fix: handle Union with objects in query array params

### DIFF
--- a/src/parse-query.ts
+++ b/src/parse-query.ts
@@ -91,9 +91,11 @@ export function parseQueryFromURL(
 
 		if (array && array?.[finalKey]) {
 			if (finalValue.charCodeAt(0) === 91) {
-				if (object && object?.[finalKey])
+				try {
 					finalValue = JSON.parse(finalValue) as any
-				else finalValue = finalValue.slice(1, -1).split(',') as any
+				} catch {
+					finalValue = finalValue.slice(1, -1).split(',') as any
+				}
 
 				if (currentValue === undefined) result[finalKey] = finalValue
 				else if (Array.isArray(currentValue))
@@ -103,10 +105,10 @@ export function parseQueryFromURL(
 					result[finalKey].unshift(currentValue)
 				}
 			} else {
+				// join multi-param values as comma-separated so ArrayQuery
+				// Decode handles them uniformly (same as comma format)
 				if (currentValue === undefined) result[finalKey] = finalValue
-				else if (Array.isArray(currentValue))
-					currentValue.push(finalValue)
-				else result[finalKey] = [currentValue, finalValue]
+				else result[finalKey] = currentValue + ',' + finalValue
 			}
 		} else {
 			result[finalKey] = finalValue

--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -426,7 +426,6 @@ export const ElysiaType = {
 		const compiler = compile(schema)
 
 		const tryParseItem = (v: string) => {
-			// try to parse JSON objects/arrays from string
 			const c = v.charCodeAt(0)
 			if (c === 123 || c === 91) {
 				try { return JSON.parse(v) } catch {}
@@ -434,14 +433,44 @@ export const ElysiaType = {
 			return v
 		}
 
+		// split by commas but respect {} [] and quoted strings
+		const splitTopLevel = (value: string) => {
+			const parts: string[] = []
+			let depth = 0
+			let inStr = 0 // 0=none, 34=", 39='
+			let start = 0
+
+			for (let i = 0; i < value.length; i++) {
+				const ch = value.charCodeAt(i)
+
+				if (inStr) {
+					if (ch === inStr && value.charCodeAt(i - 1) !== 92)
+						inStr = 0
+					continue
+				}
+
+				if (ch === 34 || ch === 39) { inStr = ch; continue }
+				if (ch === 123 || ch === 91) { depth++; continue }
+				if (ch === 125 || ch === 93) { depth--; continue }
+
+				if (ch === 44 && depth === 0) {
+					parts.push(value.slice(start, i))
+					start = i + 1
+				}
+			}
+
+			parts.push(value.slice(start))
+			return parts
+		}
+
 		const decode = (value: string) => {
-			// has , (as used in nuqs)
 			if (value.indexOf(',') !== -1) {
-				// try wrapping as JSON array to correctly handle objects in unions
 				try {
 					return compiler.Decode(JSON.parse(`[${value}]`))
 				} catch {
-					return compiler.Decode(value.split(','))
+					return compiler.Decode(
+						splitTopLevel(value).map(tryParseItem)
+					)
 				}
 			}
 

--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -425,12 +425,27 @@ export const ElysiaType = {
 		const schema = t.Array(children, options)
 		const compiler = compile(schema)
 
+		const tryParseItem = (v: string) => {
+			// try to parse JSON objects/arrays from string
+			const c = v.charCodeAt(0)
+			if (c === 123 || c === 91) {
+				try { return JSON.parse(v) } catch {}
+			}
+			return v
+		}
+
 		const decode = (value: string) => {
 			// has , (as used in nuqs)
-			if (value.indexOf(',') !== -1)
-				return compiler.Decode(value.split(','))
+			if (value.indexOf(',') !== -1) {
+				// try wrapping as JSON array to correctly handle objects in unions
+				try {
+					return compiler.Decode(JSON.parse(`[${value}]`))
+				} catch {
+					return compiler.Decode(value.split(','))
+				}
+			}
 
-			return compiler.Decode([value])
+			return compiler.Decode([tryParseItem(value)])
 		}
 
 		return t


### PR DESCRIPTION
## Summary
When using `t.Union([t.Object({a}), t.Object({b})])` inside a query array schema, only the first object variant worked. The second always failed with a validation error.

## Problem
```typescript
const schema = t.Object({
  data: t.Array(t.Union([
    t.Number(),
    t.Object({ a: t.String() }),
    t.Object({ b: t.String() }), // this variant always failed
  ]))
})
```

Two root causes:
1. `ArrayQuery` decode used `value.split(',')` which produced string items like `'{"b":"world"}'` that TypeBox couldn't match against Object union variants
2. Multi-param format (`data=1&data={"b":"world"}`) built a string array that failed `Check` before `Decode` could run

## Changes
- `src/type-system/index.ts`: ArrayQuery decode now tries `JSON.parse('[' + value + ']')` before falling back to naive split, and parses JSON-like single items via `tryParseItem`
- `src/parse-query.ts`: multi-param ArrayQuery values are joined as comma-separated string instead of building a string array, so Decode handles both formats uniformly

## Test plan
- [x] Comma format with first/second object variant both pass
- [x] Multi-param format with first/second object variant both pass
- [x] All query validation tests pass (56 pass)
- [x] Full test suite passes (1525 pass, 0 fail)

Fixes #1829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query parameter parsing for arrays to better handle bracketed and malformed inputs, with safer parsing and fallback behavior.
  * Enhanced handling of repeated multi-value parameters by normalizing them into comma-delimited values.
  * More robust splitting of comma-delimited query strings that respects nested structures and quoted segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->