### PR TITLE
fix: map onError plain returns to error status codes instead of 200

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,11 @@ import type {
 	StandardSchemaV1Like,
 	ElysiaHandlerToResponseSchema,
 	ElysiaHandlerToResponseSchemas,
+	ErrorHandlerToResponseSchema,
+	ErrorHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -3179,7 +3182,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3232,7 +3235,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3322,7 +3325,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3343,7 +3346,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3362,7 +3365,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3452,7 +3455,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3473,7 +3476,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3492,7 +3495,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3964,7 +3967,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4214,7 +4217,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4253,7 +4256,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4289,7 +4292,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4323,7 +4326,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4360,7 +4363,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4394,7 +4397,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4468,7 +4471,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2192,6 +2192,26 @@ export type ValueToResponseSchema<Value> = ExtractErrorFromHandle<Value> &
 				: { 200: R200 }
 		: {})
 
+/**
+ * Like ValueToResponseSchema but for onError handlers.
+ * Maps plain (non-ElysiaCustomStatusResponse) returns to error status codes
+ * instead of 200, matching runtime behavior where error status is preserved.
+ */
+type ExtractPlainErrorReturn<T> = Exclude<
+	T extends AnyElysiaCustomStatusResponse
+		? Exclude<T, AnyElysiaCustomStatusResponse>
+		: T,
+	undefined
+>
+
+export type ErrorValueToResponseSchema<Value> =
+	ExtractErrorFromHandle<Value> &
+		(ExtractPlainErrorReturn<Value> extends infer ErrVal
+			? IsNever<ErrVal> extends true
+				? {}
+				: { 400: ErrVal; 404: ErrVal; 422: ErrVal; 500: ErrVal }
+			: {})
+
 export type ValueOrFunctionToResponseSchema<T> = T extends (
 	...a: any
 ) => MaybePromise<infer R>
@@ -2202,6 +2222,13 @@ export type ElysiaHandlerToResponseSchema<in out Handle extends Function> =
 	Prettify<
 		Handle extends (...a: any) => MaybePromise<infer R>
 			? ValueToResponseSchema<Exclude<R, undefined>>
+			: {}
+	>
+
+export type ErrorHandlerToResponseSchema<in out Handle extends Function> =
+	Prettify<
+		Handle extends (...a: any) => MaybePromise<infer R>
+			? ErrorValueToResponseSchema<Exclude<R, undefined>>
 			: {}
 	>
 
@@ -2217,6 +2244,18 @@ export type ElysiaHandlerToResponseSchemas<
 		>
 	: Prettify<Carry>
 
+export type ErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			// @ts-ignore trust me bro
+			UnionResponseStatus<ErrorHandlerToResponseSchema<Current>, Carry>
+		>
+	: Prettify<Carry>
+
 export type ElysiaHandlerToResponseSchemaAmbiguous<
 	Schemas extends MaybeArray<Function>
 > =
@@ -2226,6 +2265,17 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 			? ElysiaHandlerToResponseSchema<Schemas>
 			: Schemas extends Function[]
 				? ElysiaHandlerToResponseSchemas<Schemas>
+				: {}
+
+export type ErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ErrorHandlerToResponseSchemas<Schemas>
 				: {}
 
 type ReconcileStatus<

--- a/src/types.ts
+++ b/src/types.ts
@@ -2204,6 +2204,16 @@ type ExtractPlainErrorReturn<T> = Exclude<
 	undefined
 >
 
+/**
+ * Maps a plain (non-`ElysiaCustomStatusResponse`) return value from an `onError`
+ * handler to a set of HTTP error status codes in the inferred response schema.
+ *
+ * **Limitation**: plain returns are typed against the most common Elysia built-in
+ * error codes (400, 404, 422, 500). Other codes (401, 403, 405, 429, 502, 503,
+ * etc.) are not statically knowable from the return type alone and will not appear
+ * in the schema. Use an explicit `status(N, value)` return to capture any specific
+ * status code accurately.
+ */
 export type ErrorValueToResponseSchema<Value> =
 	ExtractErrorFromHandle<Value> &
 		(ExtractPlainErrorReturn<Value> extends infer ErrVal
@@ -2244,6 +2254,12 @@ export type ElysiaHandlerToResponseSchemas<
 		>
 	: Prettify<Carry>
 
+// Mirrors `ElysiaHandlerToResponseSchemas`, differing only in delegating to
+// `ErrorHandlerToResponseSchema` instead of `ElysiaHandlerToResponseSchema`.
+// A shared generic recursive type is not used because the `in out` variance
+// annotation on the `Handle` parameter causes TypeScript to reject the
+// conditional narrowing inside the recursive branch — the `// @ts-ignore`
+// suppressions below are intentional and match the established pattern.
 export type ErrorHandlerToResponseSchemas<
 	Handle extends Function[],
 	Carry extends PossibleResponse = {}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1006,11 +1006,15 @@ import { Prettify } from '../../../src/types'
 				Math.random() > 0.5 ? status(418, 'sartre') : 'sartre'
 		])
 
+	// Plain returns from onError map to error status codes (400, 404, 422, 500)
+	// instead of 200, matching runtime behavior where error status is preserved
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'fouco' | 'sartre' | 'lilith'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1028,10 +1032,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'fouco' | 'sartre' | 'lilith'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1049,10 +1055,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'fouco' | 'sartre' | 'lilith'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 


### PR DESCRIPTION
## Summary

Fixes #313

- When `onError` returns a plain value (not wrapped in `status()`), the type system previously recorded it under status `200`. At runtime, Elysia correctly preserves the error's actual status code via `if(set.status===200||!set.status) set.status=error.status`. This type/runtime mismatch caused Eden to type errors as `{status: unknown, value: unknown}` instead of the actual return type.
- Introduces `ErrorValueToResponseSchema` (and corresponding `ErrorHandlerToResponseSchema`, `ErrorHandlerToResponseSchemas`, `ErrorHandlerToResponseSchemaAmbiguous`) that maps plain `onError` returns to error status codes (400, 404, 422, 500) instead of 200
- Explicit `status()` returns (e.g., `status(404, 'not found')`) continue to work exactly as before
- Updates type tests to reflect the corrected behavior

## Example

```ts
const app = new Elysia()
  .onError(({ error }) => {
    return { failure: error.message }
  })
  .get('/', () => { throw new Error('oops') })
```

**Before:** Eden types `error` as `{status: unknown, value: unknown}` because `{failure: string}` was recorded under status 200.

**After:** `{failure: string}` is recorded under error statuses (400, 404, 422, 500), so Eden can properly type the error response.

## Test plan

- [x] `tsc --noEmit --project tsconfig.test.json` passes with zero errors
- [x] All 183 lifecycle tests pass (`bun test test/lifecycle/`)
- [x] All 213 core tests pass (`bun test test/core/`)
- [x] Updated type soundness tests for onError local/scoped/global scopes

@algora-pbc /claim #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript inference for error handlers so plain error returns are reflected as standard error status responses (e.g., 400/422/500) and aggregated correctly across scoped/global handlers.
  * Added utilities to model combined/ambiguous error response shapes for more accurate editor hints.

* **Tests**
  * Updated type-level tests to align expectations with the refined error-response inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->