### PR TITLE
:wrench: fix: keep JSON-looking multipart fields as strings when sche…

### DIFF
--- a/src/adapter/web-standard/index.ts
+++ b/src/adapter/web-standard/index.ts
@@ -40,89 +40,22 @@ export const WebStandardAdapter: ElysiaAdapter = {
 				return `c.body=await c.request.arrayBuffer()\n`
 			},
 			formData(isOptional) {
-				let fnLiteral = '\nc.body={}\n'
-
 				if (isOptional)
-					fnLiteral += `let form;try{form=await c.request.formData()}catch{}`
-				else fnLiteral += `const form=await c.request.formData()\n`
+					return (
+						'\nc.body={}\n' +
+						`let form;try{form=await c.request.formData()}catch{}\n` +
+						`if(form!==undefined){` +
+						`const fd=parseFormData(form)\n` +
+						`c.body=fd.body\n` +
+						`if(fd.structured!==undefined)c[ELYSIA_STRUCTURED_FORM]=fd.structured` +
+						`}\n`
+					)
 
 				return (
-					fnLiteral +
-					`const dangerousKeys=new Set(['__proto__','constructor','prototype'])\n` +
-					`const isDangerousKey=(k)=>{` +
-					`if(dangerousKeys.has(k))return true;` +
-					`const m=k.match(/^(.+)\\[(\\d+)\\]$/);` +
-					`return m?dangerousKeys.has(m[1]):false` +
-					`}\n` +
-					`const parseArrayKey=(k)=>{` +
-					`const m=k.match(/^(.+)\\[(\\d+)\\]$/);` +
-					`return m?{name:m[1],index:parseInt(m[2],10)}:null` +
-					`}\n` +
-					`const grouped=new Map()\n` +
-					`form.forEach((v,k)=>{const l=grouped.get(k);if(l)l.push(v);else grouped.set(k,[v])})\n` +
-					`for(const [key,value] of grouped){` +
-					`if(c.body[key])continue\n` +
-					`let finalValue\n` +
-    				`if(value.length===1){\n` +
-    				`const sv=value[0]\n` +
-    				`if(typeof sv==='string'&&(sv.charCodeAt(0)===123||sv.charCodeAt(0)===91)){\n` +
-    				`try{\n` +
-    				`const p=JSON.parse(sv)\n` +
-    				`if(p&&typeof p==='object')finalValue=p\n` +
-    				`}catch{}\n` +
-    				`}\n` +
-    				`if(finalValue===undefined)finalValue=sv\n` +
-    				`}else finalValue=value\n` +
-					`if(Array.isArray(finalValue)){\n` +
-					`const stringValue=finalValue.find((entry)=>typeof entry==='string')\n` +
-					`const files=typeof File==='undefined'?[]:finalValue.filter((entry)=>entry instanceof File)\n` +
-					`if(stringValue&&files.length&&stringValue.charCodeAt(0)===123){\n` +
-					`try{\n` +
-					`const parsed=JSON.parse(stringValue)\n` +
-					`if(parsed&&typeof parsed==='object'&&!Array.isArray(parsed)){\n` +
-					`if(!('file' in parsed)&&files.length===1)parsed.file=files[0]\n` +
-					`else if(!('files' in parsed)&&files.length>1)parsed.files=files\n` +
-					`finalValue=parsed\n` +
-					`}\n` +
-					`}catch{}\n` +
-					`}\n` +
-					`}\n` +
-					`if(key.includes('.')||key.includes('[')){` +
-					`const keys=key.split('.')\n` +
-					`const lastKey=keys.pop()\n` +
-					`if(isDangerousKey(lastKey)||keys.some(isDangerousKey))continue\n` +
-					`let current=c.body\n` +
-					`for(const k of keys){` +
-					`const arrayInfo=parseArrayKey(k)\n` +
-					`if(arrayInfo){` +
-					`if(!Array.isArray(current[arrayInfo.name]))current[arrayInfo.name]=[]\n` +
-					`const existing=current[arrayInfo.name][arrayInfo.index]\n` +
-					`const isFile=typeof File!=='undefined'&&existing instanceof File\n` +
-					`if(!existing||typeof existing!=='object'||Array.isArray(existing)||isFile){\n` +
-					`let parsed\n` +
-					`if(typeof existing==='string'&&existing.charCodeAt(0)===123){\n` +
-					`try{` +
-					`parsed=JSON.parse(existing)\n` +
-					`if(!parsed||typeof parsed!=='object'||Array.isArray(parsed))parsed=undefined` +
-					`}catch{}\n` +
-					`}\n` +
-					`current[arrayInfo.name][arrayInfo.index]=parsed||{}\n` +
-					`}\n` +
-					`current=current[arrayInfo.name][arrayInfo.index]` +
-					`}else{` +
-					`if(!current[k]||typeof current[k]!=='object')current[k]={}\n` +
-					`current=current[k]` +
-					`}` +
-					`}\n` +
-					`const arrayInfo=parseArrayKey(lastKey)\n` +
-					`if(arrayInfo){` +
-					`if(!Array.isArray(current[arrayInfo.name]))current[arrayInfo.name]=[]\n` +
-					`current[arrayInfo.name][arrayInfo.index]=finalValue` +
-					`}else{` +
-					`current[lastKey]=finalValue` +
-					`}` +
-					`}else c.body[key]=finalValue` +
-					`}`
+					`\nconst form=await c.request.formData()\n` +
+					`const fd=parseFormData(form)\n` +
+					`c.body=fd.body\n` +
+					`if(fd.structured!==undefined)c[ELYSIA_STRUCTURED_FORM]=fd.structured\n`
 				)
 			}
 		}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -14,6 +14,7 @@ import {
 	parseQueryFromURL,
 	parseQueryStandardSchema
 } from './parse-query'
