### PR TITLE
fix(types): preserve macro resolve unions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1034,6 +1034,23 @@ type MergeFlattenMacroResponse<A, B> = {
 			? B[K]
 			: never
 }
+
+type UnionKeys<T> = T extends unknown ? keyof T : never
+
+type UnionValue<T, K extends PropertyKey> = T extends unknown
+	? K extends keyof T
+		? T[K]
+		: never
+	: never
+
+type MergeObjectUnion<T> = [T] extends [object]
+	? Prettify<
+			{
+				[K in UnionKeys<T>]: UnionValue<T, K>
+			}
+		>
+	: T
+
 type UnionMacroContext<A> = UnionToIntersect<{
 	[K in Exclude<keyof A, 'return'>]: A[K]
 }> & {
@@ -1054,7 +1071,12 @@ export type MacroToContext<
 		R
 	> extends infer A
 		? {
-				[K in Exclude<keyof A, 'return'>]: UnionToIntersect<A[K]>
+				[K in Exclude<
+					keyof A,
+					'return'
+				>]: K extends 'resolve'
+					? MergeObjectUnion<A[K]>
+					: UnionToIntersect<A[K]>
 			} & Prettify<{
 				// @ts-ignore
 				return: FlattenMacroResponse<A['return']>

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -231,6 +231,44 @@ import { expectTypeOf } from 'expect-type'
 		)
 }
 
+// resolve union of object shapes preserves shared context
+{
+	const plugin = new Elysia({ name: 'plugin' }).macro({
+		withUser: {
+			resolve() {
+				if (Math.random() > 0.5)
+					return {
+						user: {
+							id: 'a'
+						}
+					}
+
+				return {
+					user: {
+						id: 'b'
+					},
+					admin: true
+				}
+			}
+		}
+	})
+
+	new Elysia()
+		.use(plugin)
+		.get(
+			'/',
+			({ user, admin }) => {
+				expectTypeOf(user).toEqualTypeOf<{ id: string }>()
+				expectTypeOf(admin).toEqualTypeOf<boolean | undefined>()
+
+				return user.id
+			},
+			{
+				withUser: true
+			}
+		)
+}
+
 // resolve with custom status
 {
 	const app = new Elysia()


### PR DESCRIPTION
## Summary
- preserve union object values from macro `resolve` instead of intersecting them into `never`
- keep existing intersection behavior for schema/response macro context merging
- add a regression test for a macro whose `resolve` returns different object shapes

Fixes #1891

## Reproduction
A macro `resolve` returning `{ user: { id } } | { user: { id }, admin: true }` previously inferred `user` as `never` inside the route handler. The new type test verifies `user` remains `{ id: string }` and `admin` remains `boolean | undefined`.

## Boundary report
- scoped to type-level macro context merging only
- runtime macro behavior unchanged
- multiple macro resolve fields still merge into one route context
- schema and response macro merging still use the existing intersection path

## Tests
- `bun run test:types`
- `bun test test/macro/macro.test.ts`
- `bun test`
- `bun run test:imports`
- `bun run build`
- `bun run test:node`

Note: `bun run test` executes `test:node` without building `dist` first in this checkout, so `test:node` fails from missing `dist/index.js` unless `bun run build` runs first. After building, `bun run test:node` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for macros that resolve to unions of different object shapes. Conditional properties are now correctly inferred as optional or required based on whether they appear across all resolved shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->