### PR TITLE
fix(types): infer onError plain returns as error responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,11 @@ import type {
 	StandardSchemaV1Like,
 	ElysiaHandlerToResponseSchema,
 	ElysiaHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -162,7 +165,7 @@ import type {
 	UnknownRouteSchema,
 	MaybeFunction,
 	InlineHandlerNonMacro,
-	Router,
+	Router
 } from './types'
 import {
 	coercePrimitiveRoot,
@@ -3179,7 +3182,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3232,7 +3235,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3322,7 +3325,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3343,7 +3346,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3362,7 +3365,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3452,7 +3455,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3473,7 +3476,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3492,7 +3495,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3964,7 +3967,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4214,7 +4217,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4253,7 +4256,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4289,7 +4292,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4323,7 +4326,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4360,7 +4363,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4394,7 +4397,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4468,7 +4471,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4703,7 +4706,12 @@ export default class Elysia<
 						} = hook
 
 						const hasStandaloneSchema =
-							body || headers || query || params || cookie || response
+							body ||
+							headers ||
+							query ||
+							params ||
+							cookie ||
+							response
 
 						const startIndex = processedUntil
 						processedUntil = instance.router.history.length
@@ -4731,11 +4739,13 @@ export default class Elysia<
 										: Array.isArray(localHook.error)
 											? [
 													...(localHook.error ?? []),
-													...(sandbox.event.error ?? [])
+													...(sandbox.event.error ??
+														[])
 												]
 											: [
 													localHook.error,
-													...(sandbox.event.error ?? [])
+													...(sandbox.event.error ??
+														[])
 												],
 									standaloneValidator: !hasStandaloneSchema
 										? localHook.standaloneValidator

--- a/src/types.ts
+++ b/src/types.ts
@@ -1017,24 +1017,27 @@ type ExtractAllResponseFromMacro<A> =
 			}
 
 type ExtractAllErrorResponseFromMacro<A> =
-	IsNever<A> extends true
-		? {}
-		: {
-				return: MergeResponseStatus<A> &
-					(Exclude<A, AnyElysiaCustomStatusResponse> extends infer A
-						? IsAny<A> extends true
-							? {}
-							: IsNever<A> extends true
-								? {}
-								: NonNullable<void> extends A
+	Exclude<A, undefined | void> extends infer A
+		? IsAny<A> extends true
+			? {}
+			: IsNever<A> extends true
+				? {}
+				: {
+						return: MergeResponseStatus<A> &
+							(Exclude<
+								A,
+								AnyElysiaCustomStatusResponse
+							> extends infer A
+								? IsAny<A> extends true
 									? {}
-									: undefined extends A
+									: IsNever<A> extends true
 										? {}
 										: {
 												500: A
 											}
-						: {})
-			}
+								: {})
+					}
+		: {}
 
 type FlattenMacroResponse<T> = T extends object
 	? '_' extends keyof T
@@ -2212,14 +2215,16 @@ export type ValueToResponseSchema<Value> = ExtractErrorFromHandle<Value> &
 				: { 200: R200 }
 		: {})
 
-export type ValueToErrorResponseSchema<Value> = ExtractErrorFromHandle<Value> &
-	(Exclude<Value, AnyElysiaCustomStatusResponse> extends infer RError
+export type ValueToErrorResponseSchema<Value> = UnionResponseStatus<
+	ExtractErrorFromHandle<Value>,
+	Exclude<Value, AnyElysiaCustomStatusResponse> extends infer RError
 		? undefined extends RError
 			? {}
 			: IsNever<RError> extends true
 				? {}
 				: { 500: RError }
-		: {})
+		: {}
+>
 
 export type ValueOrFunctionToResponseSchema<T> = T extends (
 	...a: any
@@ -2249,7 +2254,7 @@ export type ElysiaHandlerToResponseSchemas<
 export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
 	Prettify<
 		Handle extends (...a: any) => MaybePromise<infer R>
-			? ValueToErrorResponseSchema<Exclude<R, undefined>>
+			? ValueToErrorResponseSchema<Exclude<R, undefined | void>>
 			: {}
 	>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1016,6 +1016,26 @@ type ExtractAllResponseFromMacro<A> =
 						: {})
 			}
 
+type ExtractAllErrorResponseFromMacro<A> =
+	IsNever<A> extends true
+		? {}
+		: {
+				return: MergeResponseStatus<A> &
+					(Exclude<A, AnyElysiaCustomStatusResponse> extends infer A
+						? IsAny<A> extends true
+							? {}
+							: IsNever<A> extends true
+								? {}
+								: NonNullable<void> extends A
+									? {}
+									: undefined extends A
+										? {}
+										: {
+												500: A
+											}
+						: {})
+			}
+
 type FlattenMacroResponse<T> = T extends object
 	? '_' extends keyof T
 		? MergeFlattenMacroResponse<
@@ -1108,7 +1128,7 @@ type InnerMacroToContext<
 										Value['afterHandle']
 									>
 								> &
-								ExtractAllResponseFromMacro<
+								ExtractAllErrorResponseFromMacro<
 									// @ts-expect-error type is checked in key mapping
 									FunctionArrayReturnType<Value['error']>
 								> &
