### PR TITLE
fix(sucrose): parse compact method parameters

### DIFF
--- a/src/sucrose.ts
+++ b/src/sucrose.ts
@@ -111,15 +111,30 @@ export const separateFunction = (
 	const start = code.indexOf('(')
 
 	if (start !== -1) {
-		const sep = code.indexOf('\n', 2)
-		const parameter = code.slice(0, sep)
-		const end = parameter.lastIndexOf(')') + 1
+		let end = start + 1
+		let deep = 1
 
-		const body = code.slice(sep + 1)
+		for (; end < code.length; end++) {
+			const char = code.charCodeAt(end)
+
+			if (char === 40) deep++
+			else if (char === 41) deep--
+
+			if (deep === 0) break
+		}
+
+		if (deep !== 0) {
+			const x = code.split('\n', 2)
+
+			return [x[0], x[1], { isArrowReturn: false }]
+		}
+
+		let body = code.slice(end + 1).trimStart()
+		if (body.charCodeAt(0) !== 123) body = '{' + body
 
 		return [
-			parameter.slice(start, end),
-			'{' + body,
+			code.slice(start + 1, end),
+			body,
 			{
 				isArrowReturn: false
 			}
@@ -550,11 +565,12 @@ export const isContextPassToFunction = (
 ) => {
 	// ! Function is passed to another function, assume as all is accessed
 	try {
+		const escapedContext = context.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 		const captureFunction = new RegExp(
-			`\\w\\((?:.*?)?${context}(?:.*?)?\\)`,
+			`\\w\\((?:.*?)?${escapedContext}(?:.*?)?\\)`,
 			'gs'
 		)
-		const exactParameter = new RegExp(`${context}(,|\\))`, 'gs')
+		const exactParameter = new RegExp(`${escapedContext}(,|\\))`, 'gs')
 
 		const length = body.length
 		let fn

--- a/src/sucrose.ts
+++ b/src/sucrose.ts
@@ -35,6 +35,94 @@ export namespace Sucrose {
 	}
 }
 
+const skipString = (code: string, index: number, quote: number) => {
+	for (let i = index + 1; i < code.length; i++) {
+		const char = code.charCodeAt(i)
+
+		if (char === 92) {
+			i++
+			continue
+		}
+
+		if (char === quote) return i
+	}
+
+	return code.length - 1
+}
+
+const skipBlockComment = (code: string, index: number) => {
+	const end = code.indexOf('*/', index + 2)
+
+	return end === -1 ? code.length - 1 : end + 1
+}
+
+const skipLineComment = (code: string, index: number) => {
+	const end = code.indexOf('\n', index + 2)
+
+	return end === -1 ? code.length - 1 : end
+}
+
+const skipTemplate = (code: string, index: number): number => {
+	for (let i = index + 1; i < code.length; i++) {
+		const char = code.charCodeAt(i)
+
+		if (char === 92) {
+			i++
+			continue
+		}
+
+		if (char === 96) return i
+
+		if (char === 36 && code.charCodeAt(i + 1) === 123) {
+			i = skipBlock(code, i + 1, 123, 125)
+			continue
+		}
+	}
+
+	return code.length - 1
+}
+
+const skipBlock = (
+	code: string,
+	index: number,
+	open: number,
+	close: number
+): number => {
+	let deep = 1
+
+	for (let i = index + 1; i < code.length; i++) {
+		const char = code.charCodeAt(i)
+		const next = code.charCodeAt(i + 1)
+
+		if (char === 34 || char === 39) {
+			i = skipString(code, i, char)
+			continue
+		}
+
+		if (char === 96) {
+			i = skipTemplate(code, i)
+			continue
+		}
+
+		if (char === 47 && next === 47) {
+			i = skipLineComment(code, i)
+			continue
+		}
+
+		if (char === 47 && next === 42) {
+			i = skipBlockComment(code, i)
+			continue
+		}
+
+		if (char === open) deep++
+		else if (char === close) deep--
+
+		if (deep === 0) return i
+	}
+
+	return code.length - 1
+}
+
 /**
  * Separate stringified function body and parameter
  *
@@ -116,6 +204,27 @@ export const separateFunction = (
 
 		for (; end < code.length; end++) {
 			const char = code.charCodeAt(end)
+			const next = code.charCodeAt(end + 1)
+
+			if (char === 34 || char === 39) {
+				end = skipString(code, end, char)
+				continue
+			}
+
+			if (char === 96) {
+				end = skipTemplate(code, end)
+				continue
+			}
+
+			if (char === 47 && next === 47) {
+				end = skipLineComment(code, end)
+				continue
+			}
+
+			if (char === 47 && next === 42) {
+				end = skipBlockComment(code, end)
+				continue
+			}
 
 			if (char === 40) deep++
 			else if (char === 41) deep--

--- a/test/sucrose/separate-function.test.ts
+++ b/test/sucrose/separate-function.test.ts
@@ -156,4 +156,29 @@ describe('Sucrose: separateFunction', () => {
 			}
 		])
 	})
+
+	it('separate method with quoted closing paren in default parameter', () => {
+		const method = 'beforeHandle(ctx = createGuard(")")){return ctx.query}'
+
+		expect(separateFunction(method)).toEqual([
+			'ctx = createGuard(")")',
+			'{return ctx.query}',
+			{
+				isArrowReturn: false
+			}
+		])
+	})
+
+	it('separate method with template and comment parens in parameters', () => {
+		const method =
+			'beforeHandle(ctx = createGuard(`value ${")"}`), next = /* ) */ fallback){return next(ctx)}'
+
+		expect(separateFunction(method)).toEqual([
+			'ctx = createGuard(`value ${")"}`), next = /* ) */ fallback',
+			'{return next(ctx)}',
+			{
+				isArrowReturn: false
+			}
+		])
+	})
 })

