### PR TITLE
fix(cookie): support encode option

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -601,10 +601,12 @@ export const composeHandler = ({
 	const cookieMeta: {
 		secrets?: string | string[]
 		sign: string[] | true
+		encode?: CookieOptions['encode']
 		properties: { [x: string]: Object }
 	} = validator.cookie?.config
 		? mergeCookie(validator?.cookie?.config, app.config.cookie as any)
 		: app.config.cookie
+	const hasCookieEncode = typeof cookieMeta?.encode === 'function'
 
 	let _encodeCookie = ''
 	const encodeCookie = () => {
@@ -736,6 +738,7 @@ export const composeHandler = ({
 				get('priority') +
 				get('sameSite') +
 				get('secure') +
+				(hasCookieEncode ? 'encode:cookieEncode,' : '') +
 				'}'
 			: 'undefined'
 
@@ -2151,6 +2154,7 @@ export const composeHandler = ({
 		allocateIf(`parseCookie,`, hasCookie) +
 		allocateIf(`signCookie,`, hasCookie) +
 		allocateIf(`decodeURIComponent,`, hasQuery) +
+		allocateIf(`cookieEncode,`, hasCookieEncode) +
 		`ElysiaCustomStatusResponse,` +
 		allocateIf(`ELYSIA_TRACE,`, hasTrace) +
 		allocateIf(`ELYSIA_REQUEST_ID,`, hasTrace) +
@@ -2205,6 +2209,7 @@ export const composeHandler = ({
 			ERROR_CODE,
 			parseCookie: hasCookie ? parseCookie : undefined,
 			signCookie: hasCookie ? signCookie : undefined,
+			cookieEncode: hasCookieEncode ? cookieMeta.encode : undefined,
 			Cookie: hasCookie ? Cookie : undefined,
 			decodeURIComponent: hasQuery ? decode : undefined,
 			ElysiaCustomStatusResponse,

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -122,6 +122,14 @@ export interface CookieOptions {
 	secure?: boolean | undefined
 
 	/**
+	 * Specifies a function that will be used to encode a cookie value before
+	 * serializing it into the `Set-Cookie` header.
+	 *
+	 * @default encodeURIComponent
+	 */
+	encode?: ((value: string) => string) | undefined
+
+	/**
 	 * Secret key for signing cookie
 	 *
 	 * If array is passed, will use Key Rotation.
@@ -295,6 +303,14 @@ export class Cookie<T> implements ElysiaCookie {
 
 	set partitioned(partitioned: boolean | undefined) {
 		this.setCookie.partitioned = partitioned
+	}
+
+	get encode() {
+		return this.cookie.encode
+	}
+
+	set encode(encode: ElysiaCookie['encode']) {
+		this.setCookie.encode = encode
 	}
 
 	get secrets() {

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -476,7 +476,7 @@ export const createDynamicHandler = (app: AnyElysia) => {
 					routeCookieConfig?.partitioned,
 				sameSite: app.config.cookie?.sameSite ?? routeCookieConfig?.sameSite,
 				secure: app.config.cookie?.secure ?? routeCookieConfig?.secure,
-				encode: app.config.cookie?.encode ?? routeCookieConfig?.encode,
+				encode: routeCookieConfig?.encode ?? app.config.cookie?.encode,
 				secrets: app.config.cookie?.secrets ?? routeCookieConfig?.secrets,
 				sign: app.config.cookie?.sign ?? routeCookieConfig?.sign
 			} as CookieOptions & {

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -447,47 +447,38 @@ export const createDynamicHandler = (app: AnyElysia) => {
 			for (const [key, value] of request.headers.entries())
 				context.headers[key] = value
 
+			const routeCookieConfig = (
+				(hooks as {
+					cookie?: {
+						config?: CookieOptions & {
+							sign?: true | string | string[]
+						}
+					}
+				}).cookie?.config ??
+				(validator?.cookie?.config as
+					| (CookieOptions & {
+							sign?: true | string | string[]
+					  })
+					| undefined)
+			)
+
 			const cookieMeta = {
-				domain:
-					app.config.cookie?.domain ??
-					// @ts-expect-error
-					validator?.cookie?.config.domain,
-				expires:
-					app.config.cookie?.expires ??
-					// @ts-expect-error
-					validator?.cookie?.config.expires,
+				domain: app.config.cookie?.domain ?? routeCookieConfig?.domain,
+				expires: app.config.cookie?.expires ?? routeCookieConfig?.expires,
 				httpOnly:
-					app.config.cookie?.httpOnly ??
-					// @ts-expect-error
-					validator?.cookie?.config.httpOnly,
-				maxAge:
-					app.config.cookie?.maxAge ??
-					// @ts-expect-error
-					validator?.cookie?.config.maxAge,
-				// @ts-expect-error
-				path: app.config.cookie?.path ?? validator?.cookie?.config.path,
+					app.config.cookie?.httpOnly ?? routeCookieConfig?.httpOnly,
+				maxAge: app.config.cookie?.maxAge ?? routeCookieConfig?.maxAge,
+				path: app.config.cookie?.path ?? routeCookieConfig?.path,
 				priority:
-					app.config.cookie?.priority ??
-					// @ts-expect-error
-					validator?.cookie?.config.priority,
+					app.config.cookie?.priority ?? routeCookieConfig?.priority,
 				partitioned:
 					app.config.cookie?.partitioned ??
-					// @ts-expect-error
-					validator?.cookie?.config.partitioned,
-				sameSite:
-					app.config.cookie?.sameSite ??
-					// @ts-expect-error
-					validator?.cookie?.config.sameSite,
-				secure:
-					app.config.cookie?.secure ??
-					// @ts-expect-error
-					validator?.cookie?.config.secure,
-				secrets:
-					app.config.cookie?.secrets ??
-					// @ts-expect-error
-					validator?.cookie?.config.secrets,
-				// @ts-expect-error
-				sign: app.config.cookie?.sign ?? validator?.cookie?.config.sign
+					routeCookieConfig?.partitioned,
+				sameSite: app.config.cookie?.sameSite ?? routeCookieConfig?.sameSite,
+				secure: app.config.cookie?.secure ?? routeCookieConfig?.secure,
+				encode: app.config.cookie?.encode ?? routeCookieConfig?.encode,
+				secrets: app.config.cookie?.secrets ?? routeCookieConfig?.secrets,
+				sign: app.config.cookie?.sign ?? routeCookieConfig?.sign
 			} as CookieOptions & {
 				sign?: true | string | string[]
 			}

--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -521,6 +521,7 @@ export const ElysiaType = {
 			priority,
 			sameSite,
 			secure,
+			encode,
 			secrets,
 			sign,
 			...options
@@ -537,6 +538,7 @@ export const ElysiaType = {
 			priority,
 			sameSite,
 			secure,
+			encode,
 			secrets,
 			sign
 		}

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -338,6 +338,37 @@ describe('Cookie Response', () => {
 		])
 	})
 
+	it('uses route cookie encode over constructor in dynamic mode', async () => {
+		const app = new Elysia({
+			aot: false,
+			cookie: {
+				encode: (value) => `app-${value.replaceAll(' ', '-')}`
+			}
+		}).get(
+			'/',
+			({ cookie: { name } }) => {
+				name.value = 'seminar Himari'
+			},
+			{
+				cookie: t.Cookie(
+					{
+						name: t.Optional(t.String())
+					},
+					{
+						encode: (value) =>
+							`route-${value.replaceAll(' ', '-')}`
+					}
+				)
+			}
+		)
+
+		const response = await app.handle(req('/'))
+
+		expect(response.headers.getAll('Set-Cookie')).toEqual([
+			'name=route-seminar-Himari; Path=/'
+		])
+	})
+
 	it('uses cookie encode set on a cookie instance', async () => {
 		const app = new Elysia().get('/', ({ cookie: { name } }) => {
 			name.encode = (value) => value.replaceAll(' ', '+')

--- a/test/cookie/response.test.ts
+++ b/test/cookie/response.test.ts
@@ -255,6 +255,102 @@ describe('Cookie Response', () => {
 		])
 	})
 
+	it('uses cookie encode from constructor', async () => {
+		const app = new Elysia({
+			cookie: {
+				encode: (value) => value.replaceAll(' ', '+')
+			}
+		}).get('/', ({ cookie: { name } }) => {
+			name.value = 'seminar Himari'
+		})
+
+		const response = await app.handle(req('/'))
+
+		expect(response.headers.getAll('Set-Cookie')).toEqual([
+			'name=seminar+Himari; Path=/'
+		])
+	})
+
+	it('uses cookie encode from constructor in dynamic mode', async () => {
+		const app = new Elysia({
+			aot: false,
+			cookie: {
+				encode: (value) => value.replaceAll(' ', '+')
+			}
+		}).get('/', ({ cookie: { name } }) => {
+			name.value = 'seminar Himari'
+		})
+
+		const response = await app.handle(req('/'))
+
+		expect(response.headers.getAll('Set-Cookie')).toEqual([
+			'name=seminar+Himari; Path=/'
+		])
+	})
+
+	it('uses cookie encode from route cookie config', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ cookie: { name } }) => {
+				name.value = 'seminar Himari'
+			},
+			{
+				cookie: t.Cookie(
+					{
+						name: t.Optional(t.String())
+					},
+					{
+						encode: (value) => value.replaceAll(' ', '+')
+					}
+				)
+			}
+		)
+
+		const response = await app.handle(req('/'))
+
+		expect(response.headers.getAll('Set-Cookie')).toEqual([
+			'name=seminar+Himari; Path=/'
+		])
+	})
+
+	it('uses cookie encode from route cookie config in dynamic mode', async () => {
+		const app = new Elysia({ aot: false }).get(
+			'/',
+			({ cookie: { name } }) => {
+				name.value = 'seminar Himari'
+			},
+			{
+				cookie: t.Cookie(
+					{
+						name: t.Optional(t.String())
+					},
+					{
+						encode: (value) => value.replaceAll(' ', '+')
+					}
+				)
+			}
+		)
+
+		const response = await app.handle(req('/'))
+
+		expect(response.headers.getAll('Set-Cookie')).toEqual([
+			'name=seminar+Himari; Path=/'
+		])
+	})
+
+	it('uses cookie encode set on a cookie instance', async () => {
+		const app = new Elysia().get('/', ({ cookie: { name } }) => {
+			name.encode = (value) => value.replaceAll(' ', '+')
+			name.value = 'seminar Himari'
+		})
+
+		const response = await app.handle(req('/'))
+
+		expect(response.headers.getAll('Set-Cookie')).toEqual([
+			'name=seminar+Himari; Path=/'
+		])
+	})
+
 	it('retain cookie value when using set if not provided', async () => {
 		const response = await app.handle(req('/set'))
 


### PR DESCRIPTION
## Summary
- expose `encode` on cookie options and cookie instances
- pass `encode` into cookie parsing/serialization in both AOT and dynamic handlers
- preserve route-level `t.Cookie(..., { encode })` config in dynamic mode

Fixes #1698

## Reproduction
Before this change, a custom cookie encoder was ignored and the response emitted `name=seminar%20Himari; Path=/`:

```ts
new Elysia({
  cookie: {
    encode: (value) => value.replaceAll(' ', '+')
  }
}).get('/', ({ cookie: { name } }) => {
  name.value = 'seminar Himari'
})
```

The expected header is `name=seminar+Himari; Path=/`.

## Boundary report
Covered cases:
- global cookie config in AOT mode
- global cookie config in dynamic mode
- route-level `t.Cookie(..., { encode })` in AOT mode
- route-level `t.Cookie(..., { encode })` in dynamic mode
- per-cookie instance override with `cookie.name.encode = ...`
- existing signed, JSON, remove, unchanged, and validator cookie behavior

## Tests
- `bun test test/cookie/response.test.ts`
- `bun test test/cookie`
- `bun test test/validator/cookie.test.ts`
- `bun run test:types`
- `bun test`
- `bun run test:imports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cookie values can now be encoded using custom encoder functions, configurable at the app level, per-route, or per-cookie instance.
  * Route-level encoders override app-level configuration, enabling fine-grained control over cookie serialization.

* **Tests**
  * Added comprehensive test coverage for custom cookie encoding across configuration scopes and precedence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->