@@ -2192,6 +2212,15 @@ export type ValueToResponseSchema<Value> = ExtractErrorFromHandle<Value> &
 				: { 200: R200 }
 		: {})
 
+export type ValueToErrorResponseSchema<Value> = ExtractErrorFromHandle<Value> &
+	(Exclude<Value, AnyElysiaCustomStatusResponse> extends infer RError
+		? undefined extends RError
+			? {}
+			: IsNever<RError> extends true
+				? {}
+				: { 500: RError }
+		: {})
+
 export type ValueOrFunctionToResponseSchema<T> = T extends (
 	...a: any
 ) => MaybePromise<infer R>
@@ -2217,6 +2246,28 @@ export type ElysiaHandlerToResponseSchemas<
 		>
 	: Prettify<Carry>
 
+export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
+	Prettify<
+		Handle extends (...a: any) => MaybePromise<infer R>
+			? ValueToErrorResponseSchema<Exclude<R, undefined>>
+			: {}
+	>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			// @ts-ignore trust me bro
+			UnionResponseStatus<
+				ElysiaErrorHandlerToResponseSchema<Current & Function>,
+				Carry
+			>
+		>
+	: Prettify<Carry>
+
 export type ElysiaHandlerToResponseSchemaAmbiguous<
 	Schemas extends MaybeArray<Function>
 > =
@@ -2226,6 +2277,17 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 			? ElysiaHandlerToResponseSchema<Schemas>
 			: Schemas extends Function[]
 				? ElysiaHandlerToResponseSchemas<Schemas>
+				: {}
+
+export type ElysiaErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ElysiaErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ElysiaErrorHandlerToResponseSchemas<Schemas>
 				: {}
 
 type ReconcileStatus<

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1352,6 +1352,30 @@ const a = app
 	}>()
 }
 
+// ? onError plain return type should be exposed on error status
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			Math.random() > 0.5
+				? status(404, { reason: 'missing' as const })
+				: { failure: 'maintenance' as const }
+		)
+		.get('/', () => 'ok')
+
+	type Actual = (typeof app)['~Routes']['get']['response']
+	type Expected = {
+		200: string
+		404: {
+			reason: 'missing'
+		}
+		500: {
+			failure: 'maintenance'
+		}
+	}
+	expectTypeOf<Actual>().toMatchTypeOf<Expected>()
+	expectTypeOf<Expected>().toMatchTypeOf<Actual>()
+}
+
 app.get('/', ({ set }) => {
 	// ? Able to set literal type to set.status
 	set.status = "I'm a teapot"

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1376,6 +1376,31 @@ const a = app
 	expectTypeOf<Expected>().toMatchTypeOf<Actual>()
 }
 
+// ? onError explicit and inferred 500 responses should be unions
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			Math.random() > 0.5
+				? status(500, { explicit: 'server' as const })
+				: { failure: 'maintenance' as const }
+		)
+		.get('/', () => 'ok')
+
+	type Actual = (typeof app)['~Routes']['get']['response']
+	type Expected = {
+		200: string
+		500:
+			| {
+					explicit: 'server'
+			  }
+			| {
+					failure: 'maintenance'
+			  }
+	}
+	expectTypeOf<Actual>().toMatchTypeOf<Expected>()
+	expectTypeOf<Expected>().toMatchTypeOf<Actual>()
+}
+
 app.get('/', ({ set }) => {
 	// ? Able to set literal type to set.status
 	set.status = "I'm a teapot"

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1007,10 +1007,10 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1028,10 +1028,10 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1049,10 +1049,10 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -741,6 +741,35 @@ import { Prettify } from '../../../src/types'
 	}>()
 }
 
+// Macro should extract plain error array response on error status
+{
+	const app = new Elysia()
+		.macro({
+			a: {
+				error: [
+					() => ({ macroError: 'nope' as const }),
+					({ status }) =>
+						status(409, { explicit: 'conflict' as const })
+				]
+			}
+		})
+		.guard({
+			a: true
+		})
+
+	type Actual = Prettify<(typeof app)['~Volatile']['response']>
+	type Expected = {
+		409: {
+			explicit: 'conflict'
+		}
+		500: {
+			macroError: 'nope'
+		}
+	}
+	expectTypeOf<Actual>().toMatchTypeOf<Expected>()
+	expectTypeOf<Expected>().toMatchTypeOf<Actual>()
+}
+
 // Guard should cast to scoped
 {
 	const app = new Elysia()


### PR DESCRIPTION
Fixes #313
@algora-pbc /claim #313

## Summary
- infer plain non-status values returned from `onError` under `500` instead of route success `200`
- preserve explicit `status(...)` responses from `onError` at their declared status codes
- apply the same error-response extraction to guard and macro error hooks

## Tests
- `node node_modules/typescript/bin/tsc --project tsconfig.test.json`
- `bun test test/core/handle-error.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type inference and accuracy for error handler responses throughout the framework's type system, ensuring more precise response type definitions when using error handlers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1875)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->