### PR TITLE
fix: strip prototype pollution keys from parsed query values

### DIFF
--- a/src/parse-query.ts
+++ b/src/parse-query.ts
@@ -6,6 +6,30 @@ const KEY_NEEDS_DECODE = 2
 const VALUE_HAS_PLUS = 4
 const VALUE_NEEDS_DECODE = 8
 
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype']
+
+// `JSON.parse` keeps `__proto__` (and friends) as enumerable own keys, e.g.
+// `JSON.parse('{"__proto__":{}}')` produces an object with an own `__proto__`
+// property. Spreading or merging such a value downstream can pollute the
+// prototype chain, so strip these keys from any parsed query value.
+const stripDangerousKeys = <T>(value: T): T => {
+	if (!value || typeof value !== 'object') return value
+
+	if (Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) stripDangerousKeys(value[i])
+
+		return value
+	}
+
+	for (const key of DANGEROUS_KEYS)
+		if (Object.prototype.hasOwnProperty.call(value, key))
+			delete (value as Record<string, unknown>)[key]
+
+	for (const key in value) stripDangerousKeys((value as any)[key])
+
+	return value
+}
+
 // Parse query without array
 export function parseQueryFromURL(
 	input: string,
@@ -92,7 +116,7 @@ export function parseQueryFromURL(
 		if (array && array?.[finalKey]) {
 			if (finalValue.charCodeAt(0) === 91) {
 				if (object && object?.[finalKey])
-					finalValue = JSON.parse(finalValue) as any
+					finalValue = stripDangerousKeys(JSON.parse(finalValue)) as any
 				else finalValue = finalValue.slice(1, -1).split(',') as any
 
 				if (currentValue === undefined) result[finalKey] = finalValue
@@ -204,7 +228,7 @@ export function parseQueryStandardSchema(
 		) {
 			try {
 				// @ts-ignore
-				finalValue = JSON.parse(finalValue)
+				finalValue = stripDangerousKeys(JSON.parse(finalValue))
 			} catch {
 				// If JSON parsing fails, treat it as a regular string
 			}
@@ -218,7 +242,7 @@ export function parseQueryStandardSchema(
 		) {
 			try {
 				// @ts-ignore
-				finalValue = JSON.parse(finalValue)
+				finalValue = stripDangerousKeys(JSON.parse(finalValue))
 			} catch {
 				// If JSON parsing fails, treat it as a regular string
 			}

--- a/test/validator/query-prototype-pollution.test.ts
+++ b/test/validator/query-prototype-pollution.test.ts
@@ -1,0 +1,76 @@
+import { Elysia } from '../../src'
+import { parseQueryFromURL, parseQueryStandardSchema } from '../../src/parse-query'
+
+import * as z from 'zod'
+import { describe, expect, it } from 'bun:test'
+import { req } from '../utils'
+
+const hasOwn = (value: unknown, key: string) =>
+	Object.prototype.hasOwnProperty.call(value, key)
+
+const proto = (key: string) =>
+	encodeURIComponent(`{"${key}":{"polluted":"yes"}}`)
+
+describe('Query Prototype Pollution', () => {
+	it('strip dangerous keys from a parsed object query value', () => {
+		const query = parseQueryStandardSchema(`filter=${proto('__proto__')}`)
+
+		expect(typeof query.filter).toBe('object')
+		expect(hasOwn(query.filter, '__proto__')).toBe(false)
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+	})
+
+	it('strip dangerous keys from a parsed array query value', () => {
+		const query = parseQueryStandardSchema(
+			`filter=${encodeURIComponent('[{"__proto__":{"polluted":"yes"},"ok":1}]')}`
+		)
+
+		expect(Array.isArray(query.filter)).toBe(true)
+		expect(hasOwn((query.filter as any)[0], '__proto__')).toBe(false)
+		expect((query.filter as any)[0]).toEqual({ ok: 1 })
+	})
+
+	it('strip constructor and prototype keys', () => {
+		const query = parseQueryStandardSchema(
+			`filter=${encodeURIComponent('{"constructor":1,"prototype":2,"keep":3}')}`
+		)
+
+		expect(query.filter).toEqual({ keep: 3 })
+	})
+
+	it('preserve legitimate object and array query values', () => {
+		const query = parseQueryStandardSchema(
+			`obj=${encodeURIComponent('{"a":1,"b":["x","y"]}')}&list=${encodeURIComponent('[1,2,3]')}`
+		)
+
+		expect(query.obj).toEqual({ a: 1, b: ['x', 'y'] })
+		expect(query.list).toEqual([1, 2, 3] as any)
+	})
+
+	it('strip dangerous keys in parseQueryFromURL object arrays', () => {
+		const query = parseQueryFromURL(
+			`arr=${encodeURIComponent('[{"__proto__":{"polluted":"yes"},"k":2}]')}`,
+			0,
+			{ arr: 1 },
+			{ arr: 1 }
+		)
+
+		expect(hasOwn((query.arr as any)[0], '__proto__')).toBe(false)
+		expect((query.arr as any)[0]).toEqual({ k: 2 } as any)
+	})
+
+	it('does not pollute the prototype through a standard schema query route', async () => {
+		// A standard schema (Zod) query validator routes parsing through
+		// parseQueryStandardSchema, which auto-parses JSON-looking values.
+		const app = new Elysia().get('/', ({ query }) => query.filter, {
+			query: z.object({
+				filter: z.record(z.string(), z.unknown())
+			})
+		})
+
+		const res = await app.handle(req(`/?filter=${proto('__proto__')}`))
+
+		expect(res.status).toBe(200)
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+	})
+})


### PR DESCRIPTION
## Description

Relates to #1848 (Finding 1).

When a route uses a query schema, Elysia auto-parses query values that look like an array or object through `JSON.parse`:

- `parseQueryStandardSchema` (used with Zod/Valibot/ArkType) parses any value starting with `[`/`{`.
- `parseQueryFromURL` parses array values when the schema marks the field as an object array.

`JSON.parse` keeps `__proto__` as an **enumerable own property**, so a request like:

```
GET /?filter=%7B%22__proto__%22%3A%7B%22polluted%22%3A%22yes%22%7D%7D
```

(i.e. `?filter={"__proto__":{"polluted":"yes"}}`) produces a query value that carries an own `__proto__` key. When that object is later spread or merged downstream (`{ ...query.filter }`, recursive merges, etc.) it can pollute `Object.prototype`.

```ts
const parsed = parseQueryStandardSchema('filter=' + encodeURIComponent('{"__proto__":{"polluted":1}}'))
Object.getOwnPropertyNames(parsed.filter) // ['__proto__']  <-- before
```

This mirrors the FormData JSON parsing issue, which already strips dangerous keys via `DANGEROUS_KEYS` in `src/dynamic-handle.ts`. The query parsers were missing the same guard.

## Fix

Recursively strip `__proto__`, `constructor` and `prototype` from any value produced by `JSON.parse` in the query parsers. Legitimate object/array query values are left untouched, and nested objects (including objects inside arrays) are sanitized too.

## Tests

Added `test/validator/query-prototype-pollution.test.ts` covering:

- dangerous keys stripped from parsed object/array query values (and nested in arrays)
- `constructor` / `prototype` stripped
- legitimate object/array values preserved
- `parseQueryFromURL` object-array path
- no prototype pollution through a Zod query route

These fail on `main` and pass with this change. `bun run test` and `bun run test:types` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query parameters are now sanitized to prevent potential security vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->