--- a/test/sucrose/separate-function.test.ts
+++ b/test/sucrose/separate-function.test.ts
@@ -106,4 +106,54 @@ describe('Sucrose: separateFunction', () => {
 			}
 		])
 	})
+
+	it('separate minified method', () => {
+		const method =
+			'beforeHandle(ctx){await executeMiddleware(ctx, guardFn, logMessage)}'
+
+		expect(separateFunction(method)).toEqual([
+			'ctx',
+			'{await executeMiddleware(ctx, guardFn, logMessage)}',
+			{
+				isArrowReturn: false
+			}
+		])
+	})
+
+	it('separate async minified method', () => {
+		const method =
+			'async beforeHandle(ctx){await executeMiddleware(ctx, guardFn)}'
+
+		expect(separateFunction(method)).toEqual([
+			'ctx',
+			'{await executeMiddleware(ctx, guardFn)}',
+			{
+				isArrowReturn: false
+			}
+		])
+	})
+
+	it('separate formatted method', () => {
+		const method = 'beforeHandle(ctx) {\n  return ctx.query\n}'
+
+		expect(separateFunction(method)).toEqual([
+			'ctx',
+			'{\n  return ctx.query\n}',
+			{
+				isArrowReturn: false
+			}
+		])
+	})
+
+	it('separate method with multiple parameters', () => {
+		const method = 'beforeHandle(ctx, next){return next(ctx)}'
+
+		expect(separateFunction(method)).toEqual([
+			'ctx, next',
+			'{return next(ctx)}',
+			{
+				isArrowReturn: false
+			}
+		])
+	})
 })

--- a/test/sucrose/sucrose.test.ts
+++ b/test/sucrose/sucrose.test.ts
@@ -2,7 +2,11 @@
 import { describe, expect, it } from 'bun:test'
 import { Elysia } from '../../src'
 
-import { separateFunction, sucrose } from '../../src/sucrose'
+import {
+	isContextPassToFunction,
+	separateFunction,
+	sucrose
+} from '../../src/sucrose'
 import { req } from '../utils'
 
 describe('sucrose', () => {
@@ -327,5 +331,73 @@ describe('sucrose', () => {
 			url: true,
 			route: true
 		})
+	})
+
+	it('handles minified method context pass without warning', () => {
+		const beforeHandle = () => {}
+		beforeHandle.toString = () =>
+			'beforeHandle(ctx){await executeMiddleware(ctx, guardFn, logMessage)}'
+
+		const log = console.log
+		const logs: unknown[] = []
+		console.log = (...args) => {
+			logs.push(args)
+		}
+
+		try {
+			expect(
+				sucrose({
+					beforeHandle: [beforeHandle]
+				})
+			).toEqual({
+				query: true,
+				headers: true,
+				body: true,
+				cookie: true,
+				set: true,
+				server: true,
+				path: true,
+				url: true,
+				route: true
+			})
+
+			expect(logs).toEqual([])
+		} finally {
+			console.log = log
+		}
+	})
+
+	it('escapes invalid context before function-pass regex', () => {
+		const inference = {
+			query: false,
+			headers: false,
+			body: false,
+			cookie: false,
+			set: false,
+			server: false,
+			path: false,
+			url: false,
+			route: false
+		}
+
+		const log = console.log
+		const logs: unknown[] = []
+		console.log = (...args) => {
+			logs.push(args)
+		}
+
+		try {
+			expect(
+				isContextPassToFunction(
+					'ctx){awaitexecuteMiddleware(ctx',
+					'executeMiddleware(ctx, guardFn)',
+					inference
+				)
+			).toBe(false)
+
+			expect(logs).toEqual([])
+		} finally {
+			console.log = log
+		}
 	})
 })


### PR DESCRIPTION
## Summary
- parse object method parameters by matching the parameter list instead of relying on a newline after the signature
- preserve formatted, compact, async compact, and multi-parameter method bodies
- escape inferred context names before building function-pass regular expressions

Fixes #1860

## Boundary report
- Reproduced the reported compact beforeHandle(ctx){...} shape that previously produced a malformed context like ctx){await...
- Covered compact object methods without whitespace or newlines.
- Covered async compact object methods.
- Covered formatted object methods with a newline after the signature.
- Covered object methods with multiple parameters.
- Covered malformed context strings containing regex syntax, so fallback detection no longer logs the unexpected warning.
- Kept existing arrow function, normal function, destructuring, and context-pass inference tests passing.

## Scope
- This keeps Sucrose string-based inference model.
- It does not replace Sucrose with a JavaScript parser.
- Exotic signatures with unmatched parentheses inside strings remain outside this fix.

## Tests
- bun test test/sucrose/separate-function.test.ts test/sucrose/sucrose.test.ts
- bun test test/sucrose
- bun test test/response/stream.test.ts
- bun run test:types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced method parameter parsing to correctly handle nested parentheses, quoted strings, template literals, and comments
  * Fixed context detection to properly handle special characters in context names

* **Tests**
  * Added comprehensive test coverage for method parsing with various syntax forms and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->