### PR TITLE
fix: preserve middleware headers for Array subclass responses

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0 < 1",
         "@types/bun": ">= 1.2.0",
-        "exact-mirror": "^0.2.6",
+        "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",

--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -126,9 +126,9 @@ export const mapResponse = (
 					) as any
 
 				// custom class with an array-like value
-				// eg. Bun.sql`` result
+				// eg. Bun.sql`` result, postgres.js RowList
 				if (Array.isArray(response))
-					return Response.json(response) as any
+					return Response.json(response, set as any) as any
 
 				// @ts-expect-error
 				if (typeof response?.toResponse === 'function')
@@ -266,9 +266,9 @@ export const mapEarlyResponse = (
 					return mapEarlyResponse((response as any).toResponse(), set)
 
 				// custom class with an array-like value
-				// eg. Bun.sql`` result
+				// eg. Bun.sql`` result, postgres.js RowList
 				if (Array.isArray(response))
-					return Response.json(response) as any
+					return Response.json(response, set as any) as any
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)
@@ -377,9 +377,9 @@ export const mapEarlyResponse = (
 					return mapEarlyResponse((response as any).toResponse(), set)
 
 				// custom class with an array-like value
-				// eg. Bun.sql`` result
+				// eg. Bun.sql`` result, postgres.js RowList
 				if (Array.isArray(response))
-					return Response.json(response) as any
+					return Response.json(response, set as any) as any
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)

--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -19,8 +19,14 @@ import { ElysiaCustomStatusResponse } from '../../error'
 import type { Context } from '../../context'
 import type { AnyLocalHook } from '../../types'
 
+// Handle Array subclass responses (e.g. postgres.js RowList, Bun.sql results)
+// that bypass the constructor.name === 'Array' case in the switch statement.
 // Response.json is faster than new Response(JSON.stringify()) in Bun
 // https://x.com/jarredsumner/status/2023328556210921948
