### PR TITLE
fix(ws): correct inverted response schema validation in createHandleWSResponse

### DIFF
--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -266,7 +266,7 @@ export const createHandleWSResponse = (
 			: undefined
 
 		const send = (datum: unknown) => {
-			if (validateResponse && validateResponse(datum) === false)
+			if (validateResponse && validateResponse(datum))
 				return ws.send(
 					new ValidationError('message', responseValidator!, datum)
 						.message
@@ -286,12 +286,12 @@ export const createHandleWSResponse = (
 			return (async () => {
 				const first = await init
 
-				if (validateResponse && validateResponse(first))
+				if (validateResponse && validateResponse(first.value))
 					return ws.send(
 						new ValidationError(
 							'message',
 							responseValidator!,
-							first
+							first.value
 						).message
 					)
 


### PR DESCRIPTION
Fixes #1933.

## Root cause

`createHandleWSResponse` builds a `validateResponse` predicate that returns **truthy on failure**:

- TypeBox path: `(data) => responseValidator.Check(data) === false` — returns `true` when invalid
- Standard-schema path: `(data) => responseValidator.schema['~standard'].validate(data).issues` — returns the issues array (truthy) when invalid

The `send()` guard checked `validateResponse(datum) === false`, which is truthy only when validation **passes** — exactly backwards. Valid messages were replaced by `ValidationError` frames; invalid messages were sent through unvalidated.

Regression from `23f30f78a` ("fix: #1563 standard schema on websocket"), which extracted the old inline `Check(datum) === false` check into a closure but left `=== false` at the call site, double-negating it.

**Second bug in the same block**: the async-generator early-return path validated `first` (the `{value, done}` iterator result object) instead of `first.value` (the handler's actual yielded datum), embedding the wrapper in the `ValidationError` message.

## Fix

1. Remove `=== false` from the `send()` guard — `validateResponse(datum)` alone is truthy on failure.
2. Validate `first.value` instead of `first` in the async-generator branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response validation for websocket interactions so invalid payloads are rejected more reliably.
  * Fixed handling of generator-based responses to validate the returned value correctly and show clearer validation errors when the first result is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->