### PR TITLE
fix(validation): preserve transform decode paths

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -35,7 +35,8 @@ import {
 	NotFoundError,
 	ValidationError,
 	ERROR_CODE,
-	ElysiaCustomStatusResponse
+	ElysiaCustomStatusResponse,
+	mapTransformDecodeError
 } from './error'
 import { ELYSIA_TRACE, type TraceHandler } from './trace'
 
@@ -466,7 +467,7 @@ const coerceTransformDecodeError = (
 	`try{${fnLiteral}}catch(error){` +
 	`if(error.constructor.name === 'TransformDecodeError'){` +
 	`c.set.status=422\n` +
-	`throw error.error ?? new ValidationError('${type}',validator.${type},${value},${allowUnsafeValidationDetails})}` +
+	`throw mapTransformDecodeError(error,'${type}',validator.${type},${value},${allowUnsafeValidationDetails})}` +
 	`}`
 
 const setImmediateFn = hasSetImmediate
@@ -2141,6 +2142,7 @@ export const composeHandler = ({
 		`},` +
 		`error:{` +
 		allocateIf(`ValidationError,`, hasValidation) +
+		allocateIf(`mapTransformDecodeError,`, hasValidation) +
 		allocateIf(`ParseError`, hasBody) +
 		`},` +
 		`fileType,` +
@@ -2195,6 +2197,9 @@ export const composeHandler = ({
 			},
 			error: {
 				ValidationError: hasValidation ? ValidationError : undefined,
+				mapTransformDecodeError: hasValidation
+					? mapTransformDecodeError
+					: undefined,
 				ParseError: hasBody ? ParseError : undefined
 			},
 			fileType,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -468,6 +468,7 @@ const coerceTransformDecodeError = (
 	`if(error.constructor.name === 'TransformDecodeError'){` +
 	`c.set.status=422\n` +
 	`throw mapTransformDecodeError(error,'${type}',validator.${type},${value},${allowUnsafeValidationDetails})}` +
+	`if(error.constructor.name!=='TransformDecodeCheckError')throw error` +
 	`}`
 
 const setImmediateFn = hasSetImmediate

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -3,6 +3,7 @@ import type { Context } from './context'
 import { parseCookie } from './cookies'
 import {
 	ElysiaCustomStatusResponse,
+	mapTransformDecodeError,
 	type ElysiaErrors,
 	NotFoundError,
 	status,
@@ -38,6 +39,21 @@ export type DynamicHandler = {
  */
 const ARRAY_INDEX_REGEX = /^(.+)\[(\d+)\]$/
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+const decodeValidator = (
+	type: string,
+	validator: ElysiaTypeCheck<any>,
+	value: unknown
+) => {
+	try {
+		return validator.Decode(value)
+	} catch (error) {
+		if (error instanceof TransformDecodeError)
+			throw mapTransformDecodeError(error, type, validator, value)
+
+		throw error
+	}
+}
 
 const isDangerousKey = (key: string): boolean => {
 	if (DANGEROUS_KEYS.has(key)) return true
@@ -544,7 +560,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						)
 				} else if (validator.headers?.Decode)
 					// @ts-ignore
-					context.headers = validator.headers.Decode(context.headers)
+					context.headers = decodeValidator(
+						'header',
+						validator.headers,
+						context.headers
+					)
 
 				if (paramsValidator?.Check(context.params) === false) {
 					throw new ValidationError(
@@ -554,7 +574,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 					)
 				} else if (validator.params?.Decode)
 					// @ts-ignore
-					context.params = validator.params.Decode(context.params)
+					context.params = decodeValidator(
+						'params',
+						validator.params,
+						context.params
+					)
 
 				if (validator.query?.schema) {
 					let schema = validator.query.schema
@@ -587,7 +611,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						context.query
 					)
 				else if (validator.query?.Decode)
-					context.query = validator.query.Decode(context.query) as any
+					context.query = decodeValidator(
+						'query',
+						validator.query,
+						context.query
+					) as any
 
 				if (validator.createCookie?.()) {
 					let cookieValue: Record<string, unknown> = {}
@@ -601,7 +629,9 @@ export const createDynamicHandler = (app: AnyElysia) => {
 							cookieValue
 						)
 					else if (validator.cookie?.Decode)
-						cookieValue = validator.cookie.Decode(
+						cookieValue = decodeValidator(
+							'cookie',
+							validator.cookie,
 							cookieValue
 						) as any
 				}
@@ -609,12 +639,15 @@ export const createDynamicHandler = (app: AnyElysia) => {
 				if (validator.createBody?.()?.Check(body) === false)
 					throw new ValidationError('body', validator.body!, body)
 				else if (validator.body?.Decode) {
-						let decoded = validator.body.Decode(body) as any
-						if (decoded instanceof Promise)
-							decoded = await decoded
+					let decoded = decodeValidator(
+						'body',
+						validator.body,
+						body
+					) as any
+					if (decoded instanceof Promise) decoded = await decoded
 
-						// Zod returns { value: ... } wrapper
-						context.body = decoded?.value ?? decoded
+					// Zod returns { value: ... } wrapper
+					context.body = decoded?.value ?? decoded
 				}
 			}
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -297,6 +297,8 @@ export class ValidationError extends Error {
 	 * use this instead of message
 	 */
 	valueError?: ValueError
+	private _validationErrors?: ValueError[]
+	private _mappedValidationErrors?: ValueErrorWithSummary[]
 
 	/**
 	 * Alias of `valueError`
@@ -333,6 +335,10 @@ export class ValidationError extends Error {
 		let error
 		let expected
 		let customError
+		let validationErrorsCache: ValueError[] | undefined
+		let mappedValidationErrorsCache:
+			| ValueErrorWithSummary[]
+			| undefined
 
 		if (
 			// @ts-ignore
@@ -395,6 +401,8 @@ export class ValidationError extends Error {
 			const mappedValidationErrors = validationErrors
 				.map(mapValueError)
 				.filter((x): x is ValueErrorWithSummary => !!x)
+			validationErrorsCache = validationErrors
+			mappedValidationErrorsCache = mappedValidationErrors
 
 			const accessor = error?.path || 'root'
 
@@ -473,11 +481,20 @@ export class ValidationError extends Error {
 		this.valueError = error
 		this.expected = expected
 		this.customError = customError
+		this._validationErrors = validationErrorsCache
+		this._mappedValidationErrors = mappedValidationErrorsCache
 
 		Object.setPrototypeOf(this, ValidationError.prototype)
 	}
 
 	get all(): ValueErrorWithSummary[] {
+		if (this._mappedValidationErrors !== undefined)
+			return this._mappedValidationErrors
+		if (this._validationErrors !== undefined)
+			return this._validationErrors
+				.map(mapValueError)
+				.filter((x): x is ValueErrorWithSummary => !!x)
+
 		// Handle standard schema validators (Zod, Valibot, etc.)
 		if (
 			// @ts-ignore

--- a/src/error.ts
+++ b/src/error.ts
@@ -381,11 +381,20 @@ export class ValidationError extends Error {
 			)
 				value = value.response
 
-			error =
-				errors?.First() ??
-				('Errors' in validator
-					? validator.Errors(value).First()
-					: Value.Errors(validator, value).First())
+			const validationErrors = errors
+				? [...errors].filter((x): x is ValueError => !!x)
+				: 'Errors' in validator
+					? [...validator.Errors(value)].filter(
+							(x): x is ValueError => !!x
+						)
+					: [...Value.Errors(validator, value)].filter(
+							(x): x is ValueError => !!x
+						)
+
+			error = validationErrors[0]
+			const mappedValidationErrors = validationErrors
+				.map(mapValueError)
+				.filter((x): x is ValueErrorWithSummary => !!x)
 
 			const accessor = error?.path || 'root'
 
@@ -420,27 +429,15 @@ export class ValidationError extends Error {
 											value,
 											property: accessor,
 											message: error?.message,
-											summary:
-												mapValueError(error)?.summary,
-											found: value,
-											expected,
-											errors:
-												'Errors' in validator
-													? [
-															...validator.Errors(
-																value
-															)
-														].map(mapValueError)
-													: [
-															...Value.Errors(
-																validator,
-																value
-															)
-														].map(mapValueError)
-										},
-								validator
-							)
-						: error.schema.error
+												summary:
+													mapValueError(error)?.summary,
+												found: value,
+												expected,
+												errors: mappedValidationErrors
+											} as any,
+									validator as any
+								)
+							: error.schema.error
 					: undefined
 
 			if (customError !== undefined) {
@@ -464,14 +461,7 @@ export class ValidationError extends Error {
 						summary: mapValueError(error)?.summary,
 						expected,
 						found: value,
-						errors:
-							'Errors' in validator
-								? [...validator.Errors(value)].map(
-										mapValueError
-									)
-								: [...Value.Errors(validator, value)].map(
-										mapValueError
-									)
+						errors: mappedValidationErrors
 					},
 					null,
 					2
@@ -607,4 +597,53 @@ export class ValidationError extends Error {
 					errors
 				}
 	}
+}
+
+const createValueErrorIterator = (errors: ValueError[]): ValueErrorIterator => {
+	const iterator = errors[Symbol.iterator]()
+
+	return {
+		iterator,
+		First: () => errors[0],
+		[Symbol.iterator]: function* () {
+			yield* errors
+		}
+	} as unknown as ValueErrorIterator
+}
+
+export const mapTransformDecodeError = (
+	error: { error?: unknown; path?: string },
+	type: string,
+	validator: ValidationError['validator'],
+	value: unknown,
+	allowUnsafeValidationDetails = false
+) => {
+	if (
+		error.error instanceof ValidationError &&
+		error.error.type === 'property' &&
+		error.error.valueError
+	) {
+		const valueError = {
+			...error.error.valueError,
+			path: error.path ?? error.error.valueError.path
+		}
+
+		return new ValidationError(
+			type,
+			validator,
+			value,
+			allowUnsafeValidationDetails,
+			createValueErrorIterator([valueError])
+		)
+	}
+
+	return (
+		error.error ??
+		new ValidationError(
+			type,
+			validator,
+			value,
+			allowUnsafeValidationDetails
+		)
+	)
 }

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -1008,6 +1008,32 @@ describe('Query Validator', () => {
 		expect(err instanceof ValidationError).toBe(true)
 	})
 
+	it('reports query path on numeric transform validation errors', async () => {
+		for (const aot of [true, false]) {
+			const app = new Elysia({ aot }).get('/', ({ query }) => query, {
+				query: t.Object({
+					limit: t.Number({
+						minimum: 1,
+						maximum: 100,
+						default: 10
+					})
+				})
+			})
+
+			const response = await app.handle(req('/?limit=200'))
+			const body = await response.json()
+
+			expect(response.status).toBe(422)
+			expect(body.on).toBe('query')
+			expect(body.property).toBe('/limit')
+			expect(body.message).toBe(
+				'Expected number to be less or equal to 100'
+			)
+			expect(body.errors[0].path).toBe('/limit')
+			expect(body.errors[0].value).toBe(200)
+		}
+	})
+
 	it('handle reference query array', async () => {
 		const app = new Elysia()
 			.model({

--- a/test/validator/query.test.ts
+++ b/test/validator/query.test.ts
@@ -1034,6 +1034,62 @@ describe('Query Validator', () => {
 		}
 	})
 
+	it('preserves query transform validation errors for all and detail', async () => {
+		for (const aot of [true, false]) {
+			let all:
+				| {
+						path: string
+						value: unknown
+						message: string
+				  }[]
+				| undefined
+			let detail: unknown
+
+			const app = new Elysia({ aot })
+				.onError(({ error }) => {
+					if (error instanceof ValidationError) {
+						all = error.all.map(({ path, value, message }) => ({
+							path,
+							value,
+							message
+						}))
+						detail = error.detail(error.message)
+					}
+				})
+				.get('/', ({ query }) => query, {
+					query: t.Object({
+						limit: t.Number({
+							minimum: 1,
+							maximum: 100,
+							default: 10,
+							error: 'limit invalid'
+						})
+					})
+				})
+
+			await app.handle(req('/?limit=200'))
+
+			expect(all).toEqual([
+				{
+					path: '/limit',
+					value: 200,
+					message: 'Expected number to be less or equal to 100'
+				}
+			])
+			expect(detail).toMatchObject({
+				property: '/limit',
+				message: 'limit invalid',
+				errors: [
+					{
+						path: '/limit',
+						value: 200,
+						message: 'Expected number to be less or equal to 100'
+					}
+				]
+			})
+		}
+	})
+
 	it('handle reference query array', async () => {
 		const app = new Elysia()
 			.model({


### PR DESCRIPTION
Closes #1660
Closes #1822
Related #1831

## Problem

Numeric query constraints can fail during TypeBox transform decode after a query string has already been accepted as numeric input. In that path, the inner validation error is created as a property-level error, while the surrounding `TransformDecodeError` still has the original field path.

The result is an error response like:

```json
{
  "on": "property",
  "property": "root"
}
```

instead of preserving the request validator context and field path, for example:

```json
{
  "on": "query",
  "property": "/limit"
}
```

## Fix

This maps transform decode validation errors back to the outer request validator context:

- Preserves `TransformDecodeError.path` when the inner error is an Elysia property validation error.
- Keeps the inner validation message and decoded value, so numeric bounds still report the actual numeric constraint failure.
- Applies the mapping in both generated AOT handlers and the dynamic handler path.
- Leaves non-validation errors thrown from transform decode unchanged.

## Tests

Added a query validator regression covering both `aot: true` and `aot: false` for:

- `t.Number({ minimum: 1, maximum: 100 })`
- `?limit=200`
- response status `422`
- response `on: "query"`
- response `property: "/limit"`
- first error path `"/limit"`

Verification run:

- `bun test test/validator/query.test.ts`
- `bun run test:types`
- `git diff --check`
- `bun run build`
- `bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transformation decode failures so they consistently produce HTTP 422 responses.
  * Error payloads now preserve accurate field/path information for query, header, param, cookie, and body validation failures.
  * Reduced redundant recomputation of validation details to make error reporting more consistent and efficient.

* **Tests**
  * Added tests verifying numeric query transform errors preserve path, value, and message in responses and validation objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->