### PR TITLE
fix(query): coerce numeric literal unions

### DIFF
--- a/src/replace-schema.ts
+++ b/src/replace-schema.ts
@@ -1,5 +1,6 @@
 import { Kind, type TAnySchema, type TSchema } from "@sinclair/typebox";
 import { t } from "./type-system";
+import { compile } from "./type-system/utils";
 import type { MaybeArray } from "./types";
 
 export interface ReplaceSchemaTypeOptions {
@@ -205,9 +206,35 @@ export const stringToStructureCoercions = () => {
 
 let _queryCoercions: ReplaceSchemaTypeOptions[];
 
+const coerceNumericLiteralUnion = (schema: TSchema) => {
+	if (
+		!schema.anyOf?.length ||
+		!schema.anyOf.every((variant: TSchema) => typeof variant.const === "number")
+	)
+		return schema;
+
+	const compiler = compile(schema);
+
+	return t
+		.Transform(t.Union([t.String({ format: "numeric" }), schema], schema))
+		.Decode((value) => {
+			const number = +(value as string | number);
+
+			if (Number.isNaN(number) || !compiler.Check(number))
+				throw compiler.Error(number);
+
+			return number;
+		})
+		.Encode((value) => value) as any;
+};
+
 export const queryCoercions = () => {
 	if (!_queryCoercions) {
 		_queryCoercions = [
+			{
+				from: t.Union([t.Any(), t.Any()]),
+				to: coerceNumericLiteralUnion,
+			},
 			{
 				from: t.Object({}),
 				to: (schema) => t.ObjectString(schema.properties ?? {}, schema),

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -166,6 +166,41 @@ describe('Query Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('parse numeric literal union', async () => {
+		const app = new Elysia().get(
+			'/',
+			({ query: { totalPages } }) => ({
+				totalPages,
+				type: typeof totalPages
+			}),
+			{
+				query: t.Object({
+					totalPages: t.Union([
+						t.Literal(10),
+						t.Literal(50),
+						t.Literal(100)
+					])
+				})
+			}
+		)
+
+		const res = await app.handle(req('/?totalPages=50'))
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({
+			totalPages: 50,
+			type: 'number'
+		})
+
+		const invalid = await app.handle(req('/?totalPages=25'))
+
+		expect(invalid.status).toBe(422)
+
+		const invalidString = await app.handle(req('/?totalPages=abc'))
+
+		expect(invalidString.status).toBe(422)
+	})
+
 	it('parse single integer', async () => {
 		const app = new Elysia().get('/', ({ query: { limit } }) => limit, {
 			query: t.Object({


### PR DESCRIPTION
Closes #1804

## Problem

Query string values arrive as strings, so a query schema like:

```ts
t.Object({
  totalPages: t.Union([
    t.Literal(10),
    t.Literal(50),
    t.Literal(100)
  ])
})
```

does not accept `?totalPages=50` as the numeric literal `50`.

## Fix

This adds a query-specific coercion for unions where every variant is a numeric literal. The transform accepts numeric query strings, decodes them to numbers, and then validates the decoded value against the original union compiler before returning it.

Boundary behavior:

- `?totalPages=50` is decoded to `50` and passes.
- `?totalPages=25` still fails with validation error.
- `?totalPages=abc` still fails with validation error.
- Mixed or non-numeric literal unions are left unchanged.

## Tests

Added a regression case in `test/validator/query.test.ts` covering valid numeric literal decoding and invalid query values.

Verification run:

- `bun test test/validator/query.test.ts`
- `git diff --check`
- `bun run build`
- `bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced query parameter validation with support for numeric literal unions, enabling strict enforcement of specific numeric values while automatically converting string inputs to numbers and rejecting invalid entries.

* **Tests**
  * Added test coverage for numeric literal union query validation including valid numeric literal matches, type coercion verification, and rejection of non-matching values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->