+import { ELYSIA_STRUCTURED_FORM, parseFormData } from './parse-form-data'
 
 import {
 	ELYSIA_REQUEST_ID,
@@ -1176,6 +1177,12 @@ export const composeHandler = ({
 		}
 
 		fnLiteral += '}catch(error){throw new ParseError(error)}'
+
+		// Without validation the structured multipart interpretation is
+		// adopted as-is, otherwise body validation decides which
+		// interpretation matches the schema
+		if (!validator.body || validator.body.schema?.noValidate === true)
+			fnLiteral += `\nif(c[ELYSIA_STRUCTURED_FORM]!==undefined)c.body=c[ELYSIA_STRUCTURED_FORM]\n`
 	}
 
 	parseReporter.resolve()
@@ -1391,6 +1398,22 @@ export const composeHandler = ({
 			const hasUnion = isUnion(validator.body.schema)
 			let hasNonUnionFileWithDefault = false
 
+			// When the submitted body fails validation, retry against the
+			// structured multipart interpretation so schemas expecting
+			// objects or arrays keep accepting JSON-serialized fields
+			const structuredFormFallback = (applyDefault = '') =>
+				`{let vsb=c[ELYSIA_STRUCTURED_FORM]\n` +
+				`if(vsb===undefined){${validation.validate('body')}}\n` +
+				applyDefault +
+				composeCleaner({
+					name: 'vsb',
+					schema: validator.body!,
+					type: 'body',
+					normalize
+				}) +
+				`if(validator.body.Check(vsb)===false){${validation.validate('body')}}\n` +
+				`c.body=vsb}`
+
 			if (validator.body.hasDefault) {
 				let value = Value.Default(
 					validator.body.schema,
@@ -1441,24 +1464,35 @@ export const composeHandler = ({
 					normalize
 				})
 
+				const structuredDefault =
+					value !== undefined &&
+					value !== null &&
+					typeof value === 'object' &&
+					!Array.isArray(value)
+						? `vsb=Object.assign(${parsed},vsb)\n`
+						: ''
+
 				if (validator.body.provider === 'standard') {
 					fnLiteral +=
 						`let vab=validator.body.Check(c.body)\n` +
 						`if(vab instanceof Promise)vab=await vab\n` +
+						`if(vab.issues&&c[ELYSIA_STRUCTURED_FORM]!==undefined){` +
+						`let vsb=validator.body.Check(c[ELYSIA_STRUCTURED_FORM])\n` +
+						`if(vsb instanceof Promise)vsb=await vsb\n` +
+						`if(!vsb.issues)vab=vsb` +
+						`}\n` +
 						`if(vab.issues){` +
 						validation.validate('body', undefined, 'vab.issues') +
 						'}else{c.body=vab.value}\n'
 				} else if (validator.body?.schema?.noValidate !== true) {
 					if (validator.body.isOptional)
 						fnLiteral +=
-							`if(isNotEmptyObject&&validator.body.Check(c.body)===false){` +
-							validation.validate('body') +
-							'}'
+							`if(isNotEmptyObject&&validator.body.Check(c.body)===false)` +
+							structuredFormFallback(structuredDefault)
 					else
 						fnLiteral +=
-							`if(validator.body.Check(c.body)===false){` +
-							validation.validate('body') +
-							`}`
+							`if(validator.body.Check(c.body)===false)` +
+							structuredFormFallback(structuredDefault)
 				}
 			} else {
 				fnLiteral += composeCleaner({
@@ -1472,20 +1506,23 @@ export const composeHandler = ({
 					fnLiteral +=
 						`let vab=validator.body.Check(c.body)\n` +
 						`if(vab instanceof Promise)vab=await vab\n` +
+						`if(vab.issues&&c[ELYSIA_STRUCTURED_FORM]!==undefined){` +
+						`let vsb=validator.body.Check(c[ELYSIA_STRUCTURED_FORM])\n` +
+						`if(vsb instanceof Promise)vsb=await vsb\n` +
+						`if(!vsb.issues)vab=vsb` +
+						`}\n` +
 						`if(vab.issues){` +
 						validation.validate('body', undefined, 'vab.issues') +
 						'}else{c.body=vab.value}\n'
 				} else if (validator.body?.schema?.noValidate !== true) {
 					if (validator.body.isOptional)
 						fnLiteral +=
-							`if(isNotEmptyObject&&validator.body.Check(c.body)===false){` +
-							validation.validate('body') +
-							'}'
+							`if(isNotEmptyObject&&validator.body.Check(c.body)===false)` +
+							structuredFormFallback()
 					else
 						fnLiteral +=
-							`if(validator.body.Check(c.body)===false){` +
-							validation.validate('body') +
-							'}'
+							`if(validator.body.Check(c.body)===false)` +
+							structuredFormFallback()
 				}
 			}
 
@@ -2137,6 +2174,7 @@ export const composeHandler = ({
 		`isNotEmpty,` +
 		`utils:{` +
 		allocateIf(`parseQuery,`, hasBody) +
+		allocateIf(`parseFormData,`, hasBody) +
 		allocateIf(`parseQueryFromURL,`, hasQuery) +
 		`},` +
 		`error:{` +
@@ -2154,6 +2192,7 @@ export const composeHandler = ({
 		`ElysiaCustomStatusResponse,` +
 		allocateIf(`ELYSIA_TRACE,`, hasTrace) +
 		allocateIf(`ELYSIA_REQUEST_ID,`, hasTrace) +
+		allocateIf(`ELYSIA_STRUCTURED_FORM,`, hasBody) +
 		allocateIf('parser,', hooks.parse?.length) +
 		allocateIf(`getServer,`, inference.server) +
 		allocateIf(`fileUnions,`, fileUnions.length) +
@@ -2187,6 +2226,7 @@ export const composeHandler = ({
 			isNotEmpty,
 			utils: {
 				parseQuery: hasBody ? parseQuery : undefined,
+				parseFormData: hasBody ? parseFormData : undefined,
 				parseQueryFromURL: hasQuery
 					? validator.query?.provider === 'standard'
 						? parseQueryStandardSchema
@@ -2210,6 +2250,9 @@ export const composeHandler = ({
 			ElysiaCustomStatusResponse,
 			ELYSIA_TRACE: hasTrace ? ELYSIA_TRACE : undefined,
 			ELYSIA_REQUEST_ID: hasTrace ? ELYSIA_REQUEST_ID : undefined,
+			ELYSIA_STRUCTURED_FORM: hasBody
+				? ELYSIA_STRUCTURED_FORM
+				: undefined,
 			// @ts-expect-error private property
 			getServer: inference.server ? () => app.getServer() : undefined,
 			fileUnions: fileUnions.length ? fileUnions : undefined,

--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -9,6 +9,7 @@ import {
 	ValidationError
 } from './error'
 import type { AnyElysia, CookieOptions } from './index'
+import { parseFormData } from './parse-form-data'
 import { parseQuery } from './parse-query'
 import { getSchemaProperties, type ElysiaTypeCheck } from './schema'
 import type { TypeCheck } from './type-system'
@@ -22,150 +23,6 @@ export type DynamicHandler = {
 	hooks: Partial<LifeCycleStore>
 	validator?: SchemaValidator
 	route: string
-}
-
-/**
- * Matches array index notation in property paths
- * Examples:
- *   "users[0]"  → Group 1: "users", Group 2: "0"
- *   "items[42]" → Group 1: "items", Group 2: "42"
- *   "a[123]"    → Group 1: "a",     Group 2: "123"
- *
- * Does not match:
- *   "users"     → no brackets
- *   "users[]"   → no index
- *   "users[ab]" → non-numeric index
- */
-const ARRAY_INDEX_REGEX = /^(.+)\[(\d+)\]$/
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
-
-const isDangerousKey = (key: string): boolean => {
-	if (DANGEROUS_KEYS.has(key)) return true
-
-	const match = key.match(ARRAY_INDEX_REGEX)
-	return match ? DANGEROUS_KEYS.has(match[1]) : false
-}
-
-const parseArrayKey = (key: string) => {
-	const match = key.match(ARRAY_INDEX_REGEX)
-	if (!match) return null
-
-	return {
-		name: match[1],
-		index: parseInt(match[2], 10)
-	}
-}
-
-const parseObjectString = (entry: unknown) => {
-	if (typeof entry !== 'string' || entry.charCodeAt(0) !== 123) return
-
-	try {
-		const parsed = JSON.parse(entry)
-		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-			return parsed
-	} catch {
-		return
-	}
-}
-
-const setNestedValue = (obj: Record<string, any>, path: string, value: any) => {
-	const keys = path.split('.')
-	const lastKey = keys.pop() as string
-
-	// Validate all keys upfront
-	if (isDangerousKey(lastKey) || keys.some(isDangerousKey)) return
-
-	let current = obj
-
-	// Traverse intermediate keys
-	for (const key of keys) {
-		const arrayInfo = parseArrayKey(key)
-
-		if (arrayInfo) {
-			// Initialize array if needed
-			if (!Array.isArray(current[arrayInfo.name]))
-				current[arrayInfo.name] = []
-
-			const existing = current[arrayInfo.name][arrayInfo.index]
-			const isFile =
-				typeof File !== 'undefined' && existing instanceof File
-
-			// Initialize object at index if needed
-			if (
-				!existing ||
-				typeof existing !== 'object' ||
-				Array.isArray(existing) ||
-				isFile
-			)
-				current[arrayInfo.name][arrayInfo.index] =
-					parseObjectString(existing) ?? {}
-
-			current = current[arrayInfo.name][arrayInfo.index]
-		} else {
-			// Initialize object property if needed
-			if (!current[key] || typeof current[key] !== 'object')
-				current[key] = {}
-
-			current = current[key]
-		}
-	}
-
-	// Set final value
-	const arrayInfo = parseArrayKey(lastKey)
-
-	if (arrayInfo) {
-		if (!Array.isArray(current[arrayInfo.name]))
-			current[arrayInfo.name] = []
-
-		current[arrayInfo.name][arrayInfo.index] = value
-	} else {
-		current[lastKey] = value
-	}
-}
-
-const normalizeFormValue = (value: unknown[]) => {
-    if (value.length === 1) {
-        const stringValue = value[0]
-        if (typeof stringValue === 'string') {
-            // Try to parse JSON objects (starting with '{') or arrays (starting with '[')
-            if (stringValue.charCodeAt(0) === 123 || stringValue.charCodeAt(0) === 91) {
-                try {
-                    const parsed = JSON.parse(stringValue)
-                    if (parsed && typeof parsed === 'object') {
-                        return parsed
-                    }
-                } catch {}
-            }
-        }
-        return value[0]
-    }
-
-	const stringValue = value.find(
-		(entry): entry is string => typeof entry === 'string'
-	)
-	if (!stringValue) return value
-
-	if (typeof File === 'undefined') return value
-	const files = value.filter((entry): entry is File => entry instanceof File)
-	if (!files.length) return value
-
-	if (stringValue.charCodeAt(0) !== 123) return value
-
-	let parsed: unknown
-	try {
-		parsed = JSON.parse(stringValue)
-	} catch {
-		return value
-	}
-
-	if (typeof parsed !== 'object' || parsed === null) return value
-
-	if (!('file' in parsed) && files.length === 1)
-		(parsed as Record<string, unknown>).file = files[0]
-	else if (!('files' in parsed) && files.length > 1)
-		(parsed as Record<string, unknown>).files = files
-
-	return parsed
 }
 
 const injectDefaultValues = (
@@ -264,6 +121,7 @@ export const createDynamicHandler = (app: AnyElysia) => {
 				return await hooks.config.mount(request)
 
 			let body: string | Record<string, any> | undefined
+			let structuredForm: Record<string, any> | undefined
 			if (request.method !== 'GET' && request.method !== 'HEAD') {
 				if (content) {
 					switch (content) {
@@ -284,24 +142,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 							break
 
 						case 'multipart/form-data': {
-							body = {}
-
-							const form = await request.formData()
-							const grouped = new Map<string, any[]>()
-							form.forEach((v, k) => {
-								const list = grouped.get(k)
-								if (list) list.push(v)
-								else grouped.set(k, [v])
-							})
-							for (const [key, value] of grouped) {
-								if (body[key]) continue
-
-								const finalValue = normalizeFormValue(value)
-
-								if (key.includes('.') || key.includes('['))
-									setNestedValue(body, key, finalValue)
-								else body[key] = finalValue
-							}
+							const form = parseFormData(
+								await request.formData()
+							)
+							body = form.body
+							structuredForm = form.structured
 
 							break
 						}
@@ -349,24 +194,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 
 										case 'formdata':
 										case 'multipart/form-data': {
-											body = {}
-
-											const form = await request.formData()
-											const grouped = new Map<string, any[]>()
-											form.forEach((v, k) => {
-												const list = grouped.get(k)
-												if (list) list.push(v)
-												else grouped.set(k, [v])
-											})
-											for (const [key, value] of grouped) {
-												if (body[key]) continue
-
-												const finalValue = normalizeFormValue(value)
-
-												if (key.includes('.') || key.includes('['))
-													setNestedValue(body, key, finalValue)
-												else body[key] = finalValue
-											}
+											const form = parseFormData(
+												await request.formData()
+											)
+											body = form.body
+											structuredForm = form.structured
 
 											break
 										}
@@ -424,24 +256,11 @@ export const createDynamicHandler = (app: AnyElysia) => {
 									break
 
 								case 'multipart/form-data': {
-									body = {}
-
-									const form = await request.formData()
-									const grouped = new Map<string, any[]>()
-									form.forEach((v, k) => {
-										const list = grouped.get(k)
-										if (list) list.push(v)
-										else grouped.set(k, [v])
-									})
-									for (const [key, value] of grouped) {
-										if (body[key]) continue
-
-										const finalValue = normalizeFormValue(value)
-
-										if (key.includes('.') || key.includes('['))
-											setNestedValue(body, key, finalValue)
-										else body[key] = finalValue
-									}
+									const form = parseFormData(
+										await request.formData()
+									)
+									body = form.body
+									structuredForm = form.structured
 
 									break
 								}
@@ -450,6 +269,12 @@ export const createDynamicHandler = (app: AnyElysia) => {
 					}
 				}
 			}
+
+			// Without body validation the structured multipart
+			// interpretation is adopted as-is, otherwise validation decides
+			// which interpretation matches the schema
+			if (structuredForm !== undefined && !validator?.createBody?.())
+				body = structuredForm
 
 			context.route = route
 			context.body = body
@@ -621,15 +446,40 @@ export const createDynamicHandler = (app: AnyElysia) => {
 						) as any
 				}
 
-				if (validator.createBody?.()?.Check(body) === false)
-					throw new ValidationError('body', validator.body!, body)
-				else if (validator.body?.Decode) {
-						let decoded = validator.body.Decode(body) as any
-						if (decoded instanceof Promise)
-							decoded = await decoded
+				const bodyValidator = validator.createBody?.()
+				if (bodyValidator?.Check(body) === false) {
+					if (
+						structuredForm === undefined ||
+						bodyValidator.Check(structuredForm) === false
+					)
+						throw new ValidationError('body', validator.body!, body)
 
-						// Zod returns { value: ... } wrapper
-						context.body = decoded?.value ?? decoded
+					context.body = body = structuredForm
+				} else if (
+					structuredForm !== undefined &&
+					bodyValidator?.provider === 'standard'
+				) {
+					let result = bodyValidator.Check(body) as any
+					if (result instanceof Promise) result = await result
+
+					if (result?.issues) {
+						let structuredResult = bodyValidator.Check(
+							structuredForm
+						) as any
+						if (structuredResult instanceof Promise)
+							structuredResult = await structuredResult
+
+						if (!structuredResult?.issues)
+							context.body = body = structuredForm
+					}
+				}
+
+				if (validator.body?.Decode) {
+					let decoded = validator.body.Decode(body) as any
+					if (decoded instanceof Promise) decoded = await decoded
+
+					// Zod returns { value: ... } wrapper
+					context.body = decoded?.value ?? decoded
 				}
 			}
 

--- a/src/parse-form-data.ts
+++ b/src/parse-form-data.ts
@@ -1,0 +1,216 @@
+/**
+ * Alternative interpretation of a multipart body where single-value
+ * fields containing serialized JSON are deserialized
+ *
+ * Set on the request context by the form data parser so body validation
+ * can fall back to it when the schema expects structured data
+ */
+export const ELYSIA_STRUCTURED_FORM = Symbol('ElysiaStructuredForm')
+
+/**
+ * Matches array index notation in property paths
+ * Examples:
+ *   "users[0]"  → Group 1: "users", Group 2: "0"
+ *   "items[42]" → Group 1: "items", Group 2: "42"
+ *   "a[123]"    → Group 1: "a",     Group 2: "123"
+ *
+ * Does not match:
+ *   "users"     → no brackets
+ *   "users[]"   → no index
+ *   "users[ab]" → non-numeric index
+ */
+const ARRAY_INDEX_REGEX = /^(.+)\[(\d+)\]$/
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+const isDangerousKey = (key: string): boolean => {
+	if (DANGEROUS_KEYS.has(key)) return true
+
+	const match = key.match(ARRAY_INDEX_REGEX)
+	return match ? DANGEROUS_KEYS.has(match[1]) : false
+}
+
+const parseArrayKey = (key: string) => {
+	const match = key.match(ARRAY_INDEX_REGEX)
+	if (!match) return null
+
+	return {
+		name: match[1],
+		index: parseInt(match[2], 10)
+	}
+}
+
+const parseObjectString = (entry: unknown) => {
+	if (typeof entry !== 'string' || entry.charCodeAt(0) !== 123) return
+
+	try {
+		const parsed = JSON.parse(entry)
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+			return parsed
+	} catch {
+		return
+	}
+}
+
+const setNestedValue = (obj: Record<string, any>, path: string, value: any) => {
+	const keys = path.split('.')
+	const lastKey = keys.pop() as string
+
+	// Validate all keys upfront
+	if (isDangerousKey(lastKey) || keys.some(isDangerousKey)) return
+
+	let current = obj
+
+	// Traverse intermediate keys
+	for (const key of keys) {
+		const arrayInfo = parseArrayKey(key)
+
+		if (arrayInfo) {
+			// Initialize array if needed
+			if (!Array.isArray(current[arrayInfo.name]))
+				current[arrayInfo.name] = []
+
+			const existing = current[arrayInfo.name][arrayInfo.index]
+			const isFile =
+				typeof File !== 'undefined' && existing instanceof File
+
+			// Initialize object at index if needed
+			if (
+				!existing ||
+				typeof existing !== 'object' ||
+				Array.isArray(existing) ||
+				isFile
+			)
+				current[arrayInfo.name][arrayInfo.index] =
+					parseObjectString(existing) ?? {}
+
+			current = current[arrayInfo.name][arrayInfo.index]
+		} else {
+			// Initialize object property if needed
+			if (!current[key] || typeof current[key] !== 'object')
+				current[key] = {}
+
+			current = current[key]
+		}
+	}
+
+	// Set final value
+	const arrayInfo = parseArrayKey(lastKey)
+
+	if (arrayInfo) {
+		if (!Array.isArray(current[arrayInfo.name]))
+			current[arrayInfo.name] = []
+
+		current[arrayInfo.name][arrayInfo.index] = value
+	} else {
+		current[lastKey] = value
+	}
+}
+
+const normalizeFormValue = (value: unknown[]) => {
+	if (value.length === 1) return value[0]
+
+	const stringValue = value.find(
+		(entry): entry is string => typeof entry === 'string'
+	)
+	if (!stringValue) return value
+
+	if (typeof File === 'undefined') return value
+	const files = value.filter((entry): entry is File => entry instanceof File)
+	if (!files.length) return value
+
+	if (stringValue.charCodeAt(0) !== 123) return value
+
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(stringValue)
+	} catch {
+		return value
+	}
+
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
+		return value
+
+	if (!('file' in parsed) && files.length === 1)
+		(parsed as Record<string, unknown>).file = files[0]
+	else if (!('files' in parsed) && files.length > 1)
+		(parsed as Record<string, unknown>).files = files
+
+	return parsed
+}
+
+const parseStructuredValue = (value: string) => {
+	const code = value.charCodeAt(0)
+	// Only values that look like JSON objects ('{') or arrays ('[')
+	if (code !== 123 && code !== 91) return
+
+	try {
+		const parsed = JSON.parse(value)
+		if (parsed && typeof parsed === 'object') return parsed
+	} catch {
+		return
+	}
+}
+
+/**
+ * Normalize a FormData into a body object
+ *
+ * The returned `body` preserves every single-value field as submitted so
+ * schemas expecting text receive the original string. When at least one
+ * single-value field looks like serialized JSON, `structured` holds the
+ * variant where those fields are deserialized so schemas expecting
+ * objects or arrays keep accepting JSON-serialized fields
+ */
+export const parseFormData = (
+	// Structural type to accept both the DOM and Node FormData
+	form: { forEach(callbackfn: (value: any, key: string) => void): void }
+): {
+	body: Record<string, any>
+	structured: Record<string, any> | undefined
+} => {
+	const grouped = new Map<string, any[]>()
+	form.forEach((value, key) => {
+		const list = grouped.get(key)
+		if (list) list.push(value)
+		else grouped.set(key, [value])
+	})
+
+	let hasStructured = false
+	for (const [, value] of grouped) {
+		if (value.length !== 1 || typeof value[0] !== 'string') continue
+
+		const code = (value[0] as string).charCodeAt(0)
+		if (code === 123 || code === 91) {
+			hasStructured = true
+			break
+		}
+	}
+
+	const body: Record<string, any> = {}
+	const structured: Record<string, any> | undefined = hasStructured
+		? {}
+		: undefined
+
+	for (const [key, value] of grouped) {
+		if (body[key]) continue
+
+		const finalValue = normalizeFormValue(value)
+
+		let structuredValue = finalValue
+		if (
+			structured &&
+			value.length === 1 &&
+			typeof finalValue === 'string'
+		)
+			structuredValue = parseStructuredValue(finalValue) ?? finalValue
+
+		if (key.includes('.') || key.includes('[')) {
+			setNestedValue(body, key, finalValue)
+			if (structured) setNestedValue(structured, key, structuredValue)
+		} else {
+			body[key] = finalValue
+			if (structured) structured[key] = structuredValue
+		}
+	}
+
+	return { body, structured }
+}

--- a/test/units/parse-form-data.test.ts
+++ b/test/units/parse-form-data.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'bun:test'
+import {
+	ELYSIA_STRUCTURED_FORM,
+	parseFormData
+} from '../../src/parse-form-data'
+
+describe('parseFormData', () => {
+	it('export a unique symbol for the structured body alternate', () => {
+		expect(typeof ELYSIA_STRUCTURED_FORM).toBe('symbol')
+		expect(ELYSIA_STRUCTURED_FORM.description).toBe('ElysiaStructuredForm')
+	})
+
+	it('leave plain text fields as strings without a structured alternate', () => {
+		const form = new FormData()
+		form.append('name', 'Elysia')
+		form.append('count', '42')
+
+		const { body, structured } = parseFormData(form)
+
+		expect(structured).toBeUndefined()
+		expect(body).toEqual({
+			name: 'Elysia',
+			count: '42'
+		})
+	})
+
+	it('preserve JSON object text in body and expose parsed structured alternate', () => {
+		const raw = JSON.stringify({ theme: 'dark' })
+		const form = new FormData()
+		form.append('metadata', raw)
+
+		const { body, structured } = parseFormData(form)
+
+		expect(body.metadata).toBe(raw)
+		expect(structured).toEqual({ metadata: { theme: 'dark' } })
+	})
+
+	it('preserve JSON array text in body and expose parsed structured alternate', () => {
+		const raw = JSON.stringify([1, 2, 3])
+		const form = new FormData()
+		form.append('tags', raw)
+
+		const { body, structured } = parseFormData(form)
+
+		expect(body.tags).toBe(raw)
+		expect(structured).toEqual({ tags: [1, 2, 3] })
+	})
+
+	it('keep invalid JSON-looking text as a string in both interpretations', () => {
+		const raw = '{not-json'
+		const form = new FormData()
+		form.append('metadata', raw)
+
+		const { body, structured } = parseFormData(form)
+
+		expect(body.metadata).toBe(raw)
+		expect(structured).toEqual({ metadata: raw })
+	})
+
+	it('assemble nested values with dot notation on both interpretations', () => {
+		const raw = JSON.stringify({ nested: true })
+		const form = new FormData()
+		form.append('meta.info', raw)
+		form.append('meta.label', 'keep')
+
+		const { body, structured } = parseFormData(form)
+
+		expect(body).toEqual({
+			meta: {
+				info: raw,
+				label: 'keep'
+			}
+		})
+		expect(structured).toEqual({
+			meta: {
+				info: { nested: true },
+				label: 'keep'
+			}
+		})
+	})
+
+	it('assemble array index notation on both interpretations', () => {
+		const raw = JSON.stringify({ id: '1' })
+		const form = new FormData()
+		form.append('items[0]', raw)
+		form.append('items[1].name', 'second')
+
+		const { body, structured } = parseFormData(form)
+
+		expect(body.items[0]).toBe(raw)
+		expect(body.items[1]).toEqual({ name: 'second' })
+		expect(structured?.items[0]).toEqual({ id: '1' })
+		expect(structured?.items[1]).toEqual({ name: 'second' })
+	})
+
+	it('ignore dangerous keys that would pollute the prototype', () => {
+		const form = new FormData()
+		form.append('user.name', 'John')
+		form.append('__proto__.isAdmin', 'true')
+		form.append('constructor.prototype.bad', 'true')
+		form.append('user.__proto__.x', '1')
+
+		const { body, structured } = parseFormData(form)
+
+		expect(structured).toBeUndefined()
+		expect(body).toEqual({
+			user: { name: 'John' }
+		})
+		expect('isAdmin' in {}).toBe(false)
+	})
+
+	it('merge a single file into a JSON object sharing the same field name', () => {
+		const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+		const form = new FormData()
+		form.append('payload', JSON.stringify({ name: 'doc' }))
+		form.append('payload', file)
+
+		const { body, structured } = parseFormData(form)
+
+		// Multi-value merge happens in normalizeFormValue; no single-value
+		// JSON string remains, so no structured alternate is allocated
+		expect(structured).toBeUndefined()
+		expect(body.payload).toMatchObject({ name: 'doc' })
+		expect(body.payload.file).toBeInstanceOf(File)
+		expect(body.payload.file.name).toBe('hello.txt')
+	})
+
+	it('merge multiple files into files when JSON object shares the field name', () => {
+		const a = new File(['a'], 'a.txt')
+		const b = new File(['b'], 'b.txt')
+		const form = new FormData()
+		form.append('payload', JSON.stringify({ name: 'docs' }))
+		form.append('payload', a)
+		form.append('payload', b)
+
+		const { body } = parseFormData(form)
+
+		expect(body.payload).toMatchObject({ name: 'docs' })
+		expect(body.payload.files).toHaveLength(2)
+		expect(body.payload.files[0].name).toBe('a.txt')
+		expect(body.payload.files[1].name).toBe('b.txt')
+	})
+
+	it('keep multi-value non-JSON strings as an array', () => {
+		const form = new FormData()
+		form.append('tags', 'a')
+		form.append('tags', 'b')
+
+		const { body, structured } = parseFormData(form)
+
+		expect(structured).toBeUndefined()
+		expect(body.tags).toEqual(['a', 'b'])
+	})
+
+	it('keep a lone File without creating a structured alternate', () => {
+		const file = new File(['x'], 'x.txt')
+		const form = new FormData()
+		form.append('file', file)
+
+		const { body, structured } = parseFormData(form)
+
+		expect(structured).toBeUndefined()
+		expect(body.file).toBeInstanceOf(File)
+	})
+
+	it('do not treat JSON primitive text as structured', () => {
+		const form = new FormData()
+		form.append('flag', 'true')
+		form.append('num', '12')
+		form.append('nil', 'null')
+
+		const { body, structured } = parseFormData(form)
+
+		expect(structured).toBeUndefined()
+		expect(body).toEqual({
+			flag: 'true',
+			num: '12',
+			nil: 'null'
+		})
+	})
+
+	it('parse object string when seeding an intermediate array index', () => {
+		const seed = JSON.stringify({ keep: true })
+		const form = new FormData()
+		// First write a JSON object string at items[0], then nest under it
+		form.append('items[0]', seed)
+		form.append('items[0].extra', 'value')
+
+		const { body, structured } = parseFormData(form)
+
+		// Intermediate JSON text at items[0] is re-parsed when nesting under it
+		expect(body.items[0]).toEqual({
+			keep: true,
+			extra: 'value'
+		})
+		expect(structured?.items[0]).toEqual({
+			keep: true,
+			extra: 'value'
+		})
+	})
+})

--- a/test/validator/multipart.test.ts
+++ b/test/validator/multipart.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it } from 'bun:test'
+import { z } from 'zod'
+import { Elysia, t } from '../../src'
+
+const upload = (form: FormData) =>
+	new Request('http://localhost/upload', {
+		method: 'POST',
+		body: form
+	})
+
+describe('Multipart string field', () => {
+	it('keep JSON object text as string when field is t.String()', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => body.metadata, {
+			body: t.Object({
+				file: t.File(),
+				metadata: t.String()
+			}),
+			type: 'multipart'
+		})
+
+		const metadata = JSON.stringify({ theme: 'dark' })
+
+		const form = new FormData()
+		form.append('file', new File(['example'], 'example.txt'))
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(metadata)
+	})
+
+	it('keep JSON array text as string when field is t.String()', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => body.metadata, {
+			body: t.Object({
+				metadata: t.String()
+			}),
+			type: 'multipart'
+		})
+
+		const metadata = JSON.stringify([1, 2, 3])
+
+		const form = new FormData()
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(metadata)
+	})
+
+	it('keep JSON text as string when field is t.Optional(t.String())', async () => {
+		const app = new Elysia().post(
+			'/upload',
+			({ body }) => body.metadata ?? '',
+			{
+				body: t.Object({
+					metadata: t.Optional(t.String())
+				}),
+				type: 'multipart'
+			}
+		)
+
+		const metadata = JSON.stringify({ theme: 'dark' })
+
+		const form = new FormData()
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(metadata)
+	})
+
+	it('keep JSON text as string in nested field with dot notation', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => body.meta.info, {
+			body: t.Object({
+				meta: t.Object({
+					info: t.String()
+				})
+			}),
+			type: 'multipart'
+		})
+
+		const info = JSON.stringify({ nested: true })
+
+		const form = new FormData()
+		form.append('meta.info', info)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(info)
+	})
+
+	it('keep JSON text as string when union accepts both string and object', async () => {
+		const app = new Elysia().post(
+			'/upload',
+			({ body }) => ({
+				kind: typeof body.metadata,
+				value: body.metadata
+			}),
+			{
+				body: t.Object({
+					metadata: t.Union([
+						t.String(),
+						t.Object({ theme: t.String() })
+					])
+				}),
+				type: 'multipart'
+			}
+		)
+
+		const metadata = JSON.stringify({ theme: 'dark' })
+
+		const form = new FormData()
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			kind: 'string',
+			value: metadata
+		})
+	})
+
+	it('preserve string field while structured field is parsed in the same body', async () => {
+		const app = new Elysia().post(
+			'/upload',
+			({ body }) => ({
+				metadata: body.metadata,
+				theme: body.settings.theme
+			}),
+			{
+				body: t.Object({
+					file: t.File(),
+					metadata: t.String(),
+					settings: t.Object({
+						theme: t.String()
+					})
+				}),
+				type: 'multipart'
+			}
+		)
+
+		const metadata = JSON.stringify({ keep: 'raw' })
+
+		const form = new FormData()
+		form.append('file', new File(['example'], 'example.txt'))
+		form.append('metadata', metadata)
+		form.append('settings', JSON.stringify({ theme: 'dark' }))
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			metadata,
+			theme: 'dark'
+		})
+	})
+
+	it('keep JSON text as string for standard schema string field', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => body.metadata, {
+			body: z.object({
+				metadata: z.string()
+			}),
+			type: 'multipart'
+		})
+
+		const metadata = JSON.stringify({ theme: 'dark' })
+
+		const form = new FormData()
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(metadata)
+	})
+
+	it('keep JSON text as string for optional standard schema string field', async () => {
+		const app = new Elysia().post(
+			'/upload',
+			({ body }) => body.note ?? '',
+			{
+				body: z.object({
+					note: z.string().optional()
+				}),
+				type: 'multipart'
+			}
+		)
+
+		const note = JSON.stringify(['a', 'b'])
+
+		const form = new FormData()
+		form.append('note', note)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(note)
+	})
+
+	it('keep JSON text as string when field is t.String() in dynamic mode', async () => {
+		const app = new Elysia({ aot: false }).post(
+			'/upload',
+			({ body }) => body.metadata,
+			{
+				body: t.Object({
+					metadata: t.String()
+				})
+			}
+		)
+
+		const metadata = JSON.stringify({ theme: 'dark' })
+
+		const form = new FormData()
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(metadata)
+	})
+
+	it('keep JSON text as string in nested field in dynamic mode', async () => {
+		const app = new Elysia({ aot: false }).post(
+			'/upload',
+			({ body }) => body.meta.info,
+			{
+				body: t.Object({
+					meta: t.Object({
+						info: t.String()
+					})
+				})
+			}
+		)
+
+		const info = JSON.stringify({ nested: true })
+
+		const form = new FormData()
+		form.append('meta.info', info)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.text()).toBe(info)
+	})
+
+	it('reject mismatched structured field and identify that field', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => body, {
+			body: t.Object({
+				metadata: t.String(),
+				settings: t.Object({
+					theme: t.String()
+				})
+			}),
+			type: 'multipart'
+		})
+
+		const form = new FormData()
+		form.append('metadata', JSON.stringify({ keep: 'raw' }))
+		form.append('settings', JSON.stringify({ wrong: 1 }))
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(422)
+
+		const error = (await response.json()) as {
+			type: string
+			property: string
+		}
+		expect(error.type).toBe('validation')
+		expect(error.property).toContain('settings')
+	})
+
+	it('reject mismatched structured field for standard schema and identify that field', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => body, {
+			body: z.object({
+				metadata: z.string(),
+				settings: z.object({
+					theme: z.string()
+				})
+			}),
+			type: 'multipart'
+		})
+
+		const form = new FormData()
+		form.append('metadata', JSON.stringify({ keep: 'raw' }))
+		form.append('settings', JSON.stringify({ wrong: 1 }))
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(422)
+
+		const error = (await response.json()) as {
+			type: string
+			property: string
+		}
+		expect(error.type).toBe('validation')
+		expect(error.property).toContain('settings')
+	})
+
+	it('adopt structured interpretation when the route has no body schema', async () => {
+		const app = new Elysia().post('/upload', ({ body }) => ({
+			kind: typeof (body as any).metadata,
+			value: (body as any).metadata
+		}))
+
+		const form = new FormData()
+		form.append('metadata', JSON.stringify({ theme: 'dark' }))
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			kind: 'object',
+			value: { theme: 'dark' }
+		})
+	})
+
+	it('preserve JSON text as string when a sibling field has a default', async () => {
+		const app = new Elysia().post(
+			'/upload',
+			({ body }) => ({
+				name: body.name,
+				metadata: body.metadata
+			}),
+			{
+				body: t.Object({
+					name: t.String({ default: 'anon' }),
+					metadata: t.String()
+				}),
+				type: 'multipart'
+			}
+		)
+
+		const metadata = JSON.stringify({ a: 1 })
+		const form = new FormData()
+		form.append('metadata', metadata)
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			name: 'anon',
+			metadata
+		})
+	})
+
+	it('parse structured field when a sibling field has a default', async () => {
+		const app = new Elysia().post(
+			'/upload',
+			({ body }) => ({
+				name: body.name,
+				settings: body.settings
+			}),
+			{
+				body: t.Object({
+					name: t.String({ default: 'anon' }),
+					settings: t.Object({
+						theme: t.String()
+					})
+				}),
+				type: 'multipart'
+			}
+		)
+
+		const form = new FormData()
+		form.append('settings', JSON.stringify({ theme: 'dark' }))
+
+		const response = await app.handle(upload(form))
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			name: 'anon',
+			settings: { theme: 'dark' }
+		})
+	})
+})


