### PR TITLE
Invalidate compiled handler after route additions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ import type {
 	UnknownRouteSchema,
 	MaybeFunction,
 	InlineHandlerNonMacro,
-	Router,
+	Router
 } from './types'
 import {
 	coercePrimitiveRoot,
@@ -340,6 +340,11 @@ export default class Elysia<
 
 	protected getGlobalDefinitions() {
 		return this.definitions
+	}
+
+	private invalidateCompilation() {
+		delete (this as { fetch?: unknown }).fetch
+		this._handle = undefined
 	}
 
 	protected inference: Sucrose.Inference = {
@@ -865,6 +870,8 @@ export default class Elysia<
 				hooks
 			})
 
+			this.invalidateCompilation()
+
 			return
 		}
 
@@ -1031,6 +1038,8 @@ export default class Elysia<
 						: undefined
 				)
 			)
+
+		this.invalidateCompilation()
 
 		const handler = {
 			handler: shouldPrecompile
@@ -4703,7 +4712,12 @@ export default class Elysia<
 						} = hook
 
 						const hasStandaloneSchema =
-							body || headers || query || params || cookie || response
+							body ||
+							headers ||
+							query ||
+							params ||
+							cookie ||
+							response
 
 						const startIndex = processedUntil
 						processedUntil = instance.router.history.length
@@ -4731,11 +4745,13 @@ export default class Elysia<
 										: Array.isArray(localHook.error)
 											? [
 													...(localHook.error ?? []),
-													...(sandbox.event.error ?? [])
+													...(sandbox.event.error ??
+														[])
 												]
 											: [
 													localHook.error,
-													...(sandbox.event.error ?? [])
+													...(sandbox.event.error ??
+														[])
 												],
 									standaloneValidator: !hasStandaloneSchema
 										? localHook.standaloneValidator

--- a/test/aot/analysis.test.ts
+++ b/test/aot/analysis.test.ts
@@ -166,6 +166,24 @@ describe('Static code analysis', () => {
 		expect(response).toBe('hi')
 	})
 
+	it('handles route added after async plugin compilation', async () => {
+		const plugin = async () => {
+			await new Promise((resolve) => setTimeout(resolve, 1))
+
+			return new Elysia()
+		}
+
+		const app = new Elysia({ precompile: true }).use(plugin())
+
+		await new Promise((resolve) => setTimeout(resolve, 25))
+
+		app.use(new Elysia().get('/late', () => 'ok'))
+
+		const response = await app.handle(req('/late')).then((x) => x.text())
+
+		expect(response).toBe('ok')
+	})
+
 	it('parse custom parser with schema', async () => {
 		const app = new Elysia()
 			.onParse((request, contentType) => {


### PR DESCRIPTION
Fixes #1907.

Summary:
- clear the memoized compiled handler when routes are added
- add a regression test for a route registered after an async plugin has already caused precompilation

Tests:
- red check before the fix: focused regression returned `NOT_FOUND`
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bun test test/aot/analysis.test.ts -t "handles route added after async plugin compilation"`
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bun test test/aot/analysis.test.ts`
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bun test test/aot`
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bun test test/core/elysia.test.ts`
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bun run test:types`
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bunx prettier --check src/index.ts test/aot/analysis.test.ts`
- `git diff --check`

Also checked:
- `BUN_INSTALL_CACHE_DIR=/tmp/elysia-1907-bun-cache bun run test:functionality` currently fails on `test/sucrose/integration.test.ts > Allows process to finish` and `test/response/stream.test.ts > stop stream on canceled request`; both failures reproduce on clean upstream HEAD (`56310be`) in a separate worktree, so I did not treat them as part of this change.

AI assistance was used while drafting this patch; I reviewed the diff and verified the results above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routes added after precompilation now function correctly and are properly handled by the router.

* **Tests**
  * Added test coverage for route registration following precompilation in async plugin scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->