### PR TITLE
fix: continue aot error handlers after undefined

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2082,6 +2082,8 @@ export const composeHandler = ({
 					total: hooks.mapResponse?.length
 				})
 
+				fnLiteral += `if(er!==undefined){`
+
 				for (let i = 0; i < hooks.mapResponse.length; i++) {
 					const mapResponse = hooks.mapResponse[i]
 
@@ -2097,6 +2099,7 @@ export const composeHandler = ({
 
 					endUnit()
 				}
+				fnLiteral += `}`
 				mapResponseReporter.resolve()
 			}
 

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -125,6 +125,73 @@ describe('error', () => {
 	})
 
 	it.each([true, false])(
+		'continue error handler chain when an earlier handler returns undefined with mapResponse and aot: %p',
+		async (aot) => {
+			const events: string[] = []
+
+			const logger = new Elysia().onError({ as: 'global' }, ({ error }) => {
+				events.push(
+					`logger:${error instanceof Error ? error.message : String(error)}`
+				)
+			})
+
+			const responseWrapper = new Elysia()
+				.onError({ as: 'global' }, ({ error, set }) => {
+					events.push('response-wrapper:onError')
+					set.status = 200
+
+					return Response.json({
+						code: 403,
+						msg:
+							error instanceof Error
+								? error.message
+								: 'Forbidden',
+						data: null
+					})
+				})
+				.mapResponse({ as: 'global' }, ({ response, set }) => {
+					events.push(
+						`response-wrapper:mapResponse:${response instanceof Response}`
+					)
+
+					if (response instanceof Response) return response
+
+					set.status = 200
+
+					return Response.json({
+						code: 200,
+						msg: 'success',
+						data: response ?? null
+					})
+				})
+
+			const guard = new Elysia().onBeforeHandle({ as: 'scoped' }, () => {
+				throw new Error('denied by nested guard')
+			})
+
+			const api = new Elysia({ prefix: '/api' }).group('', (app) =>
+				app.use(guard).post('/guarded', () => ({ ok: true }))
+			)
+
+			const app = new Elysia({ aot })
+				.use(logger)
+				.use(responseWrapper)
+				.use(api)
+
+			const response = await app.handle(post('/api/guarded', {}))
+
+			expect(response.status).toBe(200)
+			expect(await response.json()).toEqual({
+				code: 403,
+				msg: 'denied by nested guard',
+				data: null
+			})
+			expect(events).toContain('logger:denied by nested guard')
+			expect(events).toContain('response-wrapper:onError')
+		}
+	)
+
+	it.each([true, false])(
 		'return correct number status on error function with aot: %p',
 		async (aot) => {
 			const app = new Elysia({ aot }).get('/', ({ status }) =>


### PR DESCRIPTION
Fixes #1900

In the AOT route error path, global `mapResponse` hooks were run after every `onError` handler, even when the handler returned `undefined`. That let a logging-only `onError` be mapped into a response and prevented later `onError` handlers from producing the intended error response.

This only runs the error-path `mapResponse` chain when the current `onError` handler actually returned a value. `undefined` keeps its existing meaning: the error was not handled yet, so the chain should continue.

Verification:

- npx -y bun test test/lifecycle/error.test.ts -t "continue error handler chain"
- npx -y bun test test/lifecycle/error.test.ts
- npx -y bun run test:types
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling to prevent unnecessary response processing when errors are not present, improving application performance and reliability in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->