### PR TITLE
fix: validate text/csv uploads

### DIFF
--- a/src/type-system/utils.ts
+++ b/src/type-system/utils.ts
@@ -101,6 +101,30 @@ export const checkFileExtension = (type: string, extension: string) => {
 	)
 }
 
+const isTextType = (type: string) => type === 'text' || type.startsWith('text/')
+
+const checkFileExtensions = (
+	type: string,
+	extension: FileType | FileType[]
+) => {
+	if (typeof extension === 'string')
+		return checkFileExtension(type, extension)
+
+	for (let i = 0; i < extension.length; i++)
+		if (checkFileExtension(type, extension[i])) return true
+
+	return false
+}
+
+const allowUnsniffableTextType = (
+	file: Blob | File,
+	extension: FileType | FileType[]
+) => {
+	if (!file.type || !isTextType(file.type)) return false
+
+	return checkFileExtensions(file.type, extension)
+}
+
 let _fileTypeFromBlobWarn = false
 const warnIfFileTypeIsNotInstalled = () => {
 	if (!_fileTypeFromBlobWarn) {
@@ -143,14 +167,13 @@ export const fileType = async (
 	if (!file) return false
 
 	const result = await fileTypeFromBlob(file)
-	if (!result) throw new InvalidFileType(name, extension)
+	if (!result) {
+		if (allowUnsniffableTextType(file, extension)) return true
 
-	if (typeof extension === 'string')
-		if (!checkFileExtension(result.mime, extension))
-			throw new InvalidFileType(name, extension)
+		throw new InvalidFileType(name, extension)
+	}
 
-	for (let i = 0; i < extension.length; i++)
-		if (checkFileExtension(result.mime, extension[i])) return true
+	if (checkFileExtensions(result.mime, extension)) return true
 
 	throw new InvalidFileType(name, extension)
 }

--- a/test/validator/body.test.ts
+++ b/test/validator/body.test.ts
@@ -1082,6 +1082,54 @@ describe('Body Validator', () => {
 		}
 	})
 
+	it('validate csv file by declared text/csv type', async () => {
+		const app = new Elysia().post('/', () => 'ok', {
+			body: t.Object({
+				file: t.File({
+					type: ['text/csv']
+				})
+			})
+		})
+
+		const body = new FormData()
+		body.append(
+			'file',
+			new File(['name,email\nelysia,hi@example.com\n'], 'sample.csv', {
+				type: 'text/csv'
+			})
+		)
+
+		const response = await app.handle(
+			new Request('http://localhost/', {
+				method: 'POST',
+				body
+			})
+		)
+
+		expect(response.status).toBe(200)
+
+		const invalidBody = new FormData()
+		invalidBody.append(
+			'file',
+			new File(
+				[await Bun.file('test/images/millenium.jpg').arrayBuffer()],
+				'sample.csv',
+				{
+					type: 'text/csv'
+				}
+			)
+		)
+
+		const invalidResponse = await app.handle(
+			new Request('http://localhost/', {
+				method: 'POST',
+				body: invalidBody
+			})
+		)
+
+		expect(invalidResponse.status).toBe(422)
+	})
+
 	it('handle body using Transform with Intersect ', async () => {
 		const app = new Elysia().post('/test', ({ body }) => body, {
 			body: t.Intersect([


### PR DESCRIPTION
Fixes #1871

CSV uploads can report `text/csv`, but `file-type` cannot always infer text formats from the file bytes. In that case Elysia rejected the upload before checking the declared file MIME.

This keeps byte sniffing first. If there is no sniffed result, it only falls back to `File.type` for matching `text/*` values. A JPEG payload declared as `text/csv` still fails validation.

Tested with:
- `bun test test/validator/body.test.ts`
- `bun test test/type-system/files.test.ts test/type-system/formdata.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file validation to handle text files more robustly when type detection is unavailable, reducing validation failures for valid files.

* **Tests**
  * Added test cases for multipart file validation, including CSV file acceptance and rejection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->