### PR TITLE
fix: strip prototype pollution keys from FormData JSON parsing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0 < 1",
         "@types/bun": ">= 1.2.0",
-        "exact-mirror": "^0.2.6",
+        "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -58,6 +58,15 @@ export const WebStandardAdapter: ElysiaAdapter = {
 					`const m=k.match(/^(.+)\\[(\\d+)\\]$/);` +
 					`return m?{name:m[1],index:parseInt(m[2],10)}:null` +
 					`}\n` +
+					`const stripDangerousKeys=(o)=>{` +
+					`if(o===null||typeof o!=='object')return o;` +
+					`if(Array.isArray(o))return o.map(stripDangerousKeys);` +
+					`const r={};` +
+					`for(const k of Object.keys(o)){` +
+					`if(dangerousKeys.has(k))continue;` +
+					`r[k]=stripDangerousKeys(o[k])` +
+					`}return r` +
+					`}\n` +
 					`for(const key of form.keys()){` +
 					`if(c.body[key])continue\n` +
 					`const value=form.getAll(key)\n` +
@@ -67,7 +76,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
     				`if(typeof sv==='string'&&(sv.charCodeAt(0)===123||sv.charCodeAt(0)===91)){\n` +
     				`try{\n` +
     				`const p=JSON.parse(sv)\n` +
-    				`if(p&&typeof p==='object')finalValue=p\n` +
+    				`if(p&&typeof p==='object')finalValue=stripDangerousKeys(p)\n` +
     				`}catch{}\n` +
     				`}\n` +
     				`if(finalValue===undefined)finalValue=sv\n` +
@@ -77,7 +86,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
 					`const files=typeof File==='undefined'?[]:finalValue.filter((entry)=>entry instanceof File)\n` +
 					`if(stringValue&&files.length&&stringValue.charCodeAt(0)===123){\n` +
 					`try{\n` +
-					`const parsed=JSON.parse(stringValue)\n` +
+					`const parsed=stripDangerousKeys(JSON.parse(stringValue))\n` +
 					`if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){\n` +
 					`if(!('file' in parsed)&&files.length===1)parsed.file=files[0]\n` +
 					`else if(!('files' in parsed)&&files.length>1)parsed.files=files\n` +
@@ -101,7 +110,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
 					`let parsed\n` +
 					`if(typeof existing==='string'&&existing.charCodeAt(0)===123){\n` +
 					`try{` +
