### PR TITLE
fix: prefer registered error code

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2058,8 +2058,8 @@ export const composeHandler = ({
 				'c.code="VALIDATION"\n' +
 				'c.set.status=422' +
 				'}else{' +
-				`c.code=error.code??error[ERROR_CODE]??"UNKNOWN"}`
-		else fnLiteral += `c.code=error.code??error[ERROR_CODE]??"UNKNOWN"\n`
+				`c.code=error[ERROR_CODE]??error.code??"UNKNOWN"}`
+		else fnLiteral += `c.code=error[ERROR_CODE]??error.code??"UNKNOWN"\n`
 
 		fnLiteral += `let er\n`
 		// Mapped error Response
@@ -2657,7 +2657,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 	fnLiteral +=
 		`const set=context.set\n` +
 		`let _r\n` +
-		`if(!context.code)context.code=error.code??error[ERROR_CODE]\n` +
+		`if(!context.code)context.code=error[ERROR_CODE]??error.code\n` +
 		`if(!(context.error instanceof Error))context.error=error\n` +
 		`if(error instanceof ElysiaCustomStatusResponse){` +
 		`set.status=error.status=error.code\n` +

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -3,6 +3,7 @@ import type { Context } from './context'
 import { parseCookie } from './cookies'
 import {
 	ElysiaCustomStatusResponse,
+	ERROR_CODE,
 	type ElysiaErrors,
 	NotFoundError,
 	status,
@@ -880,7 +881,14 @@ export const createDynamicErrorHandler = (app: AnyElysia) => {
 		},
 		error: ElysiaErrors
 	) => {
-		const errorContext = Object.assign(context, { error, code: error.code })
+		const registeredCode = (error as Error & { [ERROR_CODE]?: string })[
+			ERROR_CODE
+		]
+
+		const errorContext = Object.assign(context, {
+			error,
+			code: registeredCode ?? error.code
+		})
 		errorContext.set = context.set
 
 		if (

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -125,6 +125,34 @@ describe('error', () => {
 	})
 
 	it.each([true, false])(
+		'uses registered error key over instance code with aot: %p',
+		async (aot) => {
+			class InvalidUrlError extends Error {
+				code = 'invalid_url' as const
+
+				constructor() {
+					super('internal message')
+				}
+			}
+
+			const app = new Elysia({ aot })
+				.error({ INVALID_URL: InvalidUrlError })
+				.onError(({ code }) => {
+					if (code === 'INVALID_URL')
+						return new Response('handled', { status: 422 })
+				})
+				.get('/', () => {
+					throw new InvalidUrlError()
+				})
+
+			const response = await app.handle(req('/'))
+
+			expect(response.status).toBe(422)
+			expect(await response.text()).toBe('handled')
+		}
+	)
+
+	it.each([true, false])(
 		'return correct number status on error function with aot: %p',
 		async (aot) => {
 			const app = new Elysia({ aot }).get('/', ({ status }) =>


### PR DESCRIPTION
Fixes #1919

When a custom error class defines its own `code` field, the runtime currently prefers that instance field over the key registered through `.error()`. That makes `onError({ code })` receive a value that does not match the typed registered error key.

This changes both the AOT and dynamic error handlers to prefer the internal `ERROR_CODE` registration symbol, falling back to `error.code` for built-in errors and unregistered errors.

Verification:

- npx -y bun test test/lifecycle/error.test.ts -t "uses registered error key over instance code"
- npx -y bun test test/lifecycle/error.test.ts
- npx -y bun run test:types
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected error handler precedence logic: Registered error handlers now consistently take priority when both instance codes and registered handlers exist. This ensures predictable error routing and response generation across validation errors, request handlers, and global error handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->