### PR TITLE
test(ws): a clean server-initiated close reports wasClean=true

### DIFF
--- a/test/ws/connection.test.ts
+++ b/test/ws/connection.test.ts
@@ -34,8 +34,10 @@ describe('WebSocket connection', () => {
 		ws.send('close me!')
 
 		const { wasClean, code } = await wsClose(ws)
-		expect(wasClean).toBe(false)
-		expect(code).toBe(1000) // going away -> https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
+		// A server-initiated ws.close() completes the closing handshake, so the
+		// close is clean per the WebSocket spec (matches Node and browsers).
+		expect(wasClean).toBe(true)
+		expect(code).toBe(1000) // normal closure -> https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
 
 		app.stop()
 	})


### PR DESCRIPTION
The `should close by server` test asserts `wasClean === false` after a server-side `ws.close()`. But a server-initiated `ws.close()` completes the closing handshake, so per the [WebSocket spec](https://websockets.spec.whatwg.org/) the close is *clean* and `CloseEvent.wasClean` should be `true` — which is what Node and browsers report.

Bun's WebSocket client previously reported `false` for this case; that's a bug, fixed in oven-sh/bun#31518 to match the spec. This updates the assertion to the correct value (the `code` stays `1000`).

This passes on Bun ≥ 1.4 (which is not yet released, although is in canary), on the current released Bun it still reports the old `false`, so CI may be red until the next Bun release.

The `should terminate by server` test (`ws.terminate()`, an abrupt close with no handshake) correctly stays `wasClean: false` / code `1006` and is unchanged.