### PR TITLE
security: prevent code injection via schema default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+Bug fix:
+- [#1864](https://github.com/elysiajs/elysia/issues/1864) prevent arbitrary code execution via schema default values for query/headers/params/body (mirrors the cookie hardening from GHSA-8vch-m3f4-q8jf)
+
 # 1.4.28 - 17 Mar 2025
 Feature:
 - [#1803](https://github.com/elysiajs/elysia/pull/1803) stream response with pull based backpressure

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1407,14 +1407,13 @@ export const composeHandler = ({
 					if (!isNotEmpty(value)) value = undefined
 				}
 
-				const parsed =
-					typeof value === 'object'
-						? JSON.stringify(value)
-						: typeof value === 'string'
-							? `'${value}'`
-							: value
+				const parsed = stringifyDefault(value)
 
-				if (value !== undefined && value !== null) {
+				if (
+					value !== undefined &&
+					value !== null &&
+					parsed !== undefined
+				) {
 					if (Array.isArray(value))
 						fnLiteral += `if(!c.body)c.body=${parsed}\n`
 					else if (typeof value === 'object')

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1238,14 +1238,16 @@ export const composeHandler = ({
 					) as Object
 				)) {
 					const parsed =
-						typeof value === 'object'
-							? JSON.stringify(value)
-							: typeof value === 'string'
-								? `'${value}'`
-								: value
+						value instanceof Date
+							? `new Date(${value.getTime()})`
+							: typeof value === 'object'
+								? JSON.stringify(value)
+								: typeof value === 'string'
+									? JSON.stringify(value)
+									: value
 
 					if (parsed !== undefined)
-						fnLiteral += `c.headers['${key}']??=${parsed}\n`
+						fnLiteral += `c.headers[${JSON.stringify(key)}]??=${parsed}\n`
 				}
 
 			fnLiteral += composeCleaner({

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1332,14 +1332,18 @@ export const composeHandler = ({
 					) as Object
 				)) {
 					const parsed =
-						typeof value === 'object'
-							? JSON.stringify(value)
-							: typeof value === 'string'
-								? `'${value}'`
-								: value
+						value instanceof Date
+							? `new Date(${value.getTime()})`
+							: typeof value === 'object'
+								? JSON.stringify(value)
+								: typeof value === 'string'
+									? JSON.stringify(value)
+									: value
 
-					if (parsed !== undefined)
-						fnLiteral += `if(c.query['${key}']===undefined)c.query['${key}']=${parsed}\n`
+					if (parsed !== undefined) {
+						const accessor = `c.query[${JSON.stringify(key)}]`
+						fnLiteral += `if(${accessor}===undefined)${accessor}=${parsed}\n`
+					}
 				}
 
 			fnLiteral += composeCleaner({

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1286,15 +1286,10 @@ export const composeHandler = ({
 						{}
 					) as Object
 				)) {
-					const parsed =
-						typeof value === 'object'
-							? JSON.stringify(value)
-							: typeof value === 'string'
-								? `'${value}'`
-								: value
+					const parsed = stringifyDefault(value)
 
 					if (parsed !== undefined)
-						fnLiteral += `c.params['${key}']??=${parsed}\n`
+						fnLiteral += `c.params[${JSON.stringify(key)}]??=${parsed}\n`
 				}
 
 			if (validator.params.provider === 'standard') {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -26,7 +26,8 @@ import {
 	isNotEmpty,
 	encodePath,
 	mergeCookie,
-	getResponseLength
+	getResponseLength,
+	stringifyDefault
 } from './utils'
 import { isBun } from './universal/utils'
 import { ParseError, status } from './error'
@@ -1237,14 +1238,7 @@ export const composeHandler = ({
 						{}
 					) as Object
 				)) {
-					const parsed =
-						value instanceof Date
-							? `new Date(${value.getTime()})`
-							: typeof value === 'object'
-								? JSON.stringify(value)
-								: typeof value === 'string'
-									? JSON.stringify(value)
-									: value
+					const parsed = stringifyDefault(value)
 
 					if (parsed !== undefined)
 						fnLiteral += `c.headers[${JSON.stringify(key)}]??=${parsed}\n`
@@ -1333,14 +1327,7 @@ export const composeHandler = ({
 						{}
 					) as Object
 				)) {
-					const parsed =
-						value instanceof Date
-							? `new Date(${value.getTime()})`
-							: typeof value === 'object'
-								? JSON.stringify(value)
-								: typeof value === 'string'
-									? JSON.stringify(value)
-									: value
+					const parsed = stringifyDefault(value)
 
 					if (parsed !== undefined) {
 						const accessor = `c.query[${JSON.stringify(key)}]`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,24 @@ export const replaceUrlPath = (url: string, pathname: string) => {
 	return `${url.slice(0, pathStartIndex)}${pathname.charCodeAt(0) === 47 ? '' : '/'}${pathname}${url.slice(queryIndex)}`
 }
 
+// Render a schema default value as a JavaScript literal safe to embed in
+// AOT-generated handler source. Strings and objects are escaped via
+// JSON.stringify; Date instances round-trip through `new Date(...)` so
+// handlers still receive a real Date. Mirrors the cookie codegen pattern
+// hardened by GHSA-8vch-m3f4-q8jf.
+export const stringifyDefault = (value: unknown): string | undefined => {
+	if (value === undefined) return undefined
+	if (value === null) return 'null'
+	if (value instanceof Date) return `new Date(${value.getTime()})`
+	if (typeof value === 'string') return JSON.stringify(value)
+	if (typeof value === 'number' || typeof value === 'boolean')
+		return String(value)
+	if (typeof value === 'object') return JSON.stringify(value)
+	throw new TypeError(
+		`Unsupported schema default value type: ${typeof value}`
+	)
+}
+
 export const isClass = (v: Object) =>
 	(typeof v === 'function' && /^\s*class\s+/.test(v.toString())) ||
 	// Handle Object.create(null)

--- a/test/validator/security.test.ts
+++ b/test/validator/security.test.ts
@@ -1,0 +1,25 @@
+import { Elysia, t } from '../../src'
+
+import { describe, expect, it } from 'bun:test'
+import { req } from '../utils'
+
+describe('Validator Security', () => {
+	it('handle arbitrary code execution from query default', async () => {
+		const app = new Elysia().get(
+			'/',
+			// @ts-ignore
+			(c) => c.q ?? 'safe',
+			{
+				query: t.Object({
+					foo: t.String({
+						default: `';console.log(c.q='pwn');'`
+					})
+				})
+			}
+		)
+
+		const response = await app.handle(req('/')).then((x) => x.text())
+
+		expect(response).toBe('safe')
+	})
+})

--- a/test/validator/security.test.ts
+++ b/test/validator/security.test.ts
@@ -22,4 +22,23 @@ describe('Validator Security', () => {
 
 		expect(response).toBe('safe')
 	})
+
+	it('handle arbitrary code execution from headers default', async () => {
+		const app = new Elysia().get(
+			'/',
+			// @ts-ignore
+			(c) => c.q ?? 'safe',
+			{
+				headers: t.Object({
+					'x-foo': t.String({
+						default: `';console.log(c.q='pwn');'`
+					})
+				})
+			}
+		)
+
+		const response = await app.handle(req('/')).then((x) => x.text())
+
+		expect(response).toBe('safe')
+	})
 })

--- a/test/validator/security.test.ts
+++ b/test/validator/security.test.ts
@@ -41,4 +41,24 @@ describe('Validator Security', () => {
 
 		expect(response).toBe('safe')
 	})
+
+	it('handle arbitrary code execution from params default', async () => {
+		const app = new Elysia().get(
+			'/:id',
+			// @ts-ignore
+			(c) => c.q ?? 'safe',
+			{
+				params: t.Object({
+					id: t.String(),
+					filter: t.String({
+						default: `';console.log(c.q='pwn');'`
+					})
+				})
+			}
+		)
+
+		const response = await app.handle(req('/abc')).then((x) => x.text())
+
+		expect(response).toBe('safe')
+	})
 })

--- a/test/validator/security.test.ts
+++ b/test/validator/security.test.ts
@@ -61,4 +61,50 @@ describe('Validator Security', () => {
 
 		expect(response).toBe('safe')
 	})
+
+	it('handle arbitrary code execution from body string default', async () => {
+		const app = new Elysia().post(
+			'/',
+			// @ts-ignore
+			(c) => c.q ?? 'safe',
+			{
+				body: t.String({
+					default: `';console.log(c.q='pwn');'`
+				})
+			}
+		)
+
+		const response = await app
+			.handle(new Request('http://localhost/', { method: 'POST' }))
+			.then((x) => x.text())
+
+		expect(response).toBe('safe')
+	})
+
+	it('handle arbitrary code execution from body object default value', async () => {
+		const app = new Elysia().post(
+			'/',
+			// @ts-ignore
+			(c) => c.q ?? 'safe',
+			{
+				body: t.Object({
+					field: t.String({
+						default: `';console.log(c.q='pwn');'`
+					})
+				})
+			}
+		)
+
+		const response = await app
+			.handle(
+				new Request('http://localhost/', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({})
+				})
+			)
+			.then((x) => x.text())
+
+		expect(response).toBe('safe')
+	})
 })


### PR DESCRIPTION
Fixes #1864

## Summary
Fix arbitrary code execution via schema default values for `query`, `headers`, `params`, and `body` schemas. Mirrors the cookie hardening from [GHSA-8vch-m3f4-q8jf](https://github.com/elysiajs/elysia/security/advisories/GHSA-8vch-m3f4-q8jf), which left these four entry points untouched.

## Problem
Schema default values are interpolated into the AOT-generated handler source by `composeHandler` in `src/compose.ts`. For string defaults, the codegen wraps the raw value in single quotes:

```ts
const parsed =
    typeof value === 'object'
        ? JSON.stringify(value)
        : typeof value === 'string'
            ? `'${value}'`      // ← unsanitized interpolation
            : value

fnLiteral += `if(c.query['${key}']===undefined)c.query['${key}']=${parsed}\n`
```

When a default contains a single quote, the surrounding string literal is closed early and the rest of the value becomes executable code inside the `Function(...)` body produced at boot. This is the same class of bug fixed for `cookie` in GHSA-8vch-m3f4-q8jf — the codegen blocks for `query`, `headers`, `params`, and `body` were not patched in that advisory and remain vulnerable.

### Affected entry points

| Entry point | Location | Vulnerable interpolation |
|---|---|---|
| Query | `src/compose.ts:1325-1343` | `'${value}'` and `'${key}'` |
| Headers | `src/compose.ts:1230-1249` | same |
| Params | `src/compose.ts:1284-1302` | same |
| Body (string defaults) | `src/compose.ts:1387-1435` | same |

The dynamic-handle path (`src/dynamic-handle.ts:171-185`, `injectDefaultValues`) does a direct property assignment at runtime and is not vulnerable.

## Solution
Extract a `stringifyDefault(value: unknown)` helper in `src/utils.ts` that renders a schema default value as a safe JavaScript literal:

```ts
export const stringifyDefault = (value: unknown): string | undefined => {
    if (value === undefined) return undefined
    if (value === null) return 'null'
    if (value instanceof Date) return `new Date(${value.getTime()})`
    if (typeof value === 'string') return JSON.stringify(value)
    if (typeof value === 'number' || typeof value === 'boolean')
        return String(value)
    if (typeof value === 'object') return JSON.stringify(value)
    throw new TypeError(
        `Unsupported schema default value type: ${typeof value}`
    )
}
```

All four codegen blocks now route the default through this helper and JSON-stringify the property key for defense in depth:

```ts
const parsed = stringifyDefault(value)

if (parsed !== undefined)
    fnLiteral += `c.headers[${JSON.stringify(key)}]??=${parsed}\n`
```

The `instanceof Date` branch preserves the existing behavior of `default: new Date()` producing a real `Date` in handlers (not an ISO string). The body block keeps its existing `Array.isArray` / `typeof === 'object'` dispatch and its `File`/`Files` filter (which still runs before stringification).

## Minimal Reproduction

```ts
import { Elysia, t } from 'elysia'

new Elysia()
    .get('/', (c) => /* @ts-ignore */ c.q ?? 'safe', {
        query: t.Object({
            foo: t.String({
                default: `';console.log(c.q='pwn');'`
            })
        })
    })
    .listen(3000)

// curl http://localhost:3000/
//   stdout: "pwn"    ← console.log fired at request time
//   body:   "pwn"    ← c.q was assigned by injected code
```

The same payload reproduces against `headers`, `params`, and a top-level `body: t.String({ default: ... })`.

## Test Plan
- [x] New `test/validator/security.test.ts` covering all four entry points, modeled on the existing `handle arbitrary code execution from cookie` test in `test/core/elysia.test.ts`. Includes a regression guard for body object defaults (already-safe path that routes through `JSON.stringify`) to lock the invariant.
- [x] `bun test` — 1530 / 1530 pass.
- [x] `bun run test:types` — passes.
- [x] Existing default-value tests in `test/validator/{body,query,header,params}.test.ts` continue to pass, confirming no regression on `Date`, `Number`, `Boolean`, `String`, and `Object` defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by preventing arbitrary code execution through schema default values in query parameters, headers, path parameters, and request bodies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1876)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->