### PR TITLE
fix(types): map plain values returned from onError to status 500

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,9 @@ import type {
 	ElysiaHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -3179,7 +3182,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3232,7 +3235,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3322,7 +3325,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3343,7 +3346,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3362,7 +3365,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3452,7 +3455,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3473,7 +3476,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3492,7 +3495,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3964,7 +3967,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4214,7 +4217,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4253,7 +4256,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4289,7 +4292,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4323,7 +4326,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4360,7 +4363,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4394,7 +4397,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4468,7 +4471,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -8355,7 +8358,10 @@ export type {
 	TransformHandler,
 	HTTPHeaders,
 	EmptyRouteSchema,
-	ExtractErrorFromHandle
+	ExtractErrorFromHandle,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous
 } from './types'
 
 export { env } from './universal/env'

--- a/src/types.ts
+++ b/src/types.ts
@@ -2228,6 +2228,58 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 				? ElysiaHandlerToResponseSchemas<Schemas>
 				: {}
 
+export type ErrorValueToResponseSchema<Value> = UnionResponseStatus<
+	ExtractErrorFromHandle<Value>,
+	Extract200<Value> extends infer PlainReturn
+		? [PlainReturn] extends [never]
+			? {}
+			: [PlainReturn] extends [undefined]
+				? {}
+				: undefined extends PlainReturn
+					? Exclude<PlainReturn, undefined | void> extends infer P
+						? [P] extends [never]
+							? {}
+							: { 500: P }
+						: {}
+					: { 500: PlainReturn }
+		: {}
+>
+
+export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
+	Prettify<
+		Handle extends (...a: any) => MaybePromise<infer R>
+			? ErrorValueToResponseSchema<Exclude<R, undefined | void>>
+			: {}
+	>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			// @ts-ignore trust me bro
+			UnionResponseStatus<
+				ElysiaErrorHandlerToResponseSchema<
+					Current extends Function ? Current : any
+				>,
+				Carry
+			>
+		>
+	: Prettify<Carry>
+
+export type ElysiaErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ElysiaErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ElysiaErrorHandlerToResponseSchemas<Schemas>
+				: {}
+
 type ReconcileStatus<
 	in out A extends Record<number, unknown>,
 	in out B extends Record<number, unknown>

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -2498,6 +2498,36 @@ type a = keyof {}
 	})
 }
 
+// onError should map plain return value to 500 status in routes response metadata
+{
+	const app = new Elysia()
+		.onError(() => {
+			return { failure: 'error' }
+		})
+		.get('/', () => 'hello')
+
+	type ResponseSchema = (typeof app)['~Routes']['get']['response']
+	expectTypeOf<ResponseSchema>().toEqualTypeOf<{
+		200: string
+		500: { failure: string }
+	}>()
+}
+
+// onError should map async plain return value to 500 status in routes response metadata
+{
+	const app = new Elysia()
+		.onError(async () => {
+			return { failure: 'async error' }
+		})
+		.get('/', () => 'hello')
+
+	type ResponseSchema = (typeof app)['~Routes']['get']['response']
+	expectTypeOf<ResponseSchema>().toEqualTypeOf<{
+		200: string
+		500: { failure: string }
+	}>()
+}
+
 // onAfterHandle should have response
 {
 	new Elysia().onAfterHandle(

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1007,7 +1007,7 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
@@ -1028,7 +1028,7 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
@@ -1049,7 +1049,7 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'


### PR DESCRIPTION
Map plain return values from onError handlers to status 500 in route response type schemas instead of status 200. Fixes Eden treaty inferred error value types.

Closes #313
@algora-pbc /claim #313