### PR TITLE
fix: prioritize specific all wildcard routes

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2360,10 +2360,16 @@ export const composeGeneralHandler = (
 	const router = app.router
 
 	let findDynamicRoute = router.http.root.WS
-		? `const route=router.find(r.method==='GET'&&r.headers.get('upgrade')==='websocket'?'WS':r.method,p)`
-		: `const route=router.find(r.method,p)`
+		? `let route=router.find(r.method==='GET'&&r.headers.get('upgrade')==='websocket'?'WS':r.method,p)`
+		: `let route=router.find(r.method,p)`
 
-	findDynamicRoute += router.http.root.ALL ? `??router.find('ALL',p)\n` : '\n'
+	const allowAllRouteByScore = router.http.root.WS
+		? `!(r.method==='GET'&&r.headers.get('upgrade')==='websocket')&&`
+		: ''
+
+	findDynamicRoute += router.http.root.ALL
+		? `;{const _route=router.find('ALL',p);if(_route&&(!route||(${allowAllRouteByScore}_route.store.score>route.store.score)))route=_route}\n`
+		: '\n'
 
 	if (isWebstandard)
 		findDynamicRoute +=

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -13,7 +13,13 @@ import { parseQuery } from './parse-query'
 import { getSchemaProperties, type ElysiaTypeCheck } from './schema'
 import type { TypeCheck } from './type-system'
 import type { Handler, LifeCycleStore, SchemaValidator } from './types'
-import { hasSetImmediate, redirect, StatusMap, signCookie } from './utils'
+import {
+	hasSetImmediate,
+	redirect,
+	selectRoute,
+	StatusMap,
+	signCookie
+} from './utils'
 
 // JIT Handler
 export type DynamicHandler = {
@@ -22,6 +28,7 @@ export type DynamicHandler = {
 	hooks: Partial<LifeCycleStore>
 	validator?: SchemaValidator
 	route: string
+	score: string
 }
 
 /**
@@ -242,10 +249,14 @@ export const createDynamicHandler = (app: AnyElysia) => {
 
 			const methodKey = isWS ? 'WS' : request.method
 
-			const handler =
-				app.router.dynamic.find(request.method, path) ??
-				app.router.dynamic.find(methodKey, path) ??
-				app.router.dynamic.find('ALL', path)
+			const handler = isWS
+				? app.router.dynamic.find(request.method, path) ??
+					app.router.dynamic.find(methodKey, path) ??
+					app.router.dynamic.find('ALL', path)
+				: selectRoute(
+					app.router.dynamic.find(request.method, path),
+					app.router.dynamic.find('ALL', path)
+				)
 
 			if (!handler) {
 				// @ts-expect-error

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,8 @@ import {
 	supportPerMethodInlineHandler,
 	redirect,
 	emptySchema,
-	insertStandaloneValidator
+	insertStandaloneValidator,
+	getRouteScore
 } from './utils'
 
 import {
@@ -520,6 +521,7 @@ export default class Elysia<
 
 		if (path !== '' && path.charCodeAt(0) !== 47) path = '/' + path
 		if (this.config.prefix && !skipPrefix) path = this.config.prefix + path
+		const routeScore = getRouteScore(path)
 
 		if (localHook?.type)
 			switch (localHook.type) {
@@ -821,7 +823,8 @@ export default class Elysia<
 				hooks,
 				content: localHook?.type as string,
 				handle,
-				route: path
+				route: path,
+				score: routeScore
 			})
 
 			const encoded = encodePath(path, { dynamic: true })
@@ -831,7 +834,8 @@ export default class Elysia<
 					hooks,
 					content: localHook?.type as string,
 					handle,
-					route: path
+					route: path,
+					score: routeScore
 				})
 			}
 
@@ -842,7 +846,8 @@ export default class Elysia<
 					hooks,
 					content: localHook?.type as string,
 					handle,
-					route: path
+					route: path,
+					score: routeScore
 				})
 
 				const encoded = encodePath(loosePath)
@@ -852,7 +857,8 @@ export default class Elysia<
 						hooks,
 						content: localHook?.type as string,
 						handle,
-						route: path
+						route: path,
+						score: routeScore
 					})
 			}
 
@@ -1033,6 +1039,7 @@ export default class Elysia<
 			)
 
 		const handler = {
+			score: routeScore,
 			handler: shouldPrecompile
 				? (route[index].composed as ComposedHandler)
 				: undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2693,11 +2693,13 @@ export interface Router {
 		| Memoirist<{
 				compile: Function
 				handler?: ComposedHandler
+				score: string
 		  }>
 		| undefined
 	get http(): Memoirist<{
 		compile: Function
 		handler?: ComposedHandler
+		score: string
 	}>
 	'~dynamic': Memoirist<DynamicHandler> | undefined
 	get dynamic(): Memoirist<DynamicHandler>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1114,6 +1114,42 @@ export const getLoosePath = (path: string) => {
 	return path + '/'
 }
 
+// Mirrors Memoirist specificity: static segments > params > wildcard,
+// and an exact ending outranks a trailing wildcard at the same position.
+export const getRouteScore = (path: string) => {
+	let score = ''
+	let start = path.charCodeAt(0) === 47 ? 1 : 0
+
+	for (let i = start; i <= path.length; i++) {
+		if (i !== path.length && path.charCodeAt(i) !== 47) continue
+		if (i === start) {
+			start = i + 1
+			continue
+		}
+
+		const type = path.charCodeAt(start)
+		if (type === 42) score += '1'
+		else if (type === 58) score += '2'
+		else score += '3'
+
+		start = i + 1
+	}
+
+	return score + '4'
+}
+
+export const selectRoute = <T extends { store: { score?: string } }>(
+	preferred: T | null | undefined,
+	fallback: T | null | undefined
+) => {
+	if (!preferred) return fallback ?? null
+	if (!fallback) return preferred
+
+	return (fallback.store.score ?? '') > (preferred.store.score ?? '')
+		? fallback
+		: preferred
+}
+
 export const isNotEmpty = (obj?: Object) => {
 	if (!obj) return false
 

--- a/test/path/path.test.ts
+++ b/test/path/path.test.ts
@@ -115,6 +115,32 @@ describe('Path', () => {
 		expect(await res.text()).toBe('Wildcard')
 	})
 
+	it('prioritizes more specific all wildcard over generic method wildcard', async () => {
+		for (const aot of [true, false]) {
+			const app = new Elysia({ aot })
+				.all('/api/auth/*', () => 'auth')
+				.get('/*', () => 'spa')
+
+			const reversed = new Elysia({ aot })
+				.get('/*', () => 'spa')
+				.all('/api/auth/*', () => 'auth')
+
+			expect(
+				await app
+					.handle(req('/api/auth/callback/google'))
+					.then((res) => res.text())
+			).toBe('auth')
+			expect(
+				await reversed
+					.handle(req('/api/auth/callback/google'))
+					.then((res) => res.text())
+			).toBe('auth')
+			expect(await app.handle(req('/dashboard')).then((res) => res.text())).toBe(
+				'spa'
+			)
+		}
+	})
+
 	it('custom error', async () => {
 		const app = new Elysia().onError((error) => {
 			if (error.code === 'NOT_FOUND')


### PR DESCRIPTION
Fixes #1925.

## Summary
- Store a route specificity score with dynamic route handlers.
- When resolving dynamic routes, let a more specific `ALL` route win over a less specific method route, while keeping the method-specific route on equal specificity.
- Add regression coverage for both AOT and dynamic modes.

## Tests
- `bun test test/path/path.test.ts`
- `bun test test/bun/router.test.ts`
- `bun run test:types`
- `bun run test:imports`

Note: `bun run test:functionality` currently fails on `Stream > stop stream on canceled request`; I reproduced the same failure on a clean `main` checkout with Bun 1.3.13, so it appears unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed route matching to prioritize more specific wildcard routes over generic catch-all patterns, ensuring `/api/auth/*` matches before `/*` when both exist.
  * Improved WebSocket upgrade request handling to prevent incorrect route override behavior.

* **New Features**
  * Routes are now evaluated using a specificity scoring system for more intelligent and predictable matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->