### PR TITLE
fix: strip prototype pollution keys from FormData JSON parsing

### DIFF
--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -58,6 +58,13 @@ export const WebStandardAdapter: ElysiaAdapter = {
 					`const m=k.match(/^(.+)\\[(\\d+)\\]$/);` +
 					`return m?{name:m[1],index:parseInt(m[2],10)}:null` +
 					`}\n` +
+					`const stripDangerousKeys=(obj)=>{` +
+					`if(typeof obj!=='object'||obj===null)return obj;` +
+					`if(Array.isArray(obj)){for(let i=0;i<obj.length;i++)obj[i]=stripDangerousKeys(obj[i]);return obj}` +
+					`for(const dk of dangerousKeys)if(dk in obj)delete obj[dk];` +
+					`for(const k of Object.keys(obj))obj[k]=stripDangerousKeys(obj[k]);` +
+					`return obj` +
+					`}\n` +
 					`for(const key of form.keys()){` +
 					`if(c.body[key])continue\n` +
 					`const value=form.getAll(key)\n` +
@@ -67,7 +74,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
     				`if(typeof sv==='string'&&(sv.charCodeAt(0)===123||sv.charCodeAt(0)===91)){\n` +
     				`try{\n` +
     				`const p=JSON.parse(sv)\n` +
-    				`if(p&&typeof p==='object')finalValue=p\n` +
+    				`if(p&&typeof p==='object')finalValue=stripDangerousKeys(p)\n` +
     				`}catch{}\n` +
     				`}\n` +
     				`if(finalValue===undefined)finalValue=sv\n` +
@@ -79,6 +86,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
 					`try{\n` +
 					`const parsed=JSON.parse(stringValue)\n` +
 					`if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){\n` +
+					`stripDangerousKeys(parsed)\n` +
 					`if(!('file' in parsed)&&files.length===1)parsed.file=files[0]\n` +
 					`else if(!('files' in parsed)&&files.length>1)parsed.files=files\n` +
 					`finalValue=parsed\n` +

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -123,6 +123,28 @@ const setNestedValue = (obj: Record<string, any>, path: string, value: any) => {
 	}
 }
 
