### PR TITLE
fix: empty-body status codes send body when using string status names

### DIFF
--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -56,7 +56,7 @@ export const mapResponse = (
 				)
 
 			case undefined:
-				if (!response) return new Response('', set as any)
+				if (!response) return new Response(null, set as any)
 
 				return Response.json(response, set as any)
 

--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -307,7 +307,7 @@ export const mapEarlyResponse = (
 				)
 
 			case undefined:
-				if (!response) return new Response('')
+				if (!response) return new Response(null)
 
 				return Response.json(response)
 
@@ -423,7 +423,7 @@ export const mapCompactResponse = (
 			)
 
 		case undefined:
-			if (!response) return new Response('')
+			if (!response) return new Response(null)
 
 			return Response.json(response)
 

--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -307,7 +307,7 @@ export const mapEarlyResponse = (
 				)
 
 			case undefined:
-				if (!response) return new Response(null)
+				if (!response) return new Response()
 
 				return Response.json(response)
 
@@ -423,7 +423,7 @@ export const mapCompactResponse = (
 			)
 
 		case undefined:
-			if (!response) return new Response(null)
+			if (!response) return new Response()
 
 			return Response.json(response)
 

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -90,7 +90,7 @@ export const mapResponse = (
 				)
 
 			case undefined:
-				if (!response) return new Response('', set as any)
+				if (!response) return new Response(null, set as any)
 
 				return new Response(JSON.stringify(response), set as any)
 

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -375,7 +375,7 @@ export const mapEarlyResponse = (
 				)
 
 			case undefined:
-				if (!response) return new Response('')
+				if (!response) return new Response(null)
 
 				return new Response(JSON.stringify(response), {
 					headers: {
@@ -514,7 +514,7 @@ export const mapCompactResponse = (
 			)
 
 		case undefined:
-			if (!response) return new Response('')
+			if (!response) return new Response(null)
 
 			return new Response(JSON.stringify(response), {
 				headers: {

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -375,7 +375,7 @@ export const mapEarlyResponse = (
 				)
 
 			case undefined:
-				if (!response) return new Response(null)
+				if (!response) return new Response()
 
 				return new Response(JSON.stringify(response), {
 					headers: {
@@ -514,7 +514,7 @@ export const mapCompactResponse = (
 			)
 
 		case undefined:
-			if (!response) return new Response(null)
+			if (!response) return new Response()
 
 			return new Response(JSON.stringify(response), {
 				headers: {

--- a/src/error.ts
+++ b/src/error.ts
@@ -98,7 +98,7 @@ export class ElysiaCustomStatusResponse<
 		// @ts-ignore Trust me bro
 		this.code = StatusMap[code] ?? code
 
-		if (code in emptyHttpStatus) this.response = undefined as any
+		if (this.code in emptyHttpStatus) this.response = undefined as any
 		else
 			// @ts-ignore Trust me bro
 			this.response = res

--- a/test/response/no-content-status.test.ts
+++ b/test/response/no-content-status.test.ts
@@ -1,0 +1,44 @@
+import { Elysia } from '../../src'
+import { describe, expect, it } from 'bun:test'
+import { req } from '../utils'
+
+describe('204 No Content', () => {
+	it('should return null body for status No Content', async () => {
+		const app = new Elysia().delete('/item', ({ status }) => {
+			return status('No Content')
+		})
+
+		const response = await app.handle(
+			req('/item', { method: 'DELETE' })
+		)
+
+		expect(response.status).toBe(204)
+		expect(response.body).toBeNull()
+	})
+
+	it('should return null body for status No Content even when a message is passed', async () => {
+		const app = new Elysia().delete('/item', ({ status }) => {
+			return status('No Content', 'Item deleted successfully.')
+		})
+
+		const response = await app.handle(
+			req('/item', { method: 'DELETE' })
+		)
+
+		expect(response.status).toBe(204)
+		expect(response.body).toBeNull()
+	})
+
+	it('should return null body for status 205 Reset Content', async () => {
+		const app = new Elysia().post('/reset', ({ status }) => {
+			return status('Reset Content')
+		})
+
+		const response = await app.handle(
+			req('/reset', { method: 'POST' })
+		)
+
+		expect(response.status).toBe(205)
+		expect(response.body).toBeNull()
+	})
+})

--- a/test/response/no-content-status.test.ts
+++ b/test/response/no-content-status.test.ts
@@ -2,7 +2,7 @@ import { Elysia } from '../../src'
 import { describe, expect, it } from 'bun:test'
 import { req } from '../utils'
 
-describe('204 No Content', () => {
+describe('Empty HTTP statuses', () => {
 	it('should return null body for status No Content', async () => {
 		const app = new Elysia().delete('/item', ({ status }) => {
 			return status('No Content')


### PR DESCRIPTION
## Summary

- `ElysiaCustomStatusResponse` constructor checks `code in emptyHttpStatus`, but when using string status names like `status('No Content')`, `code` is `'No Content'` while `emptyHttpStatus` keys are numeric (`204`). The lookup always fails, so `this.response` is never cleared — resulting in a response body being sent with 204/205/304/etc.
- Fixed by checking `this.code in emptyHttpStatus` instead, since `this.code` is already resolved to the numeric status via `StatusMap`.
- Also changed `mapResponse`'s `case undefined` to use `new Response(null, set)` instead of `new Response('', set)` in both the bun and web-standard adapters, since HTTP spec requires no body for these status codes and an empty string still produces a `ReadableStream` body.

## Test plan

- [x] Added `test/response/no-content-status.test.ts` with 3 tests covering 204 (no args), 204 (with message arg), and 205
- [x] Verified all 3 tests fail before the fix and pass after
- [x] Full test suite passes (1528/1528)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized empty/falsy response handling so no-content statuses (204, 205) return null bodies across environments.
  * Use the resolved HTTP status when deciding to omit a response body for status-based responses.

* **Tests**
  * Added tests verifying 204/205 responses produce null bodies and correct HTTP statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->