### PR TITLE
fix: snapshot hook arrays at route registration to preserve order

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -271,8 +271,14 @@ export const mergeHook = (
 	if (!b) return (a as any) ?? {}
 	if (!a) return b ?? {}
 
-	if (!Object.values(b).find((x) => x !== undefined && x !== null))
-		return { ...a } as any
+	if (!Object.values(b).find((x) => x !== undefined && x !== null)) {
+		const copy = {} as any
+		for (const key in a)
+			copy[key] = Array.isArray((a as any)[key])
+				? [...(a as any)[key]]
+				: (a as any)[key]
+		return copy
+	}
 
 	const hook = {
 		...a,


### PR DESCRIPTION
## Summary
Routes picked up hooks registered after them due to shared array references.

## Problem
```typescript
new Elysia()
  .get('/a', () => 'A')
  .onBeforeHandle(() => console.log('1'))
  .get('/b', () => 'B')              // should only have hook 1
  .onBeforeHandle(() => console.log('2'))
  .get('/c', () => 'C')              // should have hooks 1, 2
```

Request to `/b` triggered both hooks `1` and `2`, but should only trigger `1`.

## Root cause
`mergeHook` has an early return when the local hook object is empty: `return { ...a }`. The spread operator copies array properties by reference, not value. So `route.hooks.beforeHandle` and `this.event.beforeHandle` pointed to the same array. Later `onBeforeHandle` calls pushed into that shared array, retroactively adding hooks to already-registered routes.

## Changes
- `src/utils.ts`: the early return in `mergeHook` now copies array values to prevent shared references

## Test plan
- [x] `/a` has 0 hooks, `/b` has 1, `/c` has 2
- [x] Full test suite passes (1525 pass, 0 fail)

Fixes #1826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object merging behavior to prevent shared array references from causing unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->