### PR TITLE
fix(types): infer params in function macro resolve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,7 @@ import type {
 	UnionResponseStatus,
 	CreateEdenResponse,
 	MacroProperty,
+	ResolveHandler,
 	MaybeValueOrVoidFunction,
 	IntersectIfObject,
 	IntersectIfObjectSchema,
@@ -5400,6 +5401,132 @@ export default class Elysia<
 			}
 			macroFn: Metadata['macroFn'] & {
 				[name in Name]: Property
+			}
+			parser: Metadata['parser']
+			response: Metadata['response']
+		},
+		Routes,
+		Ephemeral,
+		Volatile
+	>
+
+	macro<
+		const Name extends string,
+		const Params extends InputSchema<
+			keyof Definitions['typebox'] & string
+		>['params'],
+		const Body extends InputSchema<
+			keyof Definitions['typebox'] & string
+		>['body'] = undefined,
+		const Headers extends InputSchema<
+			keyof Definitions['typebox'] & string
+		>['headers'] = undefined,
+		const Query extends InputSchema<
+			keyof Definitions['typebox'] & string
+		>['query'] = undefined,
+		const Cookie extends InputSchema<
+			keyof Definitions['typebox'] & string
+		>['cookie'] = undefined,
+		const Response extends InputSchema<
+			keyof Definitions['typebox'] & string
+		>['response'] = undefined,
+		const Derivative extends
+			| Record<string, unknown>
+			| ElysiaCustomStatusResponse<any, any, any>
+			| void =
+			| Record<string, unknown>
+			| ElysiaCustomStatusResponse<any, any, any>
+			| void,
+		const Args extends any[] = any[],
+		const Schema extends RouteSchema = IntersectIfObjectSchema<
+			MergeSchema<
+				UnwrapRoute<
+					{
+						body: Body
+						headers: Headers
+						query: Query
+						params: Params
+						cookie: Cookie
+						response: Response
+					},
+					Definitions['typebox'],
+					BasePath
+				>,
+				MergeSchema<
+					Volatile['schema'],
+					MergeSchema<Ephemeral['schema'], Metadata['schema']>
+				>
+			>,
+			Metadata['standaloneSchema'] &
+				Ephemeral['standaloneSchema'] &
+				Volatile['standaloneSchema']
+		>,
+		const SingletonContext extends SingletonBase = Singleton & {
+			derive: Partial<Ephemeral['derive'] & Volatile['derive']>
+			resolve: Partial<Ephemeral['resolve'] & Volatile['resolve']>
+		},
+		const Resolve extends ResolveHandler<
+			Schema,
+			SingletonContext,
+			Derivative
+		> = ResolveHandler<Schema, SingletonContext, Derivative>
+	>(
+		macro: [Name] extends [never]
+			? never
+			: {
+					[name in Name]: (...args: Args) => {
+						body?: Body
+						headers?: Headers
+						query?: Query
+						params: Params
+						cookie?: Cookie
+						response?: Response
+						resolve: Resolve &
+							ResolveHandler<Schema, SingletonContext, Derivative>
+					} & Omit<
+						MacroProperty<
+							Metadata['macro'] &
+								InputSchema<
+									keyof Definitions['typebox'] & string
+								>,
+							Schema,
+							SingletonContext,
+							Definitions['error']
+						>,
+						'resolve'
+					>
+				}
+	): Elysia<
+		BasePath,
+		Singleton,
+		Definitions,
+		{
+			schema: Metadata['schema']
+			standaloneSchema: Metadata['standaloneSchema']
+			macro: Metadata['macro'] & {
+				[name in Name]?: Args extends [infer Params, ...any[]]
+					? Params
+					: boolean
+			}
+			macroFn: Metadata['macroFn'] & {
+				[name in Name]: (...args: Args) => {
+					body?: Body
+					headers?: Headers
+					query?: Query
+					params: Params
+					cookie?: Cookie
+					response?: Response
+					resolve: Resolve
+				} & Omit<
+					MacroProperty<
+						Metadata['macro'] &
+							InputSchema<keyof Definitions['typebox'] & string>,
+						Schema,
+						SingletonContext,
+						Definitions['error']
+					>,
+					'resolve'
+				>
 			}
 			parser: Metadata['parser']
 			response: Metadata['response']

--- a/test/types/macro.ts
+++ b/test/types/macro.ts
@@ -231,6 +231,37 @@ import { expectTypeOf } from 'expect-type'
 		)
 }
 
+// Handle function macro resolve schema
+{
+	const plugin = new Elysia().macro({
+		withParam: (enabled: boolean) => ({
+			params: t.Object({
+				id: t.String()
+			}),
+			resolve({ params }) {
+				expectTypeOf(params).toEqualTypeOf<{
+					id: string
+				}>()
+
+				return {
+					paramId: params.id
+				}
+			}
+		})
+	})
+
+	new Elysia().use(plugin).get(
+		'/:id',
+		({ params, paramId }) => {
+			expectTypeOf(params).toEqualTypeOf<{ id: string }>()
+			expectTypeOf(paramId).toEqualTypeOf<string>()
+		},
+		{
+			withParam: true
+		}
+	)
+}
+
 // resolve with custom status
 {
 	const app = new Elysia()


### PR DESCRIPTION
Closes #1834

## Problem

Function-style macros can return a local `params` schema, but the sibling `resolve` callback is typed before that returned schema is available. As a result, `resolve({ params })` sees `params` as an empty object even though runtime validation and route handler inference both use the schema.

## Fix

Add a narrow overload for function-style object macros that return a `params` schema and a single `resolve` function. The overload gives the returned object contextual typing from the local params schema, while preserving the exact resolve function type in `macroFn` so existing macro context extraction still works.

The broader macro overloads remain in place for static macros, multi-macro objects, recursive macro composition, and resolve arrays.

## Tests

- Added a type regression in `test/types/macro.ts` for a function macro with `params` inside `resolve`.
- Verified the selected macro still exposes both route `params` and returned resolve context.

## Verification

- `bun run test:types`
- `bun test test/macro/macro.test.ts`
- `bun run test:imports`
- `bun run build`
- `bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced macro function type definitions with explicit schema component derivation and improved resolve handler typing for better developer experience with TypeScript.

* **Tests**
  * Added test coverage for macro resolve schema handling with type assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->