### PR DESCRIPTION
…ma expects text

## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

Fixes #1946

Regression introduced by the multipart normalization in #1697.

## Description

### Bug

Since 1.4.23, any single-value multipart field whose text starts with `{` or `[` is run through
`JSON.parse` before validation. A route declaring that field as a string receives an object or an
array instead and fails with 422:

```ts
const app = new Elysia().post('/upload', ({ body }) => body.metadata, {
	body: t.Object({ file: t.File(), metadata: t.String() }),
	type: 'multipart'
})

const form = new FormData()
form.append('file', new File(['example'], 'example.txt'))
form.append('metadata', JSON.stringify({ theme: 'dark' }))

// 1.4.22: 200, metadata is the original string
// 1.4.23+: 422, handler never runs
```

The eager parse lives in two places: the inlined form-data program generated by the web-standard
adapter and `normalizeFormValue` in the dynamic handler.

### Why not simply remove the JSON.parse

The eager parse is what lets plain `t.Object`/`z.object` fields accept JSON-serialized text, so
removing it would regress that behavior and its tests. Making the parser schema-aware is not
possible either: Standard Schema validators expose no introspection API, so the parser cannot
know which fields expect strings.

### Fix

Multipart parsing now produces the raw body (every single-value field kept exactly as submitted)
and, when at least one field looks like serialized JSON, a structured alternate where those
fields are deserialized. Validation decides which interpretation matches the schema:

