### PR TITLE
⚙️ fix: request.url empty in onAfterResponse workaround

### DIFF
--- a/src/adapter/bun/compose.ts
+++ b/src/adapter/bun/compose.ts
@@ -24,6 +24,7 @@ const createContext = (
 	const defaultHeaders = app.setHeaders
 
 	const hasTrace = !!app.event.trace?.length
+	const hasAfterResponse = !!app.event.afterResponse?.length
 	if (hasTrace) fnLiteral += `const id=randomId()\n`
 
 	const isDynamic = /[:*]/.test(route.path)
@@ -64,7 +65,7 @@ const createContext = (
 		getPath +
 		allocateIf(
 			`url:request.url,`,
-			hasTrace || inference.url || needsQuery
+			hasTrace || inference.url || needsQuery || hasAfterResponse
 		) +
 		`redirect,` +
 		`status,` +

--- a/test/lifecycle/after-response.test.ts
+++ b/test/lifecycle/after-response.test.ts
@@ -33,4 +33,20 @@ describe('After Handle', () => {
 		await Bun.sleep(1)
 		expect(status!).toBe(404)
 	})
+
+	it('preserve request.url', async () => {
+		let url: string
+
+		const app = new Elysia()
+			.onAfterResponse(({ request }) => {
+				url = request.url
+			})
+			.get('/hello/page', () => 'hi')
+
+		const res = await app.handle(req('/hello/page?foo=bar'))
+		expect(res.status).toBe(200)
+
+		await Bun.sleep(1)
+		expect(url!).toBe('http://localhost/hello/page?foo=bar')
+	})
 })


### PR DESCRIPTION
## Summary

Fixes `request.url` being empty string in `onAfterResponse` hooks when using Bun adapter with AOT-compiled routes.

Closes #1877

## Root Cause

After the response is sent, Bun frees internal native resources of the `Request` object. The `onAfterResponse` hook fires asynchronously via `setImmediate` — by the time it runs, `request.url` has already been cleared to `""`.

Reading `request.url` during context creation keeps a JS reference to the string, preventing Bun from freeing it.

## Changes

`src/adapter/bun/compose.ts` — 2 lines added, 1 modified:

- Added `hasAfterResponse` flag in `createContext`
- Added `hasAfterResponse` to condition for `url:request.url` inclusion

`test/lifecycle/after-response.test.ts`

- Added `preserve request.url` test case

## Performance

Zero overhead — just an additional property reference. No new allocations, no header iteration.

## Known Limitations

`request.headers` has the same lifecycle issue (empty Headers in afterResponse). Fixing requires saving original `Headers` object which adds RPM overhead. A lazy getter or inference-based approach would be needed — left for a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After-response hooks now reliably receive the full absolute request URL (including query string) for handled routes, preserving request.url for use inside onAfterResponse hooks.

* **Tests**
  * Added a lifecycle test confirming request.url remains the full absolute URL for onAfterResponse hooks across asynchronous handler execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1878)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->