### PR TITLE
fix: encode stream chunks as Uint8Array for runtime compatibility

### DIFF
--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -213,6 +213,8 @@ interface CreateHandlerParameter {
 	mapCompactResponse(response: unknown, request?: Request): Response
 }
 
+const encoder = new TextEncoder()
+
 const enqueueBinaryChunk = (
 	controller: ReadableStreamDefaultController,
 	chunk: unknown
@@ -345,17 +347,17 @@ export const createStreamHandler =
 					// @ts-ignore
 					if (init.value.toSSE)
 						// @ts-ignore
-						controller.enqueue(init.value.toSSE())
+						controller.enqueue(encoder.encode(init.value.toSSE()))
 					else if (enqueueBinaryChunk(controller, init.value)) return
 					else if (typeof init.value === 'object')
 						try {
 							controller.enqueue(
-								format(JSON.stringify(init.value))
+								encoder.encode(format(JSON.stringify(init.value)))
 							)
 						} catch {
-							controller.enqueue(format(init.value.toString()))
+							controller.enqueue(encoder.encode(format(init.value.toString())))
 						}
-					else controller.enqueue(format(init.value.toString()))
+					else controller.enqueue(encoder.encode(format(init.value.toString())))
 				},
 
 				async pull(controller) {
@@ -384,17 +386,17 @@ export const createStreamHandler =
 						// @ts-ignore
 						if (chunk.toSSE)
 							// @ts-ignore
-							controller.enqueue(chunk.toSSE())
+							controller.enqueue(encoder.encode(chunk.toSSE()))
 						else if (enqueueBinaryChunk(controller, chunk)) return
 						else if (typeof chunk === 'object')
 							try {
 								controller.enqueue(
-									format(JSON.stringify(chunk))
+									encoder.encode(format(JSON.stringify(chunk)))
 								)
 							} catch {
-								controller.enqueue(format(chunk.toString()))
+								controller.enqueue(encoder.encode(format(chunk.toString())))
 							}
-						else controller.enqueue(format(chunk.toString()))
+						else controller.enqueue(encoder.encode(format(chunk.toString())))
 					} catch (error) {
 						console.warn(error)
 

--- a/test/response/stream.test.ts
+++ b/test/response/stream.test.ts
@@ -6,6 +6,10 @@ import { streamResponse } from '../../src/adapter/utils'
 import { randomId } from '../../src/utils'
 
 describe('Stream', () => {
+	const decoder = new TextDecoder()
+	const decode = (v: unknown) =>
+		v instanceof Uint8Array ? decoder.decode(v) : String(v)
+
 	it('handle stream', async () => {
 		const expected = ['a', 'b', 'c']
 
@@ -33,9 +37,9 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve(acc)
 
-					expect(value.toString()).toBe(expected.shift()!)
+					expect(decode(value)).toBe(expected.shift()!)
 
-					acc += value.toString()
+					acc += decode(value)
 					return reader.read().then(pump)
 				})
 
@@ -83,9 +87,9 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve(acc)
 
-					expect(value.toString()).toBe(expected.shift()!)
+					expect(decode(value)).toBe(expected.shift()!)
 
-					acc += value.toString()
+					acc += decode(value)
 					return reader.read().then(pump)
 				})
 
@@ -242,7 +246,7 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve()
 
-					expect(value.toString()).toBe(JSON.stringify(expected[i++]))
+					expect(decode(value)).toBe(JSON.stringify(expected[i++]))
 
 					return reader.read().then(pump)
 				})
@@ -280,7 +284,7 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve()
 
-					expect(value.toString()).toBe(expected[i++])
+					expect(decode(value)).toBe(expected[i++])
 
 					return reader.read().then(pump)
 				})
@@ -314,7 +318,7 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve(acc)
 
-					acc += value.toString()
+					acc += decode(value)
 					return reader.read().then(pump)
 				})
 
@@ -361,7 +365,7 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve(acc)
 
-					acc += value.toString()
+					acc += decode(value)
 					return reader.read().then(pump)
 				})
 
@@ -408,7 +412,7 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve(acc)
 
-					acc += value.toString()
+					acc += decode(value)
 					return reader.read().then(pump)
 				})
 
@@ -443,7 +447,7 @@ describe('Stream', () => {
 				reader.read().then(function pump({ done, value }): unknown {
 					if (done) return resolve(acc)
 
-					acc += value.toString()
+					acc += decode(value)
 					return reader.read().then(pump)
 				})
 


### PR DESCRIPTION
Fixes #1845.

\`ReadableStream\` controllers are required by the spec to receive \`BufferSource\` chunks (\`Uint8Array\`, \`ArrayBuffer\`, etc.). Bun accepts raw strings as a convenience extension, but spec-strict runtimes like Deno silently drop string chunks, causing generators and SSE to produce empty responses.

## Root cause

\`createStreamHandler\` in \`src/adapter/utils.ts\` enqueued strings directly in both the \`start()\` and \`pull()\` callbacks: 8 call sites in total.

## Fix

Added a module-scope \`TextEncoder\` singleton (matching the existing pattern in \`src/universal/request.ts\`) and wrapped all 8 string enqueue calls with \`encoder.encode()\`. Binary paths through \`enqueueBinaryChunk\` are unchanged; they already produce \`Uint8Array\`.

## Tests

The existing stream tests read chunks via \`getReader()\` and compared with \`.toString()\`, which returns decimal byte notation for \`Uint8Array\` (e.g., \`"97"\` instead of \`"a"\`). Updated 6 tests with a \`decode\` helper that uses \`TextDecoder\` when the chunk is \`Uint8Array\`.

30/30 stream tests pass. Full suite: 1524 pass, 1 pre-existing fail in \`test/sucrose/integration.test.ts\` (spawns a Bun subprocess, exits 127 in WSL because the Bun binary on PATH is the Windows executable; unrelated to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent encoding of streamed textual outputs so all text-based stream formats (SSE, JSON, plain text) are transmitted reliably as binary-encoded chunks.

* **Tests**
  * Updated stream tests to normalize and assert decoded chunk contents, validating consistent behavior across different response types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->