### PR TITLE
fix(ws): support parse 'none' and execute custom parsers on raw message (#1911)

### DIFF
--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -209,11 +209,24 @@ export class ElysiaWS<Context = unknown, Route extends RouteSchema = {}>
 }
 
 export const createWSMessageParser = (
-	parse: MaybeArray<WSParseHandler<any>>
+	parse: MaybeArray<WSParseHandler<any>> | 'none' | undefined
 ) => {
+	if (parse === 'none')
+		return function parseMessage(ws: ServerWebSocket<any>, message: any) {
+			return message
+		}
+
 	const parsers = typeof parse === 'function' ? [parse] : parse
 
 	return async function parseMessage(ws: ServerWebSocket<any>, message: any) {
+		if (parsers)
+			for (let i = 0; i < parsers.length; i++) {
+				let temp = parsers[i](ws as any, message)
+				if (temp instanceof Promise) temp = await temp
+
+				if (temp !== undefined) return temp
+			}
+
 		if (typeof message === 'string') {
 			const start = message?.charCodeAt(0)
 
@@ -228,14 +241,6 @@ export const createWSMessageParser = (
 			else if (message === 'false') message = false
 			else if (message === 'null') message = null
 		}
-
-		if (parsers)
-			for (let i = 0; i < parsers.length; i++) {
-				let temp = parsers[i](ws as any, message)
-				if (temp instanceof Promise) temp = await temp
-
-				if (temp !== undefined) return temp
-			}
 
 		return message
 	}

--- a/src/ws/index.ts
+++ b/src/ws/index.ts
@@ -219,13 +219,16 @@ export const createWSMessageParser = (
 	const parsers = typeof parse === 'function' ? [parse] : parse
 
 	return async function parseMessage(ws: ServerWebSocket<any>, message: any) {
-		if (parsers)
+		if (parsers) {
+			const elysiaWS = new ElysiaWS(ws as any, ws.data as any)
+
 			for (let i = 0; i < parsers.length; i++) {
-				let temp = parsers[i](ws as any, message)
+				let temp = parsers[i](elysiaWS as any, message)
 				if (temp instanceof Promise) temp = await temp
 
 				if (temp !== undefined) return temp
 			}
+		}
 
 		if (typeof message === 'string') {
 			const start = message?.charCodeAt(0)

--- a/src/ws/types.ts
+++ b/src/ws/types.ts
@@ -135,7 +135,7 @@ export type WSLocalHook<
 	 * Headers to register to websocket before `upgrade`
 	 */
 	upgrade?: Record<string, unknown> | ((context: Context) => unknown)
-	parse?: MaybeArray<WSParseHandler<Schema>>
+	parse?: MaybeArray<WSParseHandler<Schema>> | 'none'
 
 	/**
 	 * Transform context's value

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -609,4 +609,61 @@ describe('WebSocket message', () => {
         await wsClosed(ws)
         app.stop()
     })
+
+    it('should not parse message when parse is none', async () => {
+        const app = new Elysia()
+            .ws('/ws', {
+                parse: 'none',
+                message(ws, message) {
+                    ws.send(typeof message + ' ' + message)
+                }
+            })
+            .listen(0)
+
+        const ws = newWebsocket(app.server!)
+
+        await wsOpen(ws)
+
+        const message1 = wsMessage(ws)
+        ws.send('["ping"]')
+        const res1 = await message1
+
+        expect(res1.data).toBe('string ["ping"]')
+
+        const message2 = wsMessage(ws)
+        ws.send('{"hello":"world"}')
+        const res2 = await message2
+
+        expect(res2.data).toBe('string {"hello":"world"}')
+
+        await wsClosed(ws)
+        app.stop()
+    })
+
+    it('should pass raw message to custom parse handler', async () => {
+        const app = new Elysia()
+            .ws('/ws', {
+                parse(ws, raw) {
+                    if (typeof raw === 'string' && raw.startsWith('PREFIX:'))
+                        return raw.slice(7)
+                },
+                message(ws, message) {
+                    ws.send(typeof message + ' ' + message)
+                }
+            })
+            .listen(0)
+
+        const ws = newWebsocket(app.server!)
+
+        await wsOpen(ws)
+
+        const message = wsMessage(ws)
+        ws.send('PREFIX:["ping"]')
+        const res = await message
+
+        expect(res.data).toBe('string ["ping"]')
+
+        await wsClosed(ws)
+        app.stop()
+    })
 })

--- a/test/ws/message.test.ts
+++ b/test/ws/message.test.ts
@@ -646,6 +646,8 @@ describe('WebSocket message', () => {
                 parse(ws, raw) {
                     if (typeof raw === 'string' && raw.startsWith('PREFIX:'))
                         return raw.slice(7)
+                    if (typeof raw === 'string' && raw === '["ping"]')
+                        return raw
                 },
                 message(ws, message) {
                     ws.send(typeof message + ' ' + message)
@@ -657,11 +659,17 @@ describe('WebSocket message', () => {
 
         await wsOpen(ws)
 
-        const message = wsMessage(ws)
+        const message1 = wsMessage(ws)
         ws.send('PREFIX:["ping"]')
-        const res = await message
+        const res1 = await message1
 
-        expect(res.data).toBe('string ["ping"]')
+        expect(res1.data).toBe('string ["ping"]')
+
+        const message2 = wsMessage(ws)
+        ws.send('["ping"]')
+        const res2 = await message2
+
+        expect(res2.data).toBe('string ["ping"]')
 
         await wsClosed(ws)
         app.stop()


### PR DESCRIPTION
## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

Fixes #1911

## Description

When WebSocket text frames are received, Elysia was unconditionally attempting `JSON.parse` before passing the message to custom `parse` hooks or the main `message` handler. This caused text frames containing JSON-like strings (such as `["ping"]`) to be unexpectedly converted into objects/arrays instead of remaining raw strings.

### Changes:
1. Added support for `parse: 'none'` in WebSocket routes (matching HTTP routes) to allow completely disabling auto-parsing.
2. Executed custom `parse` handler(s) before fallback `JSON.parse`, allowing custom parsers to receive the original unparsed string.
3. Updated `WSLocalHook.parse` type definition to include `'none'`.
4. Added unit tests for `parse: 'none'` and custom parse handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to preserve WebSocket messages without automatic parsing.
  * Added support for custom message parsers that can transform raw messages before delivery.
  * Custom parsers can override built-in JSON, numeric, boolean, and null conversion.
  * Parsers can receive the WebSocket connection context and return transformed values.

* **Bug Fixes**
  * JSON-looking WebSocket payloads can now remain available as plain strings when desired.
  * Unprefixed JSON arrays are handled consistently by custom parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->