### PR TITLE
Fix TypeError on invalid cookie signature - Issue 1861

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -710,6 +710,8 @@ export const unsignCookie = async (input: string, secret: string | null) => {
 		return false
 	}
 
+	if (secret === null) return false
+
 	const tentativeValue = input.slice(0, dot)
 	const expectedInput = await signCookie(tentativeValue, secret)
 

--- a/test/validator/cookie.test.ts
+++ b/test/validator/cookie.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { Elysia, t } from '../../src'
+import { signCookie } from '../../src/utils'
 import { req } from '../utils'
 
 describe('Cookie Validation', () => {
@@ -637,6 +638,77 @@ describe('Cookie Validation', () => {
 		)
 
 		expect(second.status).toBe(200)
+	})
+
+	it('handle invalid signed cookie during unsigned transition', async () => {
+		const app = new Elysia({
+			cookie: {
+				secrets: ['1234567890', null],
+				sign: 'wizard'
+			}
+		})
+			.onError(({ code, error, set }) => {
+				if (code !== 'INVALID_COOKIE_SIGNATURE') return
+
+				set.status = 400
+
+				return {
+					type: 'invalid_cookie_signature',
+					message: error.message
+				}
+			})
+			.get('/', ({ cookie: { wizard } }) => wizard.value ?? 'empty', {
+				cookie: t.Cookie({
+					wizard: t.Optional(
+						t.Union([
+							t.Literal('1'),
+							t.Literal('2'),
+							t.Literal('3')
+						])
+					)
+				})
+			})
+
+		const signed = await signCookie('1', '1234567890')
+
+		const [unsigned, valid, invalid] = await Promise.all([
+			app.handle(
+				req('/', {
+					headers: {
+						cookie: 'wizard=1'
+					}
+				})
+			),
+			app.handle(
+				req('/', {
+					headers: {
+						cookie: `wizard=${signed}`
+					}
+				})
+			),
+			app.handle(
+				req('/', {
+					headers: {
+						cookie: 'wizard=1.invalid_sign'
+					}
+				})
+			)
+		])
+
+		expect(unsigned.status).toBe(200)
+		expect(await unsigned.text()).toBe('1')
+
+		expect(valid.status).toBe(200)
+		expect(await valid.text()).toBe('1')
+
+		expect(invalid.status).toBe(400)
+		expect(invalid.headers.get('content-type')).toBe(
+			'application/json;charset=utf-8'
+		)
+		expect(await invalid.json()).toEqual({
+			type: 'invalid_cookie_signature',
+			message: '"wizard" has invalid cookie signature'
+		})
 	})
 
 	it('handle prototype pollution', () => {


### PR DESCRIPTION
**#1861**  -> This issue involved transitioning an unsigned cookie to signed cookie was resulting in type error if the cookie was corrupted. This edge case led to function `unsignCookie()` trying every configured secret. When it reached the null transition entry, the cookie already contained a signature separator (`.`), so the unsigned fallback should have rejected it. Instead, it called
function `signCookie(value, null)` , which threw: TypeError: Secret key must be provided.

### Fix

1. This is now handled by function `unsignCookie()`, where null only accepts cookies with no signature separator. If the cookie contains a dot and the current secret is null, it now returns false, allowing the caller to continue checking other secrets or throw status **InvalidCookieSignature**. This preserves unsigned-to-signed transition behavior while ensuring corrupted signed cookies are reported as **INVALID_COOKIE_SIGNATURE**.
2. New Cookie Validation test ensures proper edge case test for:

```
secrets: ['1234567890', null],
sign: 'wizard'
```

Then it checks all three relevant inputs:

`cookie: 'wizard=1'`

Confirms `null` still allows unsigned transition cookies.

`cookie: `wizard=${signed}``

Confirms normal signed cookies still work.

`cookie: 'wizard=1.invalid_sign'`

Confirms the broken case no longer reaches function signCookie(..., null) and no longer becomes `TypeError: Secret key must be provided`

### Results
The test confirms that for this edge case, instead of returning the Type Error; it returns **400** through **INVALID_COOKIE_SIGNATURE** as JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cookie signature validation to properly handle edge cases where secrets are unavailable, ensuring invalid signatures are correctly rejected.

* **Tests**
  * Added tests validating cookie signature validation behavior across unsigned and signed cookie scenarios, including proper error responses for invalid signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->