### PR TITLE
Fix onError JSON response status typing

### DIFF
--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -36,7 +36,7 @@ const handleElysiaFile = (
 		set.status !== 416
 	)
 		return file.stats!.then((stat) => {
-			const size = stat.size as number
+			const size = stat?.size as number | undefined
 
 			if (size !== undefined) {
 				set.headers['content-range'] = `bytes 0-${size - 1}/${size}`

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2700,7 +2700,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 					`error.status=error.code\n` +
 					`error.message=error.response` +
 					`}` +
-					`if(set.status===200||!set.status)set.status=error.status\n`
+					`if(set.status===200||!set.status)set.status=error.status??500\n`
 
 				const mapResponseReporter = report('mapResponse', {
 					total: hooks.mapResponse?.length,

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -906,11 +906,19 @@ export const createDynamicErrorHandler = (app: AnyElysia) => {
 				const hook = app.event.error[i]
 				let response = hook.fn(errorContext as any)
 				if (response instanceof Promise) response = await response
-				if (response !== undefined && response !== null)
+				if (response !== undefined && response !== null) {
+					if (
+						!(response instanceof Response) &&
+						!(response instanceof ElysiaCustomStatusResponse) &&
+						(context.set.status === 200 || !context.set.status)
+					)
+						context.set.status = error.status ?? 500
+
 					return (context.response = mapResponse(
 						response,
 						context.set
 					))
+				}
 			}
 
 		if (context.response) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,9 @@ import type {
 	ElysiaHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -3179,7 +3182,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3232,7 +3235,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3322,7 +3325,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3343,7 +3346,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3362,7 +3365,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3452,7 +3455,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3473,7 +3476,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3492,7 +3495,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3964,7 +3967,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4214,7 +4217,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4253,7 +4256,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4289,7 +4292,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4323,7 +4326,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4360,7 +4363,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4394,7 +4397,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4468,7 +4471,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2197,13 +2197,17 @@ type Extract500<T> = Exclude<
 	AnyElysiaCustomStatusResponse | undefined | void
 >
 
-export type ValueToErrorResponseSchema<Value> =
-	ExtractErrorFromHandle<Value> &
-		(Extract500<Value> extends infer R500
-			? IsNever<R500> extends true
-				? {}
-				: { 500: R500 }
-			: {})
+type MergeDefaultErrorResponse<Base extends PossibleResponse, R500> =
+	IsNever<R500> extends true
+		? Base
+		: Omit<Base, 500> & {
+				500: (500 extends keyof Base ? Base[500] : never) | R500
+			}
+
+export type ValueToErrorResponseSchema<Value> = MergeDefaultErrorResponse<
+	ExtractErrorFromHandle<Value>,
+	Extract500<Value>
+>
 
 export type ValueOrFunctionToResponseSchema<T> = T extends (
 	...a: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -2192,6 +2192,19 @@ export type ValueToResponseSchema<Value> = ExtractErrorFromHandle<Value> &
 				: { 200: R200 }
 		: {})
 
+type Extract500<T> = Exclude<
+	T,
+	AnyElysiaCustomStatusResponse | undefined | void
+>
+
+export type ValueToErrorResponseSchema<Value> =
+	ExtractErrorFromHandle<Value> &
+		(Extract500<Value> extends infer R500
+			? IsNever<R500> extends true
+				? {}
+				: { 500: R500 }
+			: {})
+
 export type ValueOrFunctionToResponseSchema<T> = T extends (
 	...a: any
 ) => MaybePromise<infer R>
@@ -2226,6 +2239,42 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 			? ElysiaHandlerToResponseSchema<Schemas>
 			: Schemas extends Function[]
 				? ElysiaHandlerToResponseSchemas<Schemas>
+				: {}
+
+export type ElysiaErrorHandlerToResponseSchema<
+	in out Handle extends Function
+> = Prettify<
+	Handle extends (...a: any) => MaybePromise<infer R>
+		? ValueToErrorResponseSchema<Exclude<R, undefined>>
+		: {}
+>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			// @ts-ignore trust me bro
+			UnionResponseStatus<
+				Current extends Function
+					? ElysiaErrorHandlerToResponseSchema<Current>
+					: {},
+				Carry
+			>
+		>
+	: Prettify<Carry>
+
+export type ElysiaErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ElysiaErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ElysiaErrorHandlerToResponseSchemas<Schemas>
 				: {}
 
 type ReconcileStatus<

--- a/src/universal/file.ts
+++ b/src/universal/file.ts
@@ -163,6 +163,6 @@ export class ElysiaFile {
 	get length() {
 		if (isBun) return (this.value as BunFile).size
 
-		return this.stats?.then((x) => x.size) ?? 0
+		return this.stats?.then((x) => x?.size ?? 0) ?? 0
 	}
 }

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -141,6 +141,45 @@ describe('error', () => {
 	)
 
 	it.each([true, false])(
+		'uses error status for plain onError response with aot: %p',
+		async (aot) => {
+			const error = new Error('boom') as Error & { status: number }
+			error.status = 418
+
+			const app = new Elysia({ aot })
+				.onError(({ error }) => ({ error: error.message }))
+				.get('/', () => {
+					throw error
+				})
+
+			const response = await app.handle(req('/'))
+
+			expect(response.status).toBe(418)
+			expect(await response.json()).toEqual({ error: 'boom' })
+		}
+	)
+
+	it.each([true, false])(
+		'preserves set status for plain onError response with aot: %p',
+		async (aot) => {
+			const app = new Elysia({ aot })
+				.onError(({ error, set }) => {
+					set.status = 418
+
+					return { error: error.message }
+				})
+				.get('/', () => {
+					throw new Error('boom')
+				})
+
+			const response = await app.handle(req('/'))
+
+			expect(response.status).toBe(418)
+			expect(await response.json()).toEqual({ error: 'boom' })
+		}
+	)
+
+	it.each([true, false])(
 		'return correct number status on error function with aot: %p',
 		async (aot) => {
 			const app = new Elysia({ aot }).get('/', ({ status }) =>

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -125,6 +125,22 @@ describe('error', () => {
 	})
 
 	it.each([true, false])(
+		'defaults plain onError response to 500 with aot: %p',
+		async (aot) => {
+			const app = new Elysia({ aot })
+				.onError(({ error }) => ({ error: error.message }))
+				.get('/', () => {
+					throw new Error('boom')
+				})
+
+			const response = await app.handle(req('/'))
+
+			expect(response.status).toBe(500)
+			expect(await response.json()).toEqual({ error: 'boom' })
+		}
+	)
+
+	it.each([true, false])(
 		'return correct number status on error function with aot: %p',
 		async (aot) => {
 			const app = new Elysia({ aot }).get('/', ({ status }) =>

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1079,6 +1079,29 @@ import { Prettify } from '../../../src/types'
 	}>()
 }
 
+// onError explicit 500 response merges with plain default response
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			Math.random() > 0.5
+				? status(500, { code: 'custom' as const })
+				: { failure: 'plain' as const }
+		)
+		.get('/throws', () => {
+			throw new Error('boom')
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		500: { readonly code: 'custom' } | { failure: 'plain' }
+	}>()
+
+	expectTypeOf<
+		(typeof app)['~Routes']['throws']['get']['response']
+	>().toEqualTypeOf<{
+		500: { readonly code: 'custom' } | { failure: 'plain' }
+	}>()
+}
+
 // resolve local
 {
 	const app = new Elysia()

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1007,10 +1007,10 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1028,10 +1028,10 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1049,10 +1049,33 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
+	}>()
+}
+
+// onError plain return infers default error status
+{
+	const app = new Elysia()
+		.onError(() => ({ failure: 'boom' as string }))
+		.get('/throws', () => {
+			throw new Error('boom')
+		})
+
+	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
+		500: {
+			failure: string
+		}
+	}>()
+
+	expectTypeOf<
+		(typeof app)['~Routes']['throws']['get']['response']
+	>().toEqualTypeOf<{
+		500: {
+			failure: string
+		}
 	}>()
 }
 


### PR DESCRIPTION
## Summary
- infer plain `onError` returns as default `500` error responses instead of successful `200` responses
- default plain JSON/string `onError` runtime responses to the original error status, falling back to `500`
- keep explicit `status(...)` returns on their declared status codes
- guard nullable file stat results so the current type suite passes cleanly

## Tests
- `npm run test:types`
- `npx bun test test/lifecycle/error.test.ts`

Fixes #313

@algora-pbc /claim #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when file size/metadata is missing
  * Ensured error responses default to HTTP 500 when status is unspecified
  * Tightened error-handler fallback behavior for more consistent responses

* **Types**
  * Enhanced type-level inference for error-handler response schemas and related public typings

* **Tests**
  * Added tests covering default 500 error responses and onError behavior across configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elysiajs/elysia/pull/1892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->