### PR TITLE
:blue_book: fix: handle null secret in unsignCookie rotation (#1861)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -711,6 +711,9 @@ export const unsignCookie = async (input: string, secret: string | null) => {
 	}
 
 	const tentativeValue = input.slice(0, dot)
+
+	if (secret === null) return false
+
 	const expectedInput = await signCookie(tentativeValue, secret)
 
 	return constantTimeEqual(expectedInput, input) ? tentativeValue : false

--- a/test/cookie/signature.test.ts
+++ b/test/cookie/signature.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { parseCookie, Cookie } from '../../src/cookies'
 import { signCookie } from '../../src/utils'
+import { InvalidCookieSignature } from '../../src/error'
 
 describe('Parse Cookie', () => {
 	it('handle empty cookie', async () => {
@@ -133,5 +134,20 @@ describe('Parse Cookie', () => {
 		})
 
 		expect(result.fischl.value).toEqual('fischl')
+	})
+
+	it('rejects invalid signature with null secret in rotation', async () => {
+		const set = {
+			headers: {},
+			cookie: {}
+		}
+
+		const cookieString = `wizard=1.invalid_sign`
+		await expect(
+			parseCookie(set, cookieString, {
+				secrets: ['valid-secret', null],
+				sign: ['wizard']
+			})
+		).rejects.toThrow(InvalidCookieSignature)
 	})
 })


### PR DESCRIPTION
When cookie rotation includes a `null` entry for unsigned-to-signed
transition, a cookie with an invalid signature would cause a raw
`TypeError` (from `signCookie`) instead of the expected
`InvalidCookieSignature`.

The loop in `parseCookie` tries each secret in the rotation array.
When it reaches the `null` entry, `unsignCookie` called `signCookie`
without a null check, which throws `TypeError("Secret key must be
provided")`. The error propagated as `UNKNOWN` instead of being
caught as `InvalidCookieSignature`.

The fix adds a `null` secret guard in `unsignCookie` before calling
`signCookie`, matching the existing null-handling pattern already used
for unsigned cookies without a signature.

Fixes #1861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cookie signature validation logic to properly handle null secrets during rotation operations, preventing errors during signature verification.

* **Tests**
  * Added test coverage for secret rotation scenarios to verify invalid cookie signatures are correctly rejected when rotation secrets contain null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->