### PR TITLE
Fix README image alt typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <br>
 
-![Elysia chan cover | bun creeate elysia app](https://github.com/user-attachments/assets/a649731a-8cba-4ca2-8424-6656cbf84956)
+![Elysia chan cover | bun create elysia app](https://github.com/user-attachments/assets/a649731a-8cba-4ca2-8424-6656cbf84956)
 
 <!---
 ```bash


### PR DESCRIPTION
## Summary

Fixes a typo in the README image alt text: `creeate` -> `create`.

## Validation

- `git diff --check`

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typo in README banner image alt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->