-					`parsed=JSON.parse(existing)\n` +
+					`parsed=stripDangerousKeys(JSON.parse(existing))\n` +
 					`if(!parsed||typeof parsed!=='object'||Array.isArray(parsed))parsed=undefined` +
 					`}catch{}\n` +
 					`}\n` +

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -39,6 +39,22 @@ export type DynamicHandler = {
 const ARRAY_INDEX_REGEX = /^(.+)\[(\d+)\]$/
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
+/**
+ * Recursively removes prototype pollution keys (__proto__, constructor, prototype)
+ * from parsed JSON objects to prevent prototype pollution attacks via FormData.
+ */
+const stripDangerousKeys = (obj: any): any => {
+	if (obj === null || typeof obj !== 'object') return obj
+	if (Array.isArray(obj)) return obj.map(stripDangerousKeys)
+
+	const result: Record<string, any> = {}
+	for (const key of Object.keys(obj)) {
+		if (DANGEROUS_KEYS.has(key)) continue
+		result[key] = stripDangerousKeys(obj[key])
+	}
+	return result
+}
+
 const isDangerousKey = (key: string): boolean => {
 	if (DANGEROUS_KEYS.has(key)) return true
 
@@ -62,7 +78,7 @@ const parseObjectString = (entry: unknown) => {
 	try {
 		const parsed = JSON.parse(entry)
 		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-			return parsed
+			return stripDangerousKeys(parsed)
 	} catch {
 		return
 	}
@@ -132,7 +148,7 @@ const normalizeFormValue = (value: unknown[]) => {
                 try {
                     const parsed = JSON.parse(stringValue)
                     if (parsed && typeof parsed === 'object') {
-                        return parsed
+                        return stripDangerousKeys(parsed)
                     }
                 } catch {}
             }
@@ -153,7 +169,7 @@ const normalizeFormValue = (value: unknown[]) => {
 
 	let parsed: unknown
 	try {
-		parsed = JSON.parse(stringValue)
+		parsed = stripDangerousKeys(JSON.parse(stringValue))
 	} catch {
 		return value
 	}

--- a/test/core/formdata-prototype-pollution.test.ts
+++ b/test/core/formdata-prototype-pollution.test.ts
@@ -19,13 +19,14 @@ describe('FormData Prototype Pollution', () => {
 	it('strips __proto__ key from JSON-parsed FormData value', async () => {
 		const app = new Elysia().post('/', ({ body }) => body)
 
+		// Construct the JSON string manually: in an object literal `__proto__`
+		// acts as a prototype setter and `JSON.stringify` would drop it, so
+		// the encoded payload needs to be assembled by hand to actually carry
+		// the dangerous key on the wire.
 		const response = await app
 			.handle(
 				formPost('/', {
-					data: JSON.stringify({
-						safe: 'value',
-						__proto__: { polluted: true }
-					})
+					data: '{"safe":"value","__proto__":{"polluted":true}}'
 				})
 			)
 			.then((x) => x.json())
@@ -75,19 +76,12 @@ describe('FormData Prototype Pollution', () => {
 	it('strips nested dangerous keys from deeply nested JSON', async () => {
 		const app = new Elysia().post('/', ({ body }) => body)
 
+		// Raw JSON string: see note in the __proto__ test above about why
+		// `JSON.stringify` on an object literal drops the `__proto__` key.
 		const response = await app
 			.handle(
 				formPost('/', {
-					data: JSON.stringify({
-						level1: {
-							safe: 'ok',
-							__proto__: { polluted: true },
-							level2: {
-								constructor: { bad: true },
-								value: 'kept'
-							}
-						}
-					})
+					data: '{"level1":{"safe":"ok","__proto__":{"polluted":true},"level2":{"constructor":{"bad":true},"value":"kept"}}}'
 				})
 			)
 			.then((x) => x.json())
@@ -101,8 +95,20 @@ describe('FormData Prototype Pollution', () => {
 	it('skips __proto__ as a top-level FormData key', async () => {
 		const app = new Elysia().post('/', ({ body }) => body)
 
+		// Build FormData directly — `{ __proto__: 'polluted' }` in an object
+		// literal sets the prototype instead of creating an own property, so
+		// the helper would never call `FormData.append('__proto__', ...)`.
+		const body = new FormData()
+		body.append('__proto__', 'polluted')
+		body.append('safe', 'ok')
+
 		const response = await app
-			.handle(formPost('/', { __proto__: 'polluted', safe: 'ok' }))
+			.handle(
+				new Request('http://localhost/', {
+					method: 'POST',
+					body
+				})
+			)
 			.then((x) => x.json())
 
 		expect(response.safe).toBe('ok')
@@ -116,10 +122,7 @@ describe('FormData Prototype Pollution', () => {
 		const response = await app
 			.handle(
 				formPost('/', {
-					'user.profile': JSON.stringify({
-						name: 'ok',
-						__proto__: { polluted: true }
-					})
+					'user.profile': '{"name":"ok","__proto__":{"polluted":true}}'
 				})
 			)
 			.then((x) => x.json())
@@ -152,11 +155,7 @@ describe('FormData Prototype Pollution', () => {
 			.handle(
 				formPost('/', {
 					name: 'Alice',
-					metadata: JSON.stringify({
-						age: 30,
-						__proto__: { admin: true },
-						role: 'user'
-					})
+					metadata: '{"age":30,"__proto__":{"admin":true},"role":"user"}'
 				})
 			)
 			.then((x) => x.json())

--- a/test/core/formdata-prototype-pollution.test.ts
+++ b/test/core/formdata-prototype-pollution.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'bun:test'
+import { Elysia } from '../../src'
+
+/**
+ * Helper to create a multipart/form-data POST request.
+ */
+const formPost = (path: string, fields: Record<string, string>) => {
+	const body = new FormData()
+	for (const [key, value] of Object.entries(fields)) {
+		body.append(key, value)
+	}
+	return new Request(`http://localhost${path}`, {
+		method: 'POST',
+		body
+	})
+}
+
+describe('FormData Prototype Pollution', () => {
+	it('strips __proto__ key from JSON-parsed FormData value', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					data: JSON.stringify({
+						safe: 'value',
+						__proto__: { polluted: true }
+					})
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response.data).toBeDefined()
+		expect(response.data.safe).toBe('value')
+		expect(Object.prototype.hasOwnProperty.call(response.data, '__proto__')).toBe(false)
+		expect(response.data.polluted).toBeUndefined()
+	})
+
+	it('strips constructor key from JSON-parsed FormData value', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					data: JSON.stringify({
+						safe: 'value',
+						constructor: { prototype: { polluted: true } }
+					})
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response.data.safe).toBe('value')
+		expect(Object.prototype.hasOwnProperty.call(response.data, 'constructor')).toBe(false)
+	})
+
+	it('strips prototype key from JSON-parsed FormData value', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					data: JSON.stringify({
+						safe: 'value',
+						prototype: { polluted: true }
+					})
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response.data.safe).toBe('value')
+		expect(Object.prototype.hasOwnProperty.call(response.data, 'prototype')).toBe(false)
+	})
+
+	it('strips nested dangerous keys from deeply nested JSON', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					data: JSON.stringify({
+						level1: {
+							safe: 'ok',
+							__proto__: { polluted: true },
+							level2: {
+								constructor: { bad: true },
+								value: 'kept'
+							}
+						}
+					})
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response.data.level1.safe).toBe('ok')
+		expect(Object.prototype.hasOwnProperty.call(response.data.level1, '__proto__')).toBe(false)
+		expect(response.data.level1.level2.value).toBe('kept')
+		expect(Object.prototype.hasOwnProperty.call(response.data.level1.level2, 'constructor')).toBe(false)
+	})
+
+	it('skips __proto__ as a top-level FormData key', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(formPost('/', { __proto__: 'polluted', safe: 'ok' }))
+			.then((x) => x.json())
+
+		expect(response.safe).toBe('ok')
+		// Ensure Object.prototype was not polluted
+		expect(({} as any).polluted).toBeUndefined()
+	})
+
+	it('strips dangerous keys from nested key path with JSON value', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					'user.profile': JSON.stringify({
+						name: 'ok',
+						__proto__: { polluted: true }
+					})
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response.user.profile.name).toBe('ok')
+		expect(Object.prototype.hasOwnProperty.call(response.user.profile, '__proto__')).toBe(false)
+		expect(({} as any).polluted).toBeUndefined()
+	})
+
+	it('prevents prototype pollution via constructor.prototype path', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					'constructor.prototype': 'polluted'
+				})
+			)
+			.then((x) => x.json())
+
+		// The key path should be rejected since both 'constructor' and 'prototype' are dangerous
+		expect(Object.prototype.hasOwnProperty.call(response, 'constructor')).toBe(false)
+		expect(({} as any).polluted).toBeUndefined()
+	})
+
+	it('preserves safe data while stripping dangerous keys', async () => {
+		const app = new Elysia().post('/', ({ body }) => body)
+
+		const response = await app
+			.handle(
+				formPost('/', {
+					name: 'Alice',
+					metadata: JSON.stringify({
+						age: 30,
+						__proto__: { admin: true },
+						role: 'user'
+					})
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response.name).toBe('Alice')
+		expect(response.metadata.age).toBe(30)
+		expect(response.metadata.role).toBe('user')
+		expect(Object.prototype.hasOwnProperty.call(response.metadata, '__proto__')).toBe(false)
+		expect(({} as any).admin).toBeUndefined()
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #1848 — FormData auto-parse prototype pollution.

This replaces #1849 (which was auto-closed when the fork was deleted) and addresses the gap identified in the CodeRabbit review: the nested key path parsing code was calling `JSON.parse` on intermediate values without stripping dangerous keys.

### Changes

- Added a `stripDangerousKeys` function that recursively removes `__proto__`, `constructor`, and `prototype` keys from parsed objects
- Applied `stripDangerousKeys` to **all** `JSON.parse` results in FormData processing:
  - `normalizeFormValue` in `src/dynamic-handle.ts` (single-value JSON parse and file+JSON mixed parse)
  - `parseObjectString` in `src/dynamic-handle.ts` (nested key path intermediate object parsing)
  - All three `JSON.parse` call sites in the inlined `formData` parser in `src/adapter/web-standard/index.ts` — including the nested key path `JSON.parse(existing)` that the review flagged
- Added comprehensive tests covering `__proto__`, `constructor`, `prototype` stripping at top-level, nested, and deeply nested JSON, as well as nested key path (`user.profile`) and dangerous key path (`constructor.prototype`) scenarios

### Test plan

- All 8 new tests in `test/core/formdata-prototype-pollution.test.ts` pass
- Existing `test/core/formdata.test.ts` tests continue to pass (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form-data and JSON parsing to strip unsafe prototype-related keys from incoming values, preventing prototype-pollution from crafted inputs.

* **Tests**
  * Added end-to-end tests validating protection against prototype pollution across single fields, nested structures, arrays, dotted/bracket paths, and deep JSON payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->