### PR TITLE
Improve query parsing and response header handling

### DIFF
--- a/src/adapter/bun/handler.ts
+++ b/src/adapter/bun/handler.ts
@@ -38,7 +38,11 @@ export const mapResponse = (
 				return Response.json(response, set as any)
 
 			case 'ElysiaFile':
-				return handleFile((response as ElysiaFile).value as File, set, request)
+				return handleFile(
+					(response as ElysiaFile).value as File,
+					set,
+					request
+				)
 
 			case 'File':
 				return handleFile(response as File, set, request)
@@ -175,7 +179,11 @@ export const mapEarlyResponse = (
 				return Response.json(response, set as any)
 
 			case 'ElysiaFile':
-				return handleFile((response as ElysiaFile).value as File, set, request)
+				return handleFile(
+					(response as ElysiaFile).value as File,
+					set,
+					request
+				)
 
 			case 'File':
 				return handleFile(response as File, set, request)
@@ -219,6 +227,13 @@ export const mapEarlyResponse = (
 				)
 
 			case 'FormData':
+				if (
+					isNotEmpty(set.headers) ||
+					set.status !== 200 ||
+					isNotEmpty(set.cookie)
+				)
+					return new Response(response as FormData, set as any)
+
 				return new Response(response as FormData)
 
 			case 'Cookie':
@@ -268,7 +283,7 @@ export const mapEarlyResponse = (
 				// custom class with an array-like value
 				// eg. Bun.sql`` result
 				if (Array.isArray(response))
-					return Response.json(response) as any
+					return Response.json(response, set as any) as any
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)
@@ -289,7 +304,11 @@ export const mapEarlyResponse = (
 				return Response.json(response, set as any)
 
 			case 'ElysiaFile':
-				return handleFile((response as ElysiaFile).value as File, set, request)
+				return handleFile(
+					(response as ElysiaFile).value as File,
+					set,
+					request
+				)
 
 			case 'File':
 				return handleFile(response as File, set, request)
@@ -405,7 +424,11 @@ export const mapCompactResponse = (
 			return Response.json(response)
 
 		case 'ElysiaFile':
-			return handleFile((response as ElysiaFile).value as File, undefined, request)
+			return handleFile(
+				(response as ElysiaFile).value as File,
+				undefined,
+				request
+			)
 
 		case 'File':
 			return handleFile(response as File, undefined, request)

--- a/src/adapter/utils.ts
+++ b/src/adapter/utils.ts
@@ -106,7 +106,8 @@ export const handleFile = (
 
 	if (set.headers instanceof Headers) {
 		for (const key of Object.keys(defaultHeader))
-			if (key in set.headers) set.headers.append(key, defaultHeader[key])
+			if (defaultHeader[key] && !set.headers.has(key))
+				set.headers.set(key, defaultHeader[key])
 
 		if (immutable) {
 			set.headers.delete('content-length')

--- a/src/adapter/web-standard/handler.ts
+++ b/src/adapter/web-standard/handler.ts
@@ -270,6 +270,13 @@ export const mapEarlyResponse = (
 				)
 
 			case 'FormData':
+				if (
+					isNotEmpty(set.headers) ||
+					set.status !== 200 ||
+					isNotEmpty(set.cookie)
+				)
+					return new Response(response as FormData, set as any)
+
 				return new Response(response as FormData)
 
 			case 'Cookie':
@@ -318,12 +325,15 @@ export const mapEarlyResponse = (
 
 				// custom class with an array-like value
 				// eg. Bun.sql`` result
-				if (Array.isArray(response))
-					return new Response(JSON.stringify(response), {
-						headers: {
-							'Content-Type': 'application/json'
-						}
-					}) as any
+				if (Array.isArray(response)) {
+					if (!set.headers['Content-Type'])
+						set.headers['Content-Type'] = 'application/json'
+
+					return new Response(
+						JSON.stringify(response),
+						set as any
+					) as any
+				}
 
 				if ('charCodeAt' in (response as any)) {
 					const code = (response as any).charCodeAt(0)

--- a/src/parse-query.ts
+++ b/src/parse-query.ts
@@ -21,7 +21,7 @@ export function parseQueryFromURL(
 	let startingIndex = startIndex - 1
 	let equalityIndex = startingIndex
 
-	for (let i = 0; i < inputLength; i++)
+	for (let i = startIndex; i < inputLength; i++)
 		switch (input.charCodeAt(i)) {
 			// '&'
 			case 38:
@@ -130,7 +130,7 @@ export function parseQueryStandardSchema(
 	let startingIndex = startIndex - 1
 	let equalityIndex = startingIndex
 
-	for (let i = 0; i < inputLength; i++)
+	for (let i = startIndex; i < inputLength; i++)
 		switch (input.charCodeAt(i)) {
 			// '&'
 			case 38:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1117,6 +1117,9 @@ export const getLoosePath = (path: string) => {
 export const isNotEmpty = (obj?: Object) => {
 	if (!obj) return false
 
+	if (typeof Headers !== 'undefined' && obj instanceof Headers)
+		return !obj.keys().next().done
+
 	for (const _ in obj) return true
 
 	return false

--- a/test/adapter/web-standard/map-early-response.test.ts
+++ b/test/adapter/web-standard/map-early-response.test.ts
@@ -10,6 +10,12 @@ const defaultContext = {
 	cookie: {}
 }
 
+const createDefaultContext = () => ({
+	headers: {},
+	status: 200,
+	cookie: {}
+})
+
 const createContext = () => ({
 	headers: {
 		'x-powered-by': 'Elysia',
@@ -376,13 +382,26 @@ describe('Web Standard - Map Early Response', () => {
 			form({
 				a: Bun.file('test/kyuukurarin.mp4')
 			}),
-			defaultContext
+			createDefaultContext()
 		)!
 
 		expect(response.headers.get('content-type')).toStartWith(
 			'multipart/form-data'
 		)
 		expect(response.status).toBe(200)
+		expect(await response.formData()).toBeInstanceOf(FormData)
+	})
+
+	it('map formdata with custom context', async () => {
+		const response = mapEarlyResponse(
+			form({
+				name: 'Shiroko'
+			}),
+			createContext()
+		)!
+
+		expect(response.headers.get('x-powered-by')).toBe('Elysia')
+		expect(response.status).toBe(418)
 		expect(await response.formData()).toBeInstanceOf(FormData)
 	})
 })

--- a/test/adapter/web-standard/map-response.test.ts
+++ b/test/adapter/web-standard/map-response.test.ts
@@ -286,6 +286,35 @@ describe('Web Standard - Map Response', () => {
 		})
 	})
 
+	it('respects Headers instance in set headers', async () => {
+		const response = mapResponse('Shiroko', {
+			...createContext(),
+			headers: new Headers({
+				'x-powered-by': 'elysia'
+			})
+		})
+
+		expect(response.headers.get('x-powered-by')).toBe('elysia')
+		expect(await response.text()).toBe('Shiroko')
+	})
+
+	it('adds file headers with Headers instance in set headers', async () => {
+		const file = new Blob(['Shiroko'])
+		const response = mapResponse(file, {
+			...createContext(),
+			status: 201,
+			headers: new Headers({
+				'x-powered-by': 'elysia'
+			})
+		})
+
+		expect(response.status).toBe(201)
+		expect(response.headers.get('x-powered-by')).toBe('elysia')
+		expect(response.headers.get('accept-ranges')).toBe('bytes')
+		expect(response.headers.get('content-range')).toBe('bytes 0-6/7')
+		expect(await response.text()).toBe('Shiroko')
+	})
+
 	it('map named status', async () => {
 		const response = mapResponse('Shiroko', {
 			status: "I'm a teapot",

--- a/test/units/parse-query.test.ts
+++ b/test/units/parse-query.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+	parseQueryFromURL,
+	parseQueryStandardSchema
+} from '../../src/parse-query'
+
+describe('parse query', () => {
+	it('starts parsing from the provided URL query index', () => {
+		const url =
+			'http://localhost/path=a&ignored=true/route?name=sucrose&job=alchemist'
+		const startIndex = url.indexOf('?') + 1
+
+		expect(parseQueryFromURL(url, startIndex)).toEqual({
+			name: 'sucrose',
+			job: 'alchemist'
+		})
+	})
+
+	it('starts standard schema parsing from the provided URL query index', () => {
+		const url =
+			'http://localhost/path=a&ignored=true/route?names=sucrose,lumine'
+		const startIndex = url.indexOf('?') + 1
+
+		expect(parseQueryStandardSchema(url, startIndex)).toEqual({
+			names: ['sucrose', 'lumine']
+		})
+	})
+})


### PR DESCRIPTION
## Summary

This PR tightens a few hot-path response/query handling details:

- Starts `parseQueryFromURL` and `parseQueryStandardSchema` from the provided query offset instead of scanning the whole URL from index `0`.
- Treats native `Headers` instances as non-empty when they contain entries, so `set.headers = new Headers(...)` is respected consistently.
- Preserves file response defaults (`accept-ranges` and `content-range`) when `set.headers` is a native `Headers` instance.
- Preserves `set` status/headers/cookies for early `FormData` responses in both Web Standard and Bun adapters.
- Adds regression coverage for query offset parsing, native `Headers`, file response headers, and early `FormData` responses.

## Why

`parseQueryFromURL` already accepts a `startIndex`, and the composed handlers pass the query start offset into it. However, the implementation still iterated from the beginning of the URL. For long paths this does extra work on every request with inferred query parsing.

There were also a couple of response mapping edge cases where native `Headers` and early `FormData` responses could lose user-provided response metadata or default file headers.

## Local measurement

A small local micro-benchmark parsing the same long-path URL 300k times improved from roughly:

- Before: `~485ms`
- After: `~142ms`

The largest gain is only expected when the path before `?` is long, but the change also removes unnecessary scanning in the general case.

## Tests

```sh
bun test test/adapter/web-standard/map-early-response.test.ts test/adapter/web-standard/map-response.test.ts test/response/range.test.ts test/response/headers.test.ts test/units/parse-query.test.ts test/validator/query.test.ts
bun run test:types
bun test
```

Full local test run result: `1530 pass, 0 fail`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom status, headers, and cookies when returning form data or array-like responses.
  * Improved header handling so existing values aren’t overwritten unexpectedly.
  * Query parsing now respects the provided starting position.
  * Added special handling for `Headers` inputs when checking for empty values.

* **Tests**
  * Expanded coverage for response mapping with custom contexts, `Headers` objects, file-like responses, and query parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->