### PR TITLE
fix: detect crypto with typeof, not optional chaining

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -688,7 +688,7 @@ export const signCookie = async (val: string, secret: string | null) => {
 }
 
 const constantTimeEqual =
-	typeof crypto?.timingSafeEqual === 'function'
+	typeof crypto !== 'undefined' && typeof crypto.timingSafeEqual === 'function'
 		? (a: string, b: string) => {
 				// Compare as UTF-8 bytes; timingSafeEqual requires equal length
 				const ab = Buffer.from(a, 'utf8')


### PR DESCRIPTION
Disclaimer: AI wrote this, but I vetted it

## Summary

`constantTimeEqual` is initialized at module load with:

```ts
typeof crypto?.timingSafeEqual === 'function'
```

`typeof` does **not** protect that. Optional chaining still evaluates the identifier, so a missing `crypto` global throws `ReferenceError` instead of taking the string-compare fallback.

`randomId` in the same file already does this correctly:

```ts
typeof crypto === 'undefined' || isCloudflareWorker()
```

This change uses that same `typeof crypto` check:

```ts
typeof crypto !== 'undefined' && typeof crypto.timingSafeEqual === 'function'
```

## What is not a problem

- `crypto.subtle` in `signCookie` only runs when signing a cookie.
- `crypto.randomUUID()` only runs in the `randomId` branch after `typeof crypto === 'undefined'` has already passed.

Importing Elysia (and thus `utils.ts`) no longer requires a `crypto` global.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie comparison compatibility in environments where cryptographic browser features are unavailable.
  * Prevented errors caused by missing global cryptography support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->