### PR TITLE
skip auto-parsing of text frames when no body schema is defined

### DIFF
--- a/src/adapter/bun/index.ts
+++ b/src/adapter/bun/index.ts
@@ -506,7 +506,7 @@ export const BunAdapter: ElysiaAdapter = {
 					) as any
 
 				const handleResponse = createHandleWSResponse(responseValidator)
-				const parseMessage = createWSMessageParser(parse as any)
+				const parseMessage = createWSMessageParser(parse as any, !!messageValidator)
 
 				let _id: string | undefined
 

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -209,12 +209,13 @@ export class ElysiaWS<Context = unknown, Route extends RouteSchema = {}>
 }
 
 export const createWSMessageParser = (
-	parse: MaybeArray<WSParseHandler<any>>
+	parse: MaybeArray<WSParseHandler<any>>,
+	hasSchema = false
 ) => {
 	const parsers = typeof parse === 'function' ? [parse] : parse
 
 	return async function parseMessage(ws: ServerWebSocket<any>, message: any) {
-		if (typeof message === 'string') {
+		if (hasSchema && typeof message === 'string') {
 			const start = message?.charCodeAt(0)
 
 			if (start === 34 || start === 47 || start === 91 || start === 123)

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -249,6 +249,7 @@ describe('WebSocket message', () => {
 	it('should parse objects', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(raw)
 				}
@@ -274,6 +275,7 @@ describe('WebSocket message', () => {
 	it('should parse arrays', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -299,6 +301,7 @@ describe('WebSocket message', () => {
 	it('should parse strings', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -324,6 +327,7 @@ describe('WebSocket message', () => {
 	it('should parse numbers', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -349,6 +353,7 @@ describe('WebSocket message', () => {
 	it('should parse true', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -374,6 +379,7 @@ describe('WebSocket message', () => {
 	it('should parse false', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -399,6 +405,7 @@ describe('WebSocket message', () => {
 	it('should parse null', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -424,6 +431,7 @@ describe('WebSocket message', () => {
 	it('should parse not parse /hello', async () => {
 		const app = new Elysia()
 			.ws('/ws', {
+				body: t.Any(),
 				message(ws, raw) {
 					ws.send(JSON.stringify(raw))
 				}
@@ -441,6 +449,33 @@ describe('WebSocket message', () => {
 		const { type, data } = await message
 		expect(type).toBe('message')
 		expect(data).toInclude('/hello')
+
+		await wsClosed(ws)
+		app.stop()
+	})
+
+	it('should not parse json-like text frames without a body schema', async () => {
+		const app = new Elysia()
+			.ws('/ws', {
+				message(ws, raw) {
+					ws.send(raw as string)
+				}
+			})
+			.listen(0)
+
+		const ws = newWebsocket(app.server!)
+
+		await wsOpen(ws)
+
+		const m1 = wsMessage(ws)
+		ws.send('["ping"]')
+		const { data: d1 } = await m1
+		expect(d1).toBe('["ping"]')
+
+		const m2 = wsMessage(ws)
+		ws.send('{"key":"val"}')
+		const { data: d2 } = await m2
+		expect(d2).toBe('{"key":"val"}')
 
 		await wsClosed(ws)
 		app.stop()


### PR DESCRIPTION
fixes #1911.

**problem:** `createWSMessageParser` unconditionally parses any text frame starting with `"`, `/`, `[`, or `{` as JSON — so sending `["ping"]` delivers an array to the handler instead of the raw string. this happens even when no `body` schema is defined and the user never asked for parsing.

**fix:** added a `hasSchema` parameter to `createWSMessageParser` (defaults to `false`). the auto-parse block only runs when `hasSchema` is true. the bun adapter passes `!!messageValidator`, so coercion only fires when a `body` schema is actually present. existing tests that relied on auto-parsing without a schema now include `body: t.Any()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket message parsing behavior now adapts intelligently based on whether a schema is configured. When a message schema is present, the parser performs JSON coercion and type conversion on incoming text messages. When no schema is defined, text frames are preserved as raw strings without transformation, ensuring proper handling across different message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->