### PR TITLE
perf(cookie): memoize Cookie instances in createCookieJar (#1936)

### DIFF
--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -352,20 +352,24 @@ export const createCookieJar = (
 ): Record<string, Cookie<unknown>> => {
 	if (!set.cookie) set.cookie = Object.create(null)
 
+	const cache: Record<string, Cookie<unknown>> = Object.create(null)
+
 	return new Proxy(store, {
 		get(_, key: string) {
+			if (key in cache) return cache[key]
+
 			if (key in store)
-				return new Cookie(
+				return (cache[key] = new Cookie(
 					key,
 					set.cookie as Record<string, ElysiaCookie>,
 					Object.assign({}, initial ?? {}, store[key])
-				)
+				))
 
-			return new Cookie(
+			return (cache[key] = new Cookie(
 				key,
 				set.cookie as Record<string, ElysiaCookie>,
 				Object.assign({}, initial)
-			)
+			))
 		}
 	}) as Record<string, Cookie<unknown>>
 }

--- a/test/cookie/explicit.test.ts
+++ b/test/cookie/explicit.test.ts
@@ -125,5 +125,15 @@ describe('Explicit Cookie', () => {
 		const second = cookie.name
 
 		expect(first).toBe(second)
+
+		const set: Context['set'] = {
+			cookie: {},
+			headers: {}
+		}
+		const store = Object.create(null) as Record<string, any>
+		store.name = { value: 'himari' }
+		const parsed = createCookieJar(set, store)
+
+		expect(parsed.name).toBe(parsed.name)
 	})
 })

--- a/test/cookie/explicit.test.ts
+++ b/test/cookie/explicit.test.ts
@@ -118,4 +118,12 @@ describe('Explicit Cookie', () => {
 			Date.now()
 		)
 	})
+
+	it('memoize cookie instance across multiple accesses', () => {
+		const { cookie } = create()
+		const first = cookie.name
+		const second = cookie.name
+
+		expect(first).toBe(second)
+	})
 })


### PR DESCRIPTION
## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

Fixes #1936

## Description

The `createCookieJar` proxy previously allocated a fresh `Cookie` object and ran `Object.assign` on every single property access (e.g. `cookie.token`). When reading cookies multiple times across middleware, guards, and handlers, this caused redundant memory allocations ($O(N)$) and object identity loss.

### Changes:
1. Added per-jar `cache` in `createCookieJar` to memoize `Cookie` instances by key, ensuring $O(1)$ access and reusing instances across the request lifecycle.
2. Added unit test verifying `Cookie` instance memoization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated access to the same cookie now returns a consistent cookie instance.
  * This consistency applies to both newly created cookies and cookies loaded from existing storage.
  * Cookie defaults and shared storage continue to work as expected.

* **Tests**
  * Expanded coverage to verify cookie instance reuse across repeated accesses and stored cookies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->