### PR TITLE
fix: case-insensitive headers (RFC 2616)

### DIFF
--- a/src/adapter/bun/compose.ts
+++ b/src/adapter/bun/compose.ts
@@ -5,6 +5,7 @@ import { createHoc, createOnRequestHandler, isAsync } from '../../compose'
 import { randomId, ELYSIA_REQUEST_ID, redirect, isNotEmpty } from '../../utils'
 import { status } from '../../error'
 import { ELYSIA_TRACE } from '../../trace'
+import { createCaseInsensitiveHeaders as ciHeaders } from '../utils'
 
 import type { AnyElysia } from '../..'
 import type { InternalRoute, InputSchema } from '../../types'
@@ -70,8 +71,8 @@ const createContext = (
 		`status,` +
 		`set:{headers:` +
 		(isNotEmpty(defaultHeaders)
-			? 'Object.assign({},app.setHeaders)'
-			: 'Object.create(null)') +
+			? 'ciHeaders(Object.assign({},app.setHeaders))'
+			: 'ciHeaders()') +
 		`,status:200}`
 
 	if (inference.server) fnLiteral += `,get server(){return app.getServer()}`
@@ -117,6 +118,7 @@ export const createBunRouteHandler = (app: AnyElysia, route: InternalRoute) => {
 		'redirect=data.redirect,' +
 		'route=data.route,' +
 		'mapEarlyResponse=data.mapEarlyResponse,' +
+		'ciHeaders=data.ciHeaders,' +
 		allocateIf('randomId=data.randomId,', hasTrace) +
 		allocateIf(`ELYSIA_REQUEST_ID=data.ELYSIA_REQUEST_ID,`, hasTrace) +
 		allocateIf(`ELYSIA_TRACE=data.ELYSIA_TRACE,`, hasTrace) +
@@ -164,6 +166,7 @@ export const createBunRouteHandler = (app: AnyElysia, route: InternalRoute) => {
 		ELYSIA_TRACE: hasTrace ? ELYSIA_TRACE : undefined,
 		ELYSIA_REQUEST_ID: hasTrace ? ELYSIA_REQUEST_ID : undefined,
 		trace: hasTrace ? app.event.trace?.map((x) => x?.fn ?? x) : undefined,
-		mapEarlyResponse: mapEarlyResponse
+		mapEarlyResponse: mapEarlyResponse,
+		ciHeaders
 	})
 }