1. the raw body is checked first; if it passes, the handler receives the original strings
2. if it fails, the structured alternate is checked (cleaner and defaults reapplied) and adopted
   when it passes; otherwise the request fails with the usual 422
3. routes without a body schema (or with `noValidate`) adopt the structured alternate, keeping
   today's behavior

This works for TypeBox and Standard Schema, in both AOT and dynamic mode. A 422 for a mismatched
structured field now reports the field that actually failed instead of blaming a sibling string
field that was wrongly deserialized.

| multipart field | declared as | before | after |
|---|---|---|---|
| `'{"theme":"dark"}'` | `t.String()` / `z.string()` / optional / nested / union with string | 422 | 200, original text |
| `'[1,2,3]'` | `t.String()` | 422 | 200, original text |
| `'{"theme":"dark"}'` | `t.Object(...)` / `z.object(...)` / `t.ObjectString(...)` | 200, parsed | 200, parsed (unchanged) |
| JSON text | no body schema | parsed | parsed (unchanged) |
| invalid shape for structured field | `t.Object(...)` | 422 blaming the wrong field | 422 pointing at that field |

### Changes

- `src/parse-form-data.ts` (new): shared implementation of multipart body construction. The
  nested and dot-notation helpers (`setNestedValue`, `parseArrayKey`, dangerous-key checks,
  file+JSON merge) are moved verbatim from `dynamic-handle.ts`. The new logic is the
  dual-interpretation assembly, around 50 lines. The structured alternate is only allocated
  when a JSON-looking field exists.
