### PR TITLE
fix: preserve property path in numeric constraint validation errors

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -465,8 +465,11 @@ const coerceTransformDecodeError = (
 ) =>
 	`try{${fnLiteral}}catch(error){` +
 	`if(error.constructor.name === 'TransformDecodeError'){` +
+	`if(error.error&&!(error.error instanceof TypeError))throw error.error\n` +
 	`c.set.status=422\n` +
-	`throw error.error ?? new ValidationError('${type}',validator.${type},${value},${allowUnsafeValidationDetails})}` +
+	`const _tde=error.path?{First(){return{path:error.path,message:error.message,value:error.value,type:error.type??0,schema:error.schema??{}}},` +
+	`[Symbol.iterator](){let d=false;const s=this;return{next(){if(d)return{done:true};d=true;return{done:false,value:s.First()}}}}}:undefined\n` +
+	`throw new ValidationError('${type}',validator.${type},${value},${allowUnsafeValidationDetails},_tde)}` +
 	`}`
 
 const setImmediateFn = hasSetImmediate


### PR DESCRIPTION
## Summary
Validation errors for numeric constraints (minimum, maximum) showed `"property": "root"` instead of the actual field path like `"/a"`.

## Problem
```typescript
app.get('/', ({ query }) => query, {
  query: t.Object({
    a: t.Integer({ minimum: 1, maximum: 100 }),
  })
})
// GET /?a=0 → { property: "root" } instead of { property: "/a" }
```

TypeBox's `TransformDecodeError` has the correct `path` but it was discarded when Elysia created a new `ValidationError` using `error.error` (an empty TypeError) instead of the error itself.

## Changes
- `src/compose.ts`: `coerceTransformDecodeError` now passes `TransformDecodeError.path` through to the `ValidationError` via a synthetic error iterator, so the property field in the response matches the actual field that failed. Non-validation errors (like NotFoundError) thrown from Transform Decode are still re-thrown as-is.

## Test plan
- [x] `a=0` with `minimum: 1` shows property `/a`
- [x] `b=101` with `maximum: 100` shows property `/b`  
- [x] Type errors (string where integer expected) still show correct path
- [x] NotFoundError thrown from Decode still returns 404
- [x] Full test suite passes (1525 pass, 0 fail)

Fixes #1822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation error handling to provide more comprehensive error details when transformation errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->