--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -214,8 +214,8 @@ export const BunAdapter: ElysiaAdapter = {
 	composeHandler: {
 		...WebStandardAdapter.composeHandler,
 		headers: hasHeaderShorthand
-			? 'c.headers=c.request.headers.toJSON()\n'
-			: 'c.headers={}\n' +
+			? 'c.headers=ciHeaders(c.request.headers.toJSON())\n'
+			: 'c.headers=ciHeaders()\n' +
 				'for(const [k,v] of c.request.headers.entries())' +
 				'c.headers[k]=v\n'
 	},

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -6,6 +6,49 @@ import { env } from '../universal'
 import { isBun } from '../universal/utils'
 import { MaybePromise } from '../types'
 
+const ciHeadersHandler: ProxyHandler<Record<string, any>> = {
+	get(obj, prop) {
+		if (typeof prop === 'string') return obj[prop.toLowerCase()]
+		return obj[prop as any]
+	},
+	set(obj, prop, value) {
+		if (typeof prop === 'string') obj[prop.toLowerCase()] = value
+		else obj[prop as any] = value
+		return true
+	},
+	has(obj, prop) {
+		if (typeof prop === 'string') return prop.toLowerCase() in obj
+		return prop in obj
+	},
+	deleteProperty(obj, prop) {
+		if (typeof prop === 'string') delete obj[prop.toLowerCase()]
+		else delete obj[prop as any]
+		return true
+	},
+	ownKeys(obj) {
+		return Reflect.ownKeys(obj)
+	},
+	getOwnPropertyDescriptor(obj, prop) {
+		if (typeof prop === 'string') {
+			const lower = prop.toLowerCase()
+			if (lower in obj)
+				return {
+					value: obj[lower],
+					writable: true,
+					enumerable: true,
+					configurable: true
+				}
+			return undefined
+		}
+		return Reflect.getOwnPropertyDescriptor(obj, prop)
+	}
+}
+
+export const createCaseInsensitiveHeaders = (
+	target: Record<string, any> = Object.create(null)
+): Context['set']['headers'] =>
+	new Proxy(target, ciHeadersHandler) as Context['set']['headers']
+
 export const handleFile = (
 	response: File | Blob,
 	set?: Context['set'],

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -176,8 +176,8 @@ export const mapResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
-							set.headers['Content-Type'] = 'application/json'
+						if (!set.headers['content-type'])
+							set.headers['content-type'] = 'application/json'
 
 						return new Response(
 							JSON.stringify(response),
@@ -329,8 +329,8 @@ export const mapEarlyResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
-							set.headers['Content-Type'] = 'application/json'
+						if (!set.headers['content-type'])
+							set.headers['content-type'] = 'application/json'
 
 						return new Response(
 							JSON.stringify(response),
@@ -461,8 +461,8 @@ export const mapEarlyResponse = (
 					const code = (response as any).charCodeAt(0)
 
 					if (code === 123 || code === 91) {
-						if (!set.headers['Content-Type'])
-							set.headers['Content-Type'] = 'application/json'
+						if (!set.headers['content-type'])
+							set.headers['content-type'] = 'application/json'
 
 						return new Response(
 							JSON.stringify(response),

--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -21,7 +21,7 @@ export const WebStandardAdapter: ElysiaAdapter = {
 		preferWebstandardHeaders: true,
 		// @ts-ignore Bun specific
 		headers:
-			'c.headers={}\n' +
+			'c.headers=ciHeaders()\n' +
 			'for(const [k,v] of c.request.headers.entries())' +
 			'c.headers[k]=v\n',
 		parser: {
@@ -176,8 +176,8 @@ export const WebStandardAdapter: ElysiaAdapter = {
 				`set:{headers:`
 
 			fnLiteral += Object.keys(defaultHeaders ?? {}).length
-				? 'Object.assign({},app.setHeaders)'
-				: 'Object.create(null)'
+				? 'ciHeaders(Object.assign({},app.setHeaders))'
+				: 'ciHeaders()'
 
 			fnLiteral += `,status:200}`
 

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -63,7 +63,7 @@ import type {
 	MaybePromise,
 	SchemaValidator
 } from './types'
-import { tee } from './adapter/utils'
+import { tee, createCaseInsensitiveHeaders } from './adapter/utils'
 import { coercePrimitiveRoot } from './replace-schema'
 
 const allocateIf = (value: string, condition: unknown) =>
@@ -499,7 +499,9 @@ export const composeHandler = ({
 	if (!isHandleFn) {
 		handler = adapterHandler.mapResponse(handler, {
 			// @ts-expect-error private property
-			headers: app.setHeaders ?? {}
+			headers: createCaseInsensitiveHeaders(
+				app.setHeaders ? { ...app.setHeaders } : undefined
+			)
 		})
 
 		const isResponse =
@@ -1279,6 +1281,10 @@ export const composeHandler = ({
 				)
 
 			if (validator.headers.isOptional) fnLiteral += '}'
+
+			// Re-wrap headers in case-insensitive proxy after validation
+			// since Clean/Decode may strip the proxy
+			fnLiteral += `c.headers=ciHeaders(c.headers)\n`
 		}
 
 		if (validator.params) {
@@ -2157,6 +2163,7 @@ export const composeHandler = ({
 		allocateIf('parser,', hooks.parse?.length) +
 		allocateIf(`getServer,`, inference.server) +
 		allocateIf(`fileUnions,`, fileUnions.length) +
+		`ciHeaders,` +
 		adapterVariables +
 		allocateIf('TypeBoxError', hasValidation) +
 		`}=hooks\n` +
@@ -2215,6 +2222,7 @@ export const composeHandler = ({
 			fileUnions: fileUnions.length ? fileUnions : undefined,
 			TypeBoxError: hasValidation ? TypeBoxError : undefined,
 			parser: app['~parser'],
+			ciHeaders: createCaseInsensitiveHeaders,
 			...adapter.inject
 		})
 	} catch (error) {
@@ -2501,6 +2509,7 @@ export const composeGeneralHandler = (
 		allocateIf(`parseQueryFromURL,`, app.inference.query) +
 		allocateIf(`ELYSIA_TRACE,`, hasTrace) +
 		allocateIf(`ELYSIA_REQUEST_ID,`, hasTrace) +
+		`ciHeaders,` +
 		adapterVariables +
 		`}=data\n` +
 		`const store=app.singleton.store\n` +
@@ -2568,6 +2577,7 @@ export const composeGeneralHandler = (
 		parseQueryFromURL: app.inference.query ? parseQueryFromURL : undefined,
 		ELYSIA_TRACE: hasTrace ? ELYSIA_TRACE : undefined,
 		ELYSIA_REQUEST_ID: hasTrace ? ELYSIA_REQUEST_ID : undefined,
+		ciHeaders: createCaseInsensitiveHeaders,
 		...adapter.inject
 	})
 

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -541,17 +541,22 @@ export const createDynamicHandler = (app: AnyElysia) => {
 					for (const [key, value] of request.headers)
 						_header[key] = value
 
-					if (validator.headers!.Check(_header) === false)
+					if (headerValidator.Check(_header) === false)
 						throw new ValidationError(
 							'header',
-							validator.headers!,
+							headerValidator,
 							_header
 						)
-				} else if (validator.headers?.Decode)
+
 					// @ts-ignore
-					context.headers = createCaseInsensitiveHeaders(
-						validator.headers.Decode(context.headers)
-					)
+					if (headerValidator.Decode)
+						// @ts-ignore
+						context.headers = createCaseInsensitiveHeaders(
+							headerValidator.Decode(_header)
+						)
+					// @ts-ignore
+					else context.headers = _header
+				}
 
 				if (paramsValidator?.Check(context.params) === false) {
 					throw new ValidationError(

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -14,6 +14,7 @@ import { getSchemaProperties, type ElysiaTypeCheck } from './schema'
 import type { TypeCheck } from './type-system'
 import type { Handler, LifeCycleStore, SchemaValidator } from './types'
 import { hasSetImmediate, redirect, StatusMap, signCookie } from './utils'
+import { createCaseInsensitiveHeaders } from './adapter/utils'
 
 // JIT Handler
 export type DynamicHandler = {
@@ -201,7 +202,9 @@ export const createDynamicHandler = (app: AnyElysia) => {
 		const set: Context['set'] = {
 			cookie: {},
 			status: 200,
-			headers: defaultHeader ? { ...defaultHeader } : {}
+			headers: createCaseInsensitiveHeaders(
+				defaultHeader ? { ...defaultHeader } : undefined
+			)
 		}
 
 		const context = Object.assign(
@@ -443,7 +446,7 @@ export const createDynamicHandler = (app: AnyElysia) => {
 			// @ts-expect-error
 			context.query = qi === -1 ? {} : parseQuery(url.substring(qi + 1))
 
-			context.headers = {}
+			context.headers = createCaseInsensitiveHeaders()
 			for (const [key, value] of request.headers.entries())
 				context.headers[key] = value
 
@@ -532,7 +535,9 @@ export const createDynamicHandler = (app: AnyElysia) => {
 
 			if (validator) {
 				if (headerValidator) {
-					const _header = structuredClone(context.headers)
+					const _header = createCaseInsensitiveHeaders({
+						...context.headers
+					})
 					for (const [key, value] of request.headers)
 						_header[key] = value
 
@@ -544,7 +549,9 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						)
 				} else if (validator.headers?.Decode)
 					// @ts-ignore
-					context.headers = validator.headers.Decode(context.headers)
+					context.headers = createCaseInsensitiveHeaders(
+						validator.headers.Decode(context.headers)
+					)
 
 				if (paramsValidator?.Check(context.params) === false) {
 					throw new ValidationError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -519,6 +519,24 @@ export default class Elysia<
 				this.standaloneValidator.global
 			)
 
+		// Normalize standalone validator header schemas to lowercase
+		// since HTTP headers are case-insensitive (RFC 2616)
+		for (const validator of standaloneValidators) {
+			const h = validator.headers as any
+			if (h?.properties) {
+				const props: Record<string, any> = {}
+				for (const [key, value] of Object.entries(h.properties))
+					props[key.toLowerCase()] = value
+				validator.headers = {
+					...h,
+					properties: props,
+					required: h.required?.map((k: string) =>
+						k.toLowerCase()
+					)
+				}
+			}
+		}
+
 		if (path !== '' && path.charCodeAt(0) !== 47) path = '/' + path
 		if (this.config.prefix && !skipPrefix) path = this.config.prefix + path
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import type { WSLocalHook } from './ws/types'
 
 import { BunAdapter } from './adapter/bun/index'
 import { WebStandardAdapter } from './adapter/web-standard/index'
+import { createCaseInsensitiveHeaders } from './adapter/utils'
 import type { ElysiaAdapter } from './adapter/types'
 
 import { env } from './universal/env'
@@ -549,9 +550,27 @@ export default class Elysia<
 
 		const instanceValidator = this.validator.getCandidate()
 
+		// Normalize header schema property keys to lowercase
+		// since HTTP headers are case-insensitive (RFC 2616)
+		const rawHeaders =
+			localHook?.headers ?? (instanceValidator?.headers as any)
+		let normalizedHeaders = rawHeaders
+		if (rawHeaders?.properties) {
+			const props: Record<string, any> = {}
+			for (const [key, value] of Object.entries(rawHeaders.properties))
+				props[key.toLowerCase()] = value
+			normalizedHeaders = {
+				...rawHeaders,
+				properties: props,
+				required: rawHeaders.required?.map((k: string) =>
+					k.toLowerCase()
+				)
+			}
+		}
+
 		const cloned = {
 			body: localHook?.body ?? (instanceValidator?.body as any),
-			headers: localHook?.headers ?? (instanceValidator?.headers as any),
+			headers: normalizedHeaders,
 			params: localHook?.params ?? (instanceValidator?.params as any),
 			query: localHook?.query ?? (instanceValidator?.query as any),
 			cookie: localHook?.cookie ?? (instanceValidator?.cookie as any),
@@ -882,7 +901,9 @@ export default class Elysia<
 								: (undefined as any as Request),
 							server: null,
 							set: {
-								headers: Object.assign({}, this.setHeaders)
+								headers: createCaseInsensitiveHeaders(
+									Object.assign({}, this.setHeaders)
+								)
 							},
 							status,
 							store: this.store
@@ -1104,7 +1125,11 @@ export default class Elysia<
 
 		if (!this.setHeaders) this.setHeaders = {}
 
-		this.setHeaders = mergeDeep(this.setHeaders, header)
+		const normalized: Record<string, any> = {}
+		for (const key in header)
+			normalized[key.toLowerCase()] = (header as Record<string, any>)[key]
+
+		this.setHeaders = mergeDeep(this.setHeaders, normalized)
 
 		return this
 	}

--- a/test/response/headers.test.ts
+++ b/test/response/headers.test.ts
@@ -85,4 +85,53 @@ describe('Response Headers', () => {
 
 		expect(headers.get('x-powered-by')).toBe('Elysia')
 	})
+
+	it('treat headers as case-insensitive', async () => {
+		const app = new Elysia().get('/', ({ set }) => {
+			set.headers['Content-Type'] = 'text/html'
+
+			return '<h1>Hi</h1>'
+		})
+
+		const res = await app.handle(req('/'))
+
+		expect(res.headers.get('content-type')).toBe('text/html')
+	})
+
+	it('merge mixed-case header keys into one', async () => {
+		const app = new Elysia().get('/', ({ set }) => {
+			set.headers['X-Custom'] = 'first'
+			set.headers['x-custom'] = 'second'
+
+			return 'Hi'
+		})
+
+		const res = await app.handle(req('/'))
+
+		expect(res.headers.get('x-custom')).toBe('second')
+	})
+
+	it('support in operator for case-insensitive headers', async () => {
+		const app = new Elysia().get('/', ({ set }) => {
+			set.headers['content-type'] = 'text/plain'
+
+			return String('Content-Type' in set.headers)
+		})
+
+		const res = await app.handle(req('/'))
+
+		expect(await res.text()).toBe('true')
+	})
+
+	it('normalize static headers to lowercase', async () => {
+		const app = new Elysia()
+			.headers({
+				'X-Powered-By': 'Elysia'
+			})
+			.get('/', () => 'hi')
+
+		const res = await app.handle(req('/'))
+
+		expect(res.headers.get('x-powered-by')).toBe('Elysia')
+	})
 })

--- a/test/validator/header.test.ts
+++ b/test/validator/header.test.ts
@@ -428,6 +428,29 @@ describe('Header Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('access validated headers with any casing', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ headers }) =>
+				`${headers['x-custom']},${headers['X-Custom']},${headers['X-CUSTOM']}`,
+			{
+				headers: t.Object({
+					'X-Custom': t.String()
+				})
+			}
+		)
+		const res = await app.handle(
+			req('/', {
+				headers: {
+					'x-custom': 'hello'
+				}
+			})
+		)
+
+		expect(await res.text()).toBe('hello,hello,hello')
+		expect(res.status).toBe(200)
+	})
+
 	it('validate User-Agent schema key against lowercase header', async () => {
 		const app = new Elysia().get(
 			'/',

--- a/test/validator/header.test.ts
+++ b/test/validator/header.test.ts
@@ -405,4 +405,48 @@ describe('Header Validator', () => {
 
 		expect(err instanceof ValidationError).toBe(true)
 	})
+
+	it('validate mixed-case schema keys against lowercase headers', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ headers }) => headers['x-custom'],
+			{
+				headers: t.Object({
+					'X-Custom': t.String()
+				})
+			}
+		)
+		const res = await app.handle(
+			req('/', {
+				headers: {
+					'x-custom': 'hello'
+				}
+			})
+		)
+
+		expect(await res.text()).toBe('hello')
+		expect(res.status).toBe(200)
+	})
+
+	it('validate User-Agent schema key against lowercase header', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ headers }) => headers['user-agent'] ?? 'none',
+			{
+				headers: t.Object({
+					'User-Agent': t.String()
+				})
+			}
+		)
+		const res = await app.handle(
+			req('/', {
+				headers: {
+					'user-agent': 'TestAgent/1.0'
+				}
+			})
+		)
+
+		expect(await res.text()).toBe('TestAgent/1.0')
+		expect(res.status).toBe(200)
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #99

HTTP headers are case-insensitive per [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), but Elysia treated them as case-sensitive. This caused:

- `set.headers['Set-Cookie']` and `set.headers['set-cookie']` to be separate entries
- Header schema validation to fail when using mixed-case keys like `User-Agent` (since the runtime always provides lowercase `user-agent`)

### Changes

- **Proxy-based `createCaseInsensitiveHeaders` utility** — wraps a plain object normalizing all keys to lowercase on get/set/has/delete. Uses the same Proxy pattern already present in the cookie jar (`src/cookies.ts`)
- **Response headers (`set.headers`)** — wrapped with the proxy across Bun adapter, Web Standard adapter, dynamic handler, and compose
- **Request headers (`c.headers`)** — wrapped with the proxy so handlers can access headers with any casing (e.g., `headers['User-Agent']` or `headers['user-agent']`)
- **Header schema normalization** — schema property keys are normalized to lowercase before validation, so `t.Object({ 'User-Agent': t.String() })` correctly matches the lowercase `user-agent` from the runtime
- **Internal fix** — 3 instances of `set.headers['Content-Type']` (title-case) in web-standard handler changed to `set.headers['content-type']` for consistency

### Files modified

| File | Change |
|------|--------|
| `src/adapter/utils.ts` | New `createCaseInsensitiveHeaders` utility |
| `src/adapter/bun/compose.ts` | Wrap `set.headers` + inject utility in codegen |
| `src/adapter/bun/index.ts` | Wrap `c.headers` in codegen |
| `src/adapter/web-standard/index.ts` | Wrap `set.headers` and `c.headers` in codegen |
| `src/adapter/web-standard/handler.ts` | Fix Content-Type casing |
| `src/compose.ts` | Inject utility + re-wrap after validation |
| `src/dynamic-handle.ts` | Wrap both `set.headers` and `c.headers` |
| `src/index.ts` | Normalize header schema keys + `setHeaders` keys |
| `test/response/headers.test.ts` | 4 new tests |
| `test/validator/header.test.ts` | 2 new tests |

## Test plan

- [x] `bun test test/response/headers.test.ts` — 11 pass
- [x] `bun test test/validator/header.test.ts` — 19 pass
- [x] `bun test test/core/dynamic.test.ts` — 32 pass (includes default value test)
- [x] `bun test` — 1529 pass, 2 pre-existing failures (port conflicts)
- [x] Manual verification with curl (response headers, validation, key merging)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced consistent case-insensitive HTTP header handling across adapters and runtime; headers are normalized, merged, and preserved for enumeration/descriptor semantics. Response mapping now sets missing JSON content-type using a normalized header key.
* **Tests**
  * Added tests validating case-insensitive request header validation and response/static header behavior, including mixed-case and special-header cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->