### PR TITLE
fix: re-register WS routes through parent adapter on plugin merge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1011,7 +1011,7 @@ export default class Elysia<
 							standaloneValidators
 						}
 					: undefined,
-				localHook.webSocket
+				localHook.websocket
 					? { websocket: localHook.websocket as any }
 					: undefined
 			)
@@ -1026,7 +1026,7 @@ export default class Elysia<
 						handler: handle,
 						hooks
 					},
-					localHook.webSocket
+					localHook.websocket
 						? { websocket: localHook.websocket as any }
 						: undefined
 				)
@@ -5266,8 +5266,14 @@ export default class Elysia<
 
 		for (const { method, path, handler, hooks } of Object.values(
 			plugin.router.history
-		))
-			this.add(method, path, handler, hooks)
+		)) {
+			// WS routes carry the original options in hooks.websocket.
+			// Re-register through this app's adapter so the upgrade store
+			// used by listen() matches the one the route handler writes to.
+			if (method === 'WS' && hooks?.websocket && this['~adapter']?.ws)
+				this['~adapter'].ws(this, path, hooks.websocket)
+			else this.add(method, path, handler, hooks)
+		}
 
 		if (name) {
 			if (!(name in this.dependencies)) this.dependencies[name] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -5098,14 +5098,18 @@ export default class Elysia<
 									path,
 									handler,
 									hooks
-								} of Object.values(plugin.router.history))
-									this.add(
-										method,
-										path,
-										handler,
-										hooks,
-										undefined
-									)
+								} of Object.values(plugin.router.history)) {
+									if (method === 'WS' && hooks?.websocket && this['~adapter']?.ws)
+										this['~adapter'].ws(this, path, hooks.websocket as any)
+									else
+										this.add(
+											method,
+											path,
+											handler,
+											hooks,
+											undefined
+										)
+								}
 
 								if (plugin === this) return
 


### PR DESCRIPTION
## Problem

WebSocket routes defined inside a sub-app plugin fail silently when using adapters (e.g. `@elysiajs/node`) where the upgrade mechanism relies on internal per-adapter state.

Each call to `node()` creates a `createWebSocketAdapter()` instance with its own isolated `store` closure. When a WS route is registered on a sub-app (`new Elysia({ adapter: node() }).ws(...)`), the route handler closure captures the sub-app's store. But the crossws upgrade handler is set up by the *root* app's `listen()` using the root app's adapter store.
When an upgrade arrives, the context lookup (`store[id]`) always returns `undefined` → upgrade fails with 404/EPIPE.

Related: elysiajs/node#62 #1616, and reported multiple times in elysiajs/node.

## Root cause in core

`_use()` iterates `plugin.router.history` and calls `this.add(method, path, handler, hooks)` for each route. For `method === 'WS'`, `add()` inserts the pre-compiled handler closure directly into the router without re-calling `this['~adapter'].ws()`. The parent adapter never gets to register a fresh handler closure that closes over its own store.

## Changes

1. **`_use()` (line ~5267):** When merging a WS history entry, re-register through the parent's adapter instead of copying the stale closure. The original WS options are preserved in `hooks.websocket` and passed through as-is.

2. **`add()` history storage (lines 1014, 1029):** Fix typo — `localHook.webSocket` (camelCase guard) → `localHook.websocket` (lowercase, matching the key actually set by adapters). This caused the `websocket` top-level field to never be written to history entries.

## Effect

Sub-apps can now define WS routes using their own `adapter: node()` instance and have them work correctly when merged into a parent via `.use()`. The functional plugin pattern (`(app) => app.ws(...)`) continues to work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated WebSocket route registration to use the correct hook metadata field name for plugin routes.
  * Improved plugin route propagation so WebSocket routes are re-registered through the app adapter when available, with a safe fallback for non-adapter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->