- `src/adapter/web-standard/index.ts`: the inlined codegen string (around 80 lines) is replaced
  by a call to the injected `parseFormData`, following the existing `parseQuery` pattern. Bun
  inherits it.
- `src/compose.ts`: injects `parseFormData` and the `ELYSIA_STRUCTURED_FORM` context symbol
  (same mechanism as `ELYSIA_REQUEST_ID`); adds the validation fallback to the TypeBox and
  Standard Schema branches, including the `hasDefault` path.
- `src/dynamic-handle.ts`: the three duplicated multipart loops collapse into the shared helper,
  with the same validation fallback. Standard Schema needs its own branch since `Check` returns
  a result object rather than `false`.

The diff reads larger than it is: roughly 140 lines are new logic, the rest is moved code and
the deleted inline codegen.

### Tests

- `test/units/parse-form-data.test.ts`: 14 cases covering the helper in isolation (raw vs
  structured output, dot and array notation, prototype-pollution keys, file+JSON merges,
  invalid JSON, primitives)
- `test/validator/multipart.test.ts`: 15 end-to-end cases across TypeBox and zod, AOT and
  dynamic, including optional, nested and union fields, mixed string+structured bodies,
  defaults, no-schema routes, and 422s that must identify the mismatched structured field
- full suite: 1554 pass / 0 fail, `tsc` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multipart form-data handling for nested fields, arrays, JSON values, and file uploads.
  * Supports structured interpretation of multipart payloads when compatible with the route schema.
  * Preserves JSON-looking text as strings when fields are declared as string values.
  * Added safer handling for nested form keys and invalid JSON input.

* **Bug Fixes**
  * Improved multipart validation and fallback behavior across optimized and dynamic request handling.
  * Prevented unsafe form-data keys from affecting object structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->