+const dangerousKeys = ['__proto__', 'constructor', 'prototype']
+
+const stripDangerousKeys = (obj: unknown): unknown => {
+	if (typeof obj !== 'object' || obj === null) return obj
+
+	if (Array.isArray(obj)) {
+		for (let i = 0; i < obj.length; i++)
+			obj[i] = stripDangerousKeys(obj[i])
+		return obj
+	}
+
+	for (const key of dangerousKeys)
+		if (key in obj) delete (obj as Record<string, unknown>)[key]
+
+	for (const key of Object.keys(obj))
+		(obj as Record<string, unknown>)[key] = stripDangerousKeys(
+			(obj as Record<string, unknown>)[key]
+		)
+
+	return obj
+}
+
 const normalizeFormValue = (value: unknown[]) => {
     if (value.length === 1) {
         const stringValue = value[0]
@@ -132,7 +154,7 @@ const normalizeFormValue = (value: unknown[]) => {
                 try {
                     const parsed = JSON.parse(stringValue)
                     if (parsed && typeof parsed === 'object') {
-                        return parsed
+                        return stripDangerousKeys(parsed)
                     }
                 } catch {}
             }
@@ -159,6 +181,8 @@ const normalizeFormValue = (value: unknown[]) => {
 	}
 
 	if (typeof parsed !== 'object' || parsed === null) return value
+
+	stripDangerousKeys(parsed)
 
 	if (!('file' in parsed) && files.length === 1)
 		(parsed as Record<string, unknown>).file = files[0]

--- a/test/security/formdata-prototype-pollution.test.ts
+++ b/test/security/formdata-prototype-pollution.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from '../../src'
+
+describe('FormData prototype pollution prevention', () => {
+	const app = new Elysia().post('/submit', ({ body }) => {
+		return body
+	})
+
+	it('should strip __proto__ from parsed JSON in form values', async () => {
+		const form = new FormData()
+		form.append(
+			'data',
+			JSON.stringify({
+				__proto__: { polluted: true },
+				safe: 'value'
+			})
+		)
+
+		const response = await app.handle(
+			new Request('http://localhost/submit', {
+				method: 'POST',
+				body: form
+			})
+		)
+
+		const result = (await response.json()) as Record<string, unknown>
+		const data = result.data as Record<string, unknown>
+
+		expect(data.safe).toBe('value')
+		// __proto__ should not be an own enumerable property
+		expect(Object.keys(data)).not.toContain('__proto__')
+
+		// Verify Object.prototype was not polluted
+		const clean: Record<string, unknown> = {}
+		expect(clean).not.toHaveProperty('polluted')
+	})
+
+	it('should strip constructor and prototype keys from parsed JSON in form values', async () => {
+		const form = new FormData()
+		form.append(
+			'data',
+			JSON.stringify({
+				constructor: { prototype: { polluted: true } },
+				prototype: { polluted: true },
+				safe: 'value'
+			})
+		)
+
+		const response = await app.handle(
+			new Request('http://localhost/submit', {
+				method: 'POST',
+				body: form
+			})
+		)
+
+		const result = (await response.json()) as Record<string, unknown>
+		const data = result.data as Record<string, unknown>
+
+		expect(data.safe).toBe('value')
+		expect(Object.keys(data)).not.toContain('constructor')
+		expect(Object.keys(data)).not.toContain('prototype')
+	})
+
+	it('should strip __proto__ from nested objects in parsed JSON form values', async () => {
+		const form = new FormData()
+		form.append(
+			'data',
+			JSON.stringify({
+				nested: {
+					__proto__: { polluted: true },
+					value: 'ok'
+				},
+				safe: 'value'
+			})
+		)
+
+		const response = await app.handle(
+			new Request('http://localhost/submit', {
+				method: 'POST',
+				body: form
+			})
+		)
+
+		const result = (await response.json()) as Record<string, unknown>
+		const data = result.data as Record<string, unknown>
+		const nested = data.nested as Record<string, unknown>
+
+		expect(nested.value).toBe('ok')
+		expect(Object.keys(nested)).not.toContain('__proto__')
+
+		// Verify Object.prototype was not polluted
+		const clean: Record<string, unknown> = {}
+		expect(clean).not.toHaveProperty('polluted')
+	})
+
+	it('should still parse valid JSON form values without dangerous keys', async () => {
+		const form = new FormData()
+		form.append(
+			'data',
+			JSON.stringify({
+				name: 'test',
+				count: 42,
+				tags: ['a', 'b']
+			})
+		)
+
+		const response = await app.handle(
+			new Request('http://localhost/submit', {
+				method: 'POST',
+				body: form
+			})
+		)
+
+		const result = (await response.json()) as Record<string, unknown>
+		const data = result.data as Record<string, unknown>
+
+		expect(data.name).toBe('test')
+		expect(data.count).toBe(42)
+		expect(data.tags).toEqual(['a', 'b'])
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #1848 (Finding 2: FormData auto-parse prototype pollution)

- `normalizeFormValue` in `src/dynamic-handle.ts` and the compiled formData parser in `src/adapter/web-standard/index.ts` auto-parse form field values starting with `{` or `[` as JSON via `JSON.parse`. The parsed objects can carry `__proto__`, `constructor`, or `prototype` as enumerable own properties, creating a prototype pollution risk if downstream code merges or spreads these objects.
- After `JSON.parse`, recursively strip `__proto__`, `constructor`, and `prototype` keys from the parsed object in both the dynamic and compiled code paths.
- Added tests verifying dangerous keys are stripped from parsed JSON form values (including nested objects) while valid JSON parsing continues to work correctly.

## Test plan

- [x] New test: `test/security/formdata-prototype-pollution.test.ts` — 4 tests covering `__proto__`, `constructor`/`prototype`, nested objects, and valid JSON passthrough
- [x] Existing formdata tests pass: `bun test test/type-system/formdata.test.ts` (28/28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reinforced form data security by implementing sanitization that removes dangerous object properties from all JSON-parsed form values, ensuring protection across multiple parsing flows and file attachment scenarios.

* **Tests**
  * Added comprehensive security test suite to validate proper handling of edge cases and malicious inputs in form data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->