### PR TITLE
feat: add support for HTTP QUERY method (RFC 10008)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "peerDependencies": {
         "@sinclair/typebox": ">= 0.34.0 < 1",
         "@types/bun": ">= 1.2.0",
-        "exact-mirror": "^0.2.6",
+        "exact-mirror": ">= 0.0.9",
         "file-type": ">= 20.0.0",
         "openapi-types": ">= 12.0.0",
         "typescript": ">= 5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6699,6 +6699,113 @@ export default class Elysia<
 	}
 
 	/**
+	 * ### query
+	 * Register handler for path with method [QUERY]
+	 *
+	 * ---
+	 * @example
+	 * ```typescript
+	 * import { Elysia, t } from 'elysia'
+	 *
+	 * new Elysia()
+	 *     .query('/', () => 'hi')
+	 *     .query('/with-hook', () => 'hi', {
+	 *         response: t.String()
+	 *     })
+	 * ```
+	 */
+	query<
+		const Path extends string,
+		const Input extends Metadata['macro'] &
+			InputSchema<keyof Definitions['typebox'] & string>,
+		const Schema extends IntersectIfObjectSchema<
+			MergeSchema<
+				UnwrapRoute<
+					Input,
+					Definitions['typebox'],
+					JoinPath<BasePath, Path>
+				>,
+				MergeSchema<
+					Volatile['schema'],
+					MergeSchema<Ephemeral['schema'], Metadata['schema']>
+				>
+			>,
+			Metadata['standaloneSchema'] &
+				Ephemeral['standaloneSchema'] &
+				Volatile['standaloneSchema']
+		>,
+		const Decorator extends Singleton & {
+			derive: Ephemeral['derive'] & Volatile['derive']
+			resolve: Ephemeral['resolve'] & Volatile['resolve']
+		},
+		const MacroContext extends {} extends Metadata['macroFn']
+			? {}
+			: MacroToContext<
+					Metadata['macroFn'],
+					Omit<Input, NonResolvableMacroKey>,
+					Definitions['typebox']
+				>,
+		const Handle extends InlineHandler<
+			NoInfer<Schema>,
+			NoInfer<Decorator>,
+			// @ts-ignore
+			MacroContext
+		>
+	>(
+		path: Path,
+		handler: Handle,
+		hook?: LocalHook<
+			Input,
+			// @ts-ignore
+			Schema & MacroContext,
+			Decorator,
+			Definitions['error'],
+			keyof Metadata['parser']
+		>
+	): Elysia<
+		BasePath,
+		Singleton,
+		Definitions,
+		Metadata,
+		Routes &
+			CreateEden<
+				JoinPath<BasePath, Path>,
+				{
+					query: CreateEdenResponse<
+						Path,
+						Schema,
+						MacroContext,
+						ComposeElysiaResponse<
+							Schema &
+								MacroContext &
+								Metadata['standaloneSchema'] &
+								Ephemeral['standaloneSchema'] &
+								Volatile['standaloneSchema'],
+							Handle,
+							UnionResponseStatus<
+								Metadata['response'],
+								UnionResponseStatus<
+									Ephemeral['response'],
+									UnionResponseStatus<
+										Volatile['response'],
+										// @ts-ignore
+										MacroContext['return'] & {}
+									>
+								>
+							>
+						>
+					>
+				}
+			>,
+		Ephemeral,
+		Volatile
+	> {
+		this.add('QUERY', path, handler as any, hook)
+
+		return this as any
+	}
+
+	/**
 	 * ### route
 	 * Register handler for path with method [ROUTE]
 	 *

--- a/src/types.ts
+++ b/src/types.ts
@@ -689,6 +689,7 @@ export type HTTPMethod =
 	| 'PROPPATCH'
 	| 'PURGE'
 	| 'PUT'
+	| 'QUERY'
 	| 'REBIND'
 	| 'REPORT'
 	| 'SEARCH'

--- a/test/core/query.test.ts
+++ b/test/core/query.test.ts
@@ -1,0 +1,50 @@
+import { Elysia, t } from '../../src'
+
+import { describe, expect, it } from 'bun:test'
+import { req } from '../utils'
+
+describe('HTTP QUERY Method', () => {
+	it('handle QUERY request', async () => {
+		const app = new Elysia().query('/', () => 'QUERY')
+
+		const res = await app.handle(
+			req('/', {
+				method: 'QUERY'
+			})
+		)
+
+		expect(await res.text()).toBe('QUERY')
+	})
+
+	it('handle QUERY request with body', async () => {
+		const app = new Elysia().query(
+			'/',
+			({ body }) => body,
+			{
+				body: t.Object({
+					name: t.String()
+				})
+			}
+		)
+
+		const res = await app.handle(
+			req('/', {
+				method: 'QUERY',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ name: 'Elysia' })
+			})
+		)
+
+		expect(await res.json()).toEqual({ name: 'Elysia' })
+	})
+
+	it('return 404 for non-QUERY request', async () => {
+		const app = new Elysia().query('/', () => 'QUERY')
+
+		const res = await app.handle(req('/'))
+
+		expect(res.status).toBe(404)
+	})
+})


### PR DESCRIPTION
## Summary

Add first-class support for the HTTP `QUERY` method as defined in [RFC 10008](https://www.rfc-editor.org/info/rfc10008/).

This PR implements:
- Add `QUERY` to the `HTTPMethod` type union
- Add `query()` route helper to the Elysia class with full type inference
- Add tests for QUERY method routing and body handling

## Motivation

RFC 10008 introduces the QUERY method as a safe, idempotent alternative to POST for operations that need a request body. This is particularly useful for complex search queries that exceed URL length limits.

Refs: #1931

## Testing

All tests pass:
- handle QUERY request
- handle QUERY request with body
- return 404 for non-QUERY request

## Checklist

- [x] Code follows project style
- [x] Tests added for new functionality
- [x] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering `QUERY` routes.
  * `QUERY` handlers support request-body validation and parsed input.
  * Added full type support for `QUERY` endpoints.

* **Bug Fixes**
  * Non-`QUERY` requests to `QUERY`-only routes correctly return a 404 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->