### PR TITLE
Fix macro resolve returning a union collapsing to never

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -951,15 +951,30 @@ type _FunctionArrayReturnTypeNonNullable<T, Carry = undefined> = T extends [
 		>
 	: Carry
 
+// Flatten a union of objects into one object that unions their values
+// per key. `MacroToContext` later runs `UnionToIntersect` on each key to
+// merge contributions from different macros; without this step a single
+// macro whose resolve returns `{user: A} | {user: B}` would intersect to
+// `{user: A & B}` and collapse to `never` for disjoint A and B. See #1773.
+type UnionToSharedKeyObject<A> = [A] extends [never]
+	? {}
+	: {
+			[K in A extends unknown ? keyof A : never]: A extends unknown
+				? K extends keyof A
+					? A[K]
+					: never
+				: never
+		}
+
 type ExtractResolveFromMacro<A> =
 	IsNever<A> extends true
 		? {}
-		: A extends AnyElysiaCustomStatusResponse
+		: [A] extends [AnyElysiaCustomStatusResponse]
 			? A
 			: Exclude<A, AnyElysiaCustomStatusResponse> extends infer A
 				? IsAny<A> extends true
 					? {}
-					: A
+					: UnionToSharedKeyObject<A>
 				: {}
 
 type ExtractOnlyResponseFromMacro<A> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -966,16 +966,14 @@ type UnionToSharedKeyObject<A> = [A] extends [never]
 				: never
 		}
 
-type ExtractResolveFromMacro<A> =
-	IsNever<A> extends true
+// Caller already filters `AnyElysiaCustomStatusResponse` out via `Exclude`
+// and narrows to `Record<any, unknown>` via `Extract`, so here `A` is only
+// the object-returning branches of the resolve return type.
+type ExtractResolveFromMacro<A> = IsNever<A> extends true
+	? {}
+	: IsAny<A> extends true
 		? {}
-		: [A] extends [AnyElysiaCustomStatusResponse]
-			? A
-			: Exclude<A, AnyElysiaCustomStatusResponse> extends infer A
-				? IsAny<A> extends true
-					? {}
-					: UnionToSharedKeyObject<A>
-				: {}
+		: UnionToSharedKeyObject<A>
 
 type ExtractOnlyResponseFromMacro<A> =
 	IsNever<A> extends true

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -256,17 +256,18 @@ import { expectTypeOf } from 'expect-type'
 	type License = { kind: 'license'; did: string }
 	type Admin = { kind: 'admin'; role: string }
 
+	const license = null as License | null
+	const admin = null as Admin | null
+
 	new Elysia()
 		.macro({
 			isLicenseOrAdmin: {
 				async resolve({ status }) {
 					if (Math.random() > 0.5) {
-						const license: License | null = null as any
 						if (!license) return status(401, 'Invalid License')
 						return { user: license }
 					}
 
-					const admin: Admin | null = null as any
 					if (admin) return { user: admin }
 
 					return status(401, 'Not Authorized')

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -250,6 +250,40 @@ import { expectTypeOf } from 'expect-type'
 		})
 }
 
+// #1773: resolve branches that return the same key with different shapes
+// should surface a union on that key, not collapse to `never`.
+{
+	type License = { kind: 'license'; did: string }
+	type Admin = { kind: 'admin'; role: string }
+
+	new Elysia()
+		.macro({
+			isLicenseOrAdmin: {
+				async resolve({ status }) {
+					if (Math.random() > 0.5) {
+						const license: License | null = null as any
+						if (!license) return status(401, 'Invalid License')
+						return { user: license }
+					}
+
+					const admin: Admin | null = null as any
+					if (admin) return { user: admin }
+
+					return status(401, 'Not Authorized')
+				}
+			}
+		})
+		.get(
+			'/',
+			({ user }) => {
+				expectTypeOf(user).toEqualTypeOf<License | Admin>()
+			},
+			{
+				isLicenseOrAdmin: true
+			}
+		)
+}
+
 // retrieve resolve conditionally
 const app = new Elysia()
 	.macro({


### PR DESCRIPTION
resolves #1851 

## Problem

When a macro's `resolve` returns the same key with different shapes across branches, that key ends up as `never` on the handler instead of a union of the branch types.

```ts
const auth = new Elysia().macro({
  isLicenseOrAdmin: {
    async resolve({ status, headers }) {
      const license = await verifyLicense(headers.authorization)
      if (license) return { user: license }            // { user: License }

      const admin = await verifyAdmin(headers.authorization)
      if (admin) return { user: admin }                // { user: Admin }

      return status(401)
    }
  }
})

new Elysia().use(auth).get('/', ({ user }) => {
  // Expected: License | Admin
  // Actual:   never
})
```

## Root Cause

`MacroToContext` in `src/types.ts` runs `UnionToIntersect<A[K]>` on each context key to merge contributions from multiple selected macros, so that macro A adding `{ user: ... }` and macro B adding `{ admin: ... }` combine into `{ user, admin }`.

This intersection is applied after `ExtractResolveFromMacro` has already produced the resolve return type. When one macro's resolve returns a union of objects sharing a key, the same intersection turns `{ user: License } | { user: Admin }` into `{ user: License & Admin }`, which collapses to `never` for disjoint `License` and `Admin`.

## Fix

Flatten the resolve union into a single object keyed by its shared properties before the outer intersection runs. Cross-macro merging still works the same way, but a within-macro union on the same key is now preserved as a value-level union.

Also wraps the `AnyElysiaCustomStatusResponse` check in `[A] extends [...]` so the conditional does not distribute over the input union and skip the flattening step for some branches.

## Tests

- Added a regression case in `test/types/macro.ts` covering a resolve that returns two disjoint object shapes plus status branches, asserting the handler sees `License | Admin` on `user`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Macro type inference now preserves union-typed object fields across different branches, preventing incorrect collapse to `never` and ensuring handler parameters reflect the proper union types.

* **Tests**
  * Added type-level tests that verify macro resolve branches produce correct union inferences for shared object keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->