### PR TITLE
fix: validate file contents in dynamic mode

### DIFF
--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -1,3 +1,4 @@
+import { Kind } from '@sinclair/typebox'
 import { TransformDecodeError } from '@sinclair/typebox/value'
 import type { Context } from './context'
 import { parseCookie } from './cookies'
@@ -10,8 +11,13 @@ import {
 } from './error'
 import type { AnyElysia, CookieOptions } from './index'
 import { parseQuery } from './parse-query'
-import { getSchemaProperties, type ElysiaTypeCheck } from './schema'
+import {
+	getSchemaProperties,
+	unwrapImportSchema,
+	type ElysiaTypeCheck
+} from './schema'
 import type { TypeCheck } from './type-system'
+import { fileType } from './type-system/utils'
 import type { Handler, LifeCycleStore, SchemaValidator } from './types'
 import { hasSetImmediate, redirect, StatusMap, signCookie } from './utils'
 
@@ -615,6 +621,33 @@ export const createDynamicHandler = (app: AnyElysia) => {
 
 						// Zod returns { value: ... } wrapper
 						context.body = decoded?.value ?? decoded
+				}
+
+				// Validate file contents by magic bytes, mirroring the AOT path
+				// (`compose.ts`) which injects `fileType(...)` for File/Files
+				// fields that declare an extension. Without this, dynamic mode
+				// (`aot: false`) only checks the client-supplied MIME type and
+				// accepts a file whose bytes do not match the declared type.
+				if (validator.body) {
+					const bodyProperties = getSchemaProperties(
+						unwrapImportSchema(validator.body.schema)
+					)
+
+					if (bodyProperties)
+						for (const key in bodyProperties) {
+							const property = bodyProperties[key]
+
+							if (
+								property.extension &&
+								(property[Kind] === 'File' ||
+									property[Kind] === 'Files')
+							)
+								await fileType(
+									(context.body as any)?.[key],
+									property.extension,
+									`body.${key}`
+								)
+						}
 				}
 			}
 

--- a/test/validator/body.test.ts
+++ b/test/validator/body.test.ts
@@ -836,6 +836,38 @@ describe('Body Validator', () => {
 		}
 	})
 
+	it('validate actual file in dynamic mode', async () => {
+		const app = new Elysia({ aot: false }).post(
+			'/upload',
+			({ body: { file } }) => file.size,
+			{
+				body: t.Object({
+					file: t.File({
+						type: 'image'
+					})
+				})
+			}
+		)
+
+		{
+			const { request, size } = upload('/upload', {
+				file: 'millenium.jpg'
+			})
+
+			const response = await app.handle(request).then((r) => r.text())
+			expect(+response).toBe(size)
+		}
+
+		{
+			const { request } = upload('/upload', {
+				file: 'fake.jpg'
+			})
+
+			const status = await app.handle(request).then((r) => r.status)
+			expect(status).toBe(422)
+		}
+	})
+
 	it('validate actual file with multiple type', async () => {
 		const app = new Elysia().post(
 			'/upload',


### PR DESCRIPTION
Closes #1922.

`t.File({ type })` / `t.Files({ type })` validates the *actual* file bytes (magic-byte check via `fileType` → `file-type`) in AOT mode, but in dynamic mode (`aot: false`) the same schema only ran the synchronous TypeBox check, which trusts the client-supplied multipart MIME type. A file whose bytes do not match the declared type was accepted in dynamic mode and rejected in AOT mode — the two pipelines disagreed on the same schema.

Repro from the issue (SVG bytes uploaded as `image/png`): AOT → `422`, dynamic → `200`.

### Fix
`compose.ts` (AOT) injects `fileType(c.body.k, extension, 'body.k')` for every File/Files field that declares an extension. `createDynamicHandler` did not. After body validation, iterate the body schema's properties (via the existing `getSchemaProperties`, which also flattens unions) and run the same `fileType(...)` for File/Files fields with an extension — so both modes enforce the identical guarantee using the identical code path and error (`InvalidFileType` → `422`).

### Tests
Added `validate actual file in dynamic mode` to `test/validator/body.test.ts`, mirroring the existing AOT `validate actual file` test but with `new Elysia({ aot: false })`: a real `millenium.jpg` passes (`200`), a spoofed `fake.jpg` is rejected (`422`). Red before the change (dynamic returned `200`), green after. `test/validator/body.test.ts` (57), `test/type-system/files.test.ts` + `formdata.test.ts` (31), and `test/core/dynamic.test.ts` (32) all pass; `tsc --project tsconfig.test.json` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* File uploads now validate against their declared file type consistently across all application modes.
* File type verification is enforced in dynamic mode, preventing mismatched file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->