### PR TITLE
add bunfig for security

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+minimumReleaseAge = 86400
+
+minimumReleaseAgeExcludes = ["@types/node", "typescript"]


### PR DESCRIPTION
## Add `minimumReleaseAge` to bunfig.toml

### What
Adds a minimum release age gate of 1 day (86400s) to `bunfig.toml` to prevent recently published npm package versions from being installed automatically.

### Why
This protects against supply chain attacks that exploit the window between a malicious package being published and it being detected/removed. Recent real-world examples this would have blocked:

- **TanStack (May 2026)** — 84 malicious versions across 42 `@tanstack/*` packages were published in a 6-minute window. The malware polled GitHub tokens and wiped home directories (`rm -rf ~/`) on revocation. A 1-day age gate would have blocked all of them.
- **Bitwarden CLI (April 2026)** and **Aqua Trivy (March 2026)** — part of the same Shai-Hulud worm campaign, all using the same fast-publish attack pattern.
- **npm September 2025 wave** — 18 packages with ~2B weekly downloads compromised immediately after account takeover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to manage dependency installation timing and policies, with specific exclusions for core development dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->