### PR TITLE
Type custom onError JSON responses as errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,9 @@ import type {
 	NonResolvableMacroKey,
 	StandardSchemaV1Like,
 	ElysiaHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchema,
 	ElysiaHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
@@ -3179,7 +3181,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3232,7 +3234,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3322,7 +3324,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3343,7 +3345,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3362,7 +3364,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3452,7 +3454,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3473,7 +3475,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3492,7 +3494,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>

--- a/src/types.ts
+++ b/src/types.ts
@@ -980,7 +980,7 @@ type MergeResponseStatus<A> = {
 			? { [A in Status]: 1 }
 			: never
 		// @ts-ignore A is checked in key computation
-	>]: Extract<A, { code: status }>['response'] extends infer Value
+	>]: Extract<A, { code: status }> extends { response: infer Value }
 		? IsAny<Value> extends true
 			? // @ts-ignore status is always in Status Map
 				InvertedStatusMap[status]
@@ -2205,6 +2205,20 @@ export type ElysiaHandlerToResponseSchema<in out Handle extends Function> =
 			: {}
 	>
 
+export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
+	Prettify<
+		Handle extends (...a: any) => MaybePromise<infer R>
+			? ValueToResponseSchema<Exclude<R, undefined>> &
+					(Extract200<Exclude<R, undefined>> extends infer R500
+						? undefined extends R500
+							? {}
+							: IsNever<R500> extends true
+								? {}
+								: { 500: R500 }
+						: {})
+			: {}
+	>
+
 export type ElysiaHandlerToResponseSchemas<
 	Handle extends Function[],
 	Carry extends PossibleResponse = {}
@@ -2214,6 +2228,22 @@ export type ElysiaHandlerToResponseSchemas<
 			Rest,
 			// @ts-ignore trust me bro
 			UnionResponseStatus<ElysiaHandlerToResponseSchema<Current>, Carry>
+		>
+	: Prettify<Carry>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			Rest extends Function[] ? Rest : [],
+			// @ts-ignore trust me bro
+			UnionResponseStatus<
+				Current extends Function
+					? ElysiaErrorHandlerToResponseSchema<Current>
+					: {},
+				Carry
+			>
 		>
 	: Prettify<Carry>
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -2498,6 +2498,44 @@ type a = keyof {}
 	})
 }
 
+// onError should expose custom JSON error response under error status
+{
+	const app = new Elysia()
+		.onError(() => ({
+			failure: 'Server is during maintenance' as string
+		}))
+		.get('/error', () => {
+			throw new Error('Server is during maintenance')
+		})
+
+	expectTypeOf<
+		(typeof app)['~Routes']['error']['get']['response']
+	>().toEqualTypeOf<{
+		200: {
+			failure: string
+		}
+		500: {
+			failure: string
+		}
+	}>()
+}
+
+// onError should preserve explicit status responses
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			status(401, { error: 'Unauthorized' as string })
+		)
+		.get('/error', () => {
+			throw new Error('Unauthorized')
+		})
+
+	type Response = (typeof app)['~Routes']['error']['get']['response']
+	const _typeTest: Response extends { 401: { error: string } }
+		? true
+		: false = true
+}
+
 // onAfterHandle should have response
 {
 	new Elysia().onAfterHandle(

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1011,6 +1011,7 @@ import { Prettify } from '../../../src/types'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1032,6 +1033,7 @@ import { Prettify } from '../../../src/types'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1053,6 +1055,7 @@ import { Prettify } from '../../../src/types'
 		401: 'fouco'
 		404: 'lilith'
 		418: 'sartre'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 


### PR DESCRIPTION
## Summary
- add error-handler-specific response schema helpers so plain `onError` return values are also exposed under a 500 error response
- keep existing 200 inference for compatibility and preserve explicit `status(...)` response typing
- add focused type coverage for custom JSON `onError` responses and lifecycle soundness

## Verification
- `git diff --check`
- `npx tsc --project tsconfig.test.json` (only pre-existing unrelated errors remain: `src/adapter/web-standard/handler.ts(39,17)` and `src/universal/file.ts(166,34)`)

@algora-pbc /claim #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript response inference for error handlers.
  * Error responses now correctly preserve explicit status codes and include inferred HTTP 500 responses when applicable.
  * Updated local, scoped, and global error-handling typings for improved type accuracy.

* **Tests**
  * Added coverage for inferred error response payloads and status mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->