### PR TITLE
fix(aot): continue onError after undefined

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2077,6 +2077,8 @@ export const composeHandler = ({
 
 			endUnit()
 
+			fnLiteral += `if(er!==undefined&&er!==null){`
+
 			if (hooks.mapResponse?.length) {
 				const mapResponseReporter = report('mapResponse', {
 					total: hooks.mapResponse?.length
@@ -2112,6 +2114,7 @@ export const composeHandler = ({
 
 			fnLiteral += afterResponse(false)
 			fnLiteral += `return er}`
+			fnLiteral += '}'
 		}
 	}
 

--- a/test/core/handle-error.test.ts
+++ b/test/core/handle-error.test.ts
@@ -141,6 +141,70 @@ describe('Handle Error', () => {
 		expect(response.status).toEqual(418)
 	})
 
+	it('continues to next onError when previous hook returns undefined', async () => {
+		for (const aot of [true, false]) {
+			const calls: string[] = []
+
+			const logger = new Elysia({
+				name: `logger-on-error-${aot}`
+			}).onError({ as: 'global' }, () => {
+				calls.push('logger')
+			})
+
+			const responseWrapper = new Elysia({
+				name: `response-wrapper-${aot}`
+			})
+				.onError({ as: 'global' }, ({ error, set }) => {
+					calls.push('response-wrapper')
+					set.status = 200
+
+					return Response.json({
+						code: 403,
+						msg: error instanceof Error ? error.message : 'Forbidden',
+						data: null
+					})
+				})
+				.mapResponse({ as: 'global' }, ({ response, set }) => {
+					if (response instanceof Response) return response
+
+					set.status = 200
+
+					return Response.json({
+						code: 200,
+						msg: 'success',
+						data: response ?? null
+					})
+				})
+
+			const guard = new Elysia({
+				name: `guard-${aot}`
+			}).onBeforeHandle({ as: 'scoped' }, () => {
+				throw new Error('denied by nested guard')
+			})
+
+			const app = new Elysia({ aot })
+				.use(logger)
+				.use(responseWrapper)
+				.use(
+					new Elysia({ prefix: '/api' }).group('', (app) =>
+						app.use(guard).post('/guarded', () => ({ ok: true }))
+					)
+				)
+
+			const response = await app.handle(
+				req('/api/guarded', { method: 'POST' })
+			)
+
+			expect(response.status).toBe(200)
+			expect(await response.json()).toEqual({
+				code: 403,
+				msg: 'denied by nested guard',
+				data: null
+			})
+			expect(calls).toEqual(['logger', 'response-wrapper'])
+		}
+	})
+
 	it('handle thrown error function', async () => {
 		const app = new Elysia().get('/', ({ status }) => {
 			throw status(404, 'Not Found :(')


### PR DESCRIPTION
## Summary
- continue the AOT onError chain when a handler returns undefined or null
- only run `mapResponse`/`mapEarlyResponse` for an `onError` result that actually handled the error
- add regression coverage for nested guard errors with a logging `onError` before a response-producing `onError`

Fixes #1900

## Reproduction
Minimal reproduction repo:

https://github.com/lxy2500798479/elysia-onerror-chain-repro

In AOT mode, a logging-only global `onError` followed by a response-producing global `onError` could skip the second handler when a nested guard threw. If a `mapResponse` hook was present, it could receive `undefined` and turn the error into a success-shaped response.

## Boundary report
- AOT and dynamic modes covered in the same regression test
- nested `group` + `use` + `onBeforeHandle` throw path covered
- earlier `onError` returning `undefined` covered
- global `mapResponse` converting `undefined` covered
- existing core error handling and dynamic mode tests still pass

## Tests
- `bun test test/core/handle-error.test.ts`
- `bun test test/core/handle-error.test.ts test/core/dynamic.test.ts`
- `bun run test:types`
- `bun test`
- `bun run test:imports`