### PR TITLE
feat: optional path/domain override for cookie.remove() (#1937)(#1940)

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -326,13 +326,20 @@ export class Cookie<T> implements ElysiaCookie {
 		return this
 	}
 
-	remove() {
+	remove(
+		options?:
+			| string
+			| Partial<Omit<ElysiaCookie, 'value' | 'maxAge' | 'expires'>>
+	) {
 		if (this.value === undefined) return
+
+		if (typeof options === 'string') options = { path: options }
 
 		this.set({
 			expires: new Date(0),
 			maxAge: 0,
-			value: ''
+			value: '',
+			...options
 		})
 
 		return this

--- a/test/adapter/web-standard/cookie-to-header.test.ts
+++ b/test/adapter/web-standard/cookie-to-header.test.ts
@@ -116,4 +116,22 @@ describe('Web Standard - Cookie to Header', () => {
 		const result = serializeCookie(cookies)
 		expect(result).toBeUndefined()
 	})
+
+	it('serialize a removed cookie with matching path and domain', () => {
+		const cookies = {
+			session: {
+				value: '',
+				expires: new Date(0),
+				maxAge: 0,
+				path: '/api',
+				domain: 'millennium.sh'
+			}
+		}
+		const result = serializeCookie(cookies)
+
+		expect(result).toContain('Path=/api')
+		expect(result).toContain('Domain=millennium.sh')
+    expect(result).toContain('Max-Age=0')
+    expect(result).toContain('Expires=Thu, 01 Jan 1970')
+	})
 })

--- a/test/cookie/explicit.test.ts
+++ b/test/cookie/explicit.test.ts
@@ -118,4 +118,48 @@ describe('Explicit Cookie', () => {
 			Date.now()
 		)
 	})
+
+	it('remove cookie with a path shorthand', () => {
+		const { cookie, set } = create()
+		cookie.name.value = 'himari'
+		cookie.name.remove('/api')
+
+		expect(set.cookie?.name.path).toBe('/api')
+		expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
+			Date.now()
+    )
+    expect(set.cookie?.name.maxAge).toBe(0)
+		expect(set.cookie?.name.value).toBe('')
+	})
+
+	it('remove cookie with explicit path and domain', () => {
+		const { cookie, set } = create()
+		cookie.name.value = 'himari'
+		cookie.name.remove({ path: '/api', domain: 'millennium.sh' })
+
+		expect(set.cookie?.name.path).toBe('/api')
+    expect(set.cookie?.name.domain).toBe('millennium.sh')
+    expect(set.cookie?.name.expires?.getTime()).toBeLessThanOrEqual(
+			Date.now()
+    )
+    expect(set.cookie?.name.maxAge).toBe(0)
+    expect(set.cookie?.name.value).toBe('')
+	})
+
+	it('remove does not add a path when called without arguments', () => {
+		const { cookie, set } = create()
+		cookie.name.value = 'himari'
+		cookie.name.remove()
+
+		expect(set.cookie?.name.path).toBeUndefined()
+	})
+
+	it('remove one cookie without affecting another', () => {
+		const { cookie, set } = create()
+		cookie.name.value = 'himari'
+		cookie.other.value = 'aru'
+		cookie.name.remove('/api')
+
+		expect(set.cookie?.other).toEqual({ value: 'aru' })
+	})
 })


### PR DESCRIPTION
`cookie.remove()` reuses the cookie's initial `path`/`domain` with no
per-call override. Per RFC 6265 a browser only deletes a cookie when the
deletion `Set-Cookie` carries a `Path` (and `Domain`) matching the one used
at creation — so removing a `path: '/'` cookie from a nested route like
`/api/child` silently fails.

Now, `remove()` accept an optional argument: 
- `remove('/api')` remove cookie from an explicit path,  string shorthand for `{ path: '/api' }`
- `remove({ path: '/api', domain: 'millennium.sh' })` override matching attributes (like 'domain', and excluding 'value' , 'maxAge' , 'expires', overriding them will defeat the deletion)

Closes: #1937 (path)
Closes: #1940 (domain)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cookie removal now supports optional settings to control removal attributes, including a path shorthand.

* **Bug Fixes**
  * Removed-cookie headers now correctly reflect matching `Path`/`Domain`, including `Max-Age=0` and `Expires=Thu, 01 Jan 1970`.
  * Removing one cookie no longer impacts other cookies.

* **Tests**
  * Added coverage for web-standard cookie-to-header serialization and explicit cookie removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->