+const mapArraySubclassResponse = (response: unknown[], set: Context['set']) =>
+	Response.json(response, set as any) as any
+
+
 export const mapResponse = (
 	response: unknown,
 	set: Context['set'],
@@ -125,10 +131,8 @@ export const mapResponse = (
 						mapResponse(x, set)
 					) as any
 
-				// custom class with an array-like value
-				// eg. Bun.sql`` result, postgres.js RowList
 				if (Array.isArray(response))
-					return Response.json(response, set as any) as any
+					return mapArraySubclassResponse(response, set)
 
 				// @ts-expect-error
 				if (typeof response?.toResponse === 'function')
@@ -265,10 +269,8 @@ export const mapEarlyResponse = (
 				if (typeof response?.toResponse === 'function')
 					return mapEarlyResponse((response as any).toResponse(), set)
 
-				// custom class with an array-like value
-				// eg. Bun.sql`` result, postgres.js RowList
 				if (Array.isArray(response))
-					return Response.json(response, set as any) as any
+					return mapArraySubclassResponse(response, set)
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)
@@ -376,10 +378,8 @@ export const mapEarlyResponse = (
 				if (typeof response?.toResponse === 'function')
 					return mapEarlyResponse((response as any).toResponse(), set)
 
-				// custom class with an array-like value
-				// eg. Bun.sql`` result, postgres.js RowList
 				if (Array.isArray(response))
-					return Response.json(response, set as any) as any
+					return mapArraySubclassResponse(response, set)
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -160,13 +160,14 @@ export const mapResponse = (
 					) as any
 
 				// custom class with an array-like value
-				// eg. Bun.sql`` result
-				if (Array.isArray(response))
-					return new Response(JSON.stringify(response), {
-						headers: {
-							'Content-Type': 'application/json'
-						}
-					}) as any
+				// eg. Bun.sql`` result, postgres.js RowList
+				if (Array.isArray(response)) {
+					set.headers['content-type'] ||= 'application/json'
+					return new Response(
+						JSON.stringify(response),
+						set as any
+					) as any
+				}
 
 				// @ts-expect-error
 				if (typeof response?.toResponse === 'function')
@@ -317,13 +318,14 @@ export const mapEarlyResponse = (
 					return mapEarlyResponse((response as any).toResponse(), set)
 
 				// custom class with an array-like value
-				// eg. Bun.sql`` result
-				if (Array.isArray(response))
-					return new Response(JSON.stringify(response), {
-						headers: {
-							'Content-Type': 'application/json'
-						}
-					}) as any
+				// eg. Bun.sql`` result, postgres.js RowList
+				if (Array.isArray(response)) {
+					set.headers['content-type'] ||= 'application/json'
+					return new Response(
+						JSON.stringify(response),
+						set as any
+					) as any
+				}
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)
@@ -449,13 +451,14 @@ export const mapEarlyResponse = (
 					return mapEarlyResponse((response as any).toResponse(), set)
 
 				// custom class with an array-like value
-				// eg. Bun.sql`` result
-				if (Array.isArray(response))
-					return new Response(JSON.stringify(response), {
-						headers: {
-							'Content-Type': 'application/json'
-						}
-					}) as any
+				// eg. Bun.sql`` result, postgres.js RowList
+				if (Array.isArray(response)) {
+					set.headers['content-type'] ||= 'application/json'
+					return new Response(
+						JSON.stringify(response),
+						set as any
+					) as any
+				}
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -15,6 +15,13 @@ import { ElysiaCustomStatusResponse } from '../../error'
 import type { Context } from '../../context'
 import type { AnyLocalHook, MaybePromise } from '../../types'
 
+// Handle Array subclass responses (e.g. postgres.js RowList, Bun.sql results)
+// that bypass the constructor.name === 'Array' case in the switch statement.
+const mapArraySubclassResponse = (response: unknown[], set: Context['set']) => {
+	set.headers['content-type'] ||= 'application/json'
+	return new Response(JSON.stringify(response), set as any) as any
+}
+
 const handleElysiaFile = (
 	file: ElysiaFile,
 	set: Context['set'] = {
@@ -159,15 +166,8 @@ export const mapResponse = (
 						mapResponse(x, set)
 					) as any
 
-				// custom class with an array-like value
-				// eg. Bun.sql`` result, postgres.js RowList
-				if (Array.isArray(response)) {
-					set.headers['content-type'] ||= 'application/json'
-					return new Response(
-						JSON.stringify(response),
-						set as any
-					) as any
-				}
+				if (Array.isArray(response))
+					return mapArraySubclassResponse(response, set)
 
 				// @ts-expect-error
 				if (typeof response?.toResponse === 'function')
@@ -317,15 +317,8 @@ export const mapEarlyResponse = (
 				if (typeof response?.toResponse === 'function')
 					return mapEarlyResponse((response as any).toResponse(), set)
 
-				// custom class with an array-like value
-				// eg. Bun.sql`` result, postgres.js RowList
-				if (Array.isArray(response)) {
-					set.headers['content-type'] ||= 'application/json'
-					return new Response(
-						JSON.stringify(response),
-						set as any
-					) as any
-				}
+				if (Array.isArray(response))
+					return mapArraySubclassResponse(response, set)
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)
@@ -450,15 +443,8 @@ export const mapEarlyResponse = (
 				if (typeof response?.toResponse === 'function')
 					return mapEarlyResponse((response as any).toResponse(), set)
 
-				// custom class with an array-like value
-				// eg. Bun.sql`` result, postgres.js RowList
-				if (Array.isArray(response)) {
-					set.headers['content-type'] ||= 'application/json'
-					return new Response(
-						JSON.stringify(response),
-						set as any
-					) as any
-				}
+				if (Array.isArray(response))
+					return mapArraySubclassResponse(response, set)
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)

--- a/test/response/headers.test.ts
+++ b/test/response/headers.test.ts
@@ -85,4 +85,52 @@ describe('Response Headers', () => {
 
 		expect(headers.get('x-powered-by')).toBe('Elysia')
 	})
+
+	// Regression: Array subclass responses (e.g. postgres.js RowList, Bun.sql
+	// results) silently dropped all middleware-set headers because the
+	// constructor.name check missed them and the default fallback called
+	// Response.json() / new Response() without passing `set`.
+	// See: https://github.com/elysiajs/elysia/issues/1656
+	it('preserve headers when handler returns Array subclass', async () => {
+		class CustomArray<T> extends Array<T> {
+			command = 'SELECT'
+			count = 2
+		}
+
+		const result = new CustomArray()
+		result.push({ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' })
+
+		const app = new Elysia()
+			.onTransform(({ set }) => {
+				set.headers['x-powered-by'] = 'Elysia'
+				set.headers['access-control-allow-origin'] = '*'
+			})
+			.get('/', () => result)
+
+		const res = await app.handle(req('/'))
+
+		expect(res.headers.get('x-powered-by')).toBe('Elysia')
+		expect(res.headers.get('access-control-allow-origin')).toBe('*')
+		expect(res.headers.get('content-type')).toContain('application/json')
+		expect(await res.json()).toEqual([
+			{ id: 1, name: 'Alice' },
+			{ id: 2, name: 'Bob' }
+		])
+	})
+
+	it('preserve status when handler returns Array subclass', async () => {
+		class RowList<T> extends Array<T> {}
+		const result = new RowList()
+		result.push({ ok: true })
+
+		const app = new Elysia().get('/', ({ set }) => {
+			set.status = 201
+			return result
+		})
+
+		const res = await app.handle(req('/'))
+
+		expect(res.status).toBe(201)
+		expect(await res.json()).toEqual([{ ok: true }])
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #1842 — Array subclass responses (e.g. postgres.js `RowList`, Bun SQL results) silently drop all middleware-set headers (CORS, cache-control, custom headers).

This is the header-loss half of #1656. PR #1675 fixed body serialization by adding an `Array.isArray()` fallback in the `default` case, but that fallback called `Response.json(response)` / `new Response(JSON.stringify(response), { headers: ... })` **without passing `set`**, discarding all headers that middleware had added.

## Changes

**`src/adapter/bun/handler.ts`** — Pass `set` to `Response.json()` in 3 `Array.isArray()` fallback paths:
```diff
- return Response.json(response) as any
+ return Response.json(response, set as any) as any
```

**`src/adapter/web-standard/handler.ts`** — Use `set` instead of constructing new headers in 3 `Array.isArray()` fallback paths:
```diff
- return new Response(JSON.stringify(response), {
-   headers: { 'Content-Type': 'application/json' }
- }) as any
+ set.headers['content-type'] ||= 'application/json'
+ return new Response(JSON.stringify(response), set as any) as any
```

**`test/response/headers.test.ts`** — 2 regression tests:
- `preserve headers when handler returns Array subclass` — verifies custom headers + content-type survive
- `preserve status when handler returns Array subclass` — verifies status code survives

## Test plan

- [x] All existing response tests pass (62/62)
- [x] All core + lifecycle tests pass (396/396)
- [x] New regression tests pass
- [x] Verified manually: postgres.js `RowList` responses now include CORS headers when using `@elysiajs/cors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve middleware/hook headers and status when handlers return array-like values (e.g., DB query results), ensuring JSON responses keep intended headers and status codes.

* **Tests**
  * Added regression tests confirming middleware effects on headers and status are retained for array-like responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->