### PR TITLE
fix: keep TypeBox and exact-mirror statically visible for serverless tracing

### DIFF
--- a/src/type/compat.ts
+++ b/src/type/compat.ts
@@ -102,3 +102,25 @@ export function setupTypebox(options?: {
 		Check
 	})
 }
+
+/**
+ * Never called — it exists purely so module-graph tracers can see the
+ * `typebox` and `exact-mirror` specifiers.
+ *
+ * Both packages are loaded through
+ * `process.getBuiltinModule('module').createRequire(...)` in `./typebox-type`,
+ * `./typebox-value` and `./validator/exact-mirror`, which keeps them off the
+ * startup path. Every static analyser treats that call as opaque, so nothing
+ * links either package into the module graph: on Vercel `@vercel/nft` never
+ * copies them into the serverless bundle and the deploy dies with
+ * `Cannot find module 'typebox/type'` (#1973).
+ *
+ * Naming them in a never-awaited `import()` is enough for tracers to follow.
+ * It lives here, unused and unreferenced, so that bundlers still tree-shake it
+ * out of application bundles and the AOT `compat` stub drops it wholesale —
+ * neither TypeBox nor exact-mirror is pulled into a sealed build. `typebox/type`
+ * stands in for the whole package; tracers copy it entry by entry
+ */
+// I have nothing but my burger and I want nothing more
+export const traceOptionalDependencies = () =>
+	Promise.all([import('typebox/type'), import('exact-mirror')])

--- a/test/regression/dependency-tracing.test.ts
+++ b/test/regression/dependency-tracing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+/**
+ * Serverless platforms decide what to upload by statically walking the module
+ * graph — Vercel runs `@vercel/nft` over the built entry and copies only what
+ * it finds. TypeBox and exact-mirror are reached through
+ * `getBuiltinModule('module').createRequire(...)`, which every static analyser
+ * treats as opaque, so a build with no literal specifier anywhere ships without
+ * them and dies at runtime with `Cannot find module 'typebox/type'` (#1973).
+ *
+ * These assertions are about the *published* files, so they read `dist`
+ * directly. Run `bun run build` first.
+ */
+
+const dist = (file: string) => resolve(import.meta.dir, '../../dist', file)
+
+const read = async (file: string) => {
+	try {
+		return await readFile(dist(file), 'utf8')
+	} catch {
+		throw new Error(
+			`${file} is missing — run \`bun run build\` before this test`
+		)
+	}
+}
+
+describe('serverless dependency tracing', () => {
+	// Both module formats get deployed: Vercel's Node runtime resolves the CJS
+	// entry, other platforms the ESM one. A specifier that only survives in one
+	// of them leaves the other broken.
+	for (const [format, file] of [
+		['ESM', 'type/compat.mjs'],
+		['CJS', 'type/compat.js']
+	] as const)
+		it(`keeps typebox and exact-mirror statically visible in ${format} output`, async () => {
+			const code = await read(file)
+
+			// A bare mention in a comment would satisfy a naive `includes`, so
+			// require the specifier inside an actual import call
+			expect(code).toMatch(/import\(\s*["']typebox\/type["']\s*\)/)
+			expect(code).toMatch(/import\(\s*["']exact-mirror["']\s*\)/)
+		})
+
+	// The anchor only survives bundling if nothing references it: an unused
+	// export is dropped by application bundlers and by the AOT `compat` stub,
+	// which is what keeps sealed bundles TypeBox-free and the bundle-size
+	// budgets intact. Referencing it from live code silently undoes that.
+	it('leaves the anchor uncalled so bundlers can drop it', async () => {
+		const code = await read('type/compat.mjs')
+		const name = 'traceOptionalDependencies'
+
+		expect(code).toContain(name)
+		// Declared and exported, never invoked — a call site would make it
+		// reachable and pull TypeBox back into every bundle
+		expect(code).not.toMatch(
+			new RegExp(`${name}\\s*\\(`.replace(/\$/g, '\\$'))
+		)
+	})
+})


### PR DESCRIPTION
## Problem

Deploying Elysia `2.0.0-beta.6` to Vercel fails at runtime with `Cannot find module 'typebox/type'`.

## Root cause

TypeBox and `exact-mirror` are loaded lazily through a synchronous handle, so they stay off the startup path:

```ts
const req =
    meta.require ??
    (globalThis as any).process?.getBuiltinModule?.('module')?.createRequire(import.meta.url)

return { type: req('typebox/type'), system: req('typebox/system') }
```

Serverless platforms decide what to upload by statically walking the module graph — Vercel runs `@vercel/nft` over the built entry and copies only what it finds. Those specifiers never appear in a form any static analyser understands, so **neither package was copied into the lambda**, and the deploy died on first use.

Reproduced by running `@vercel/nft` over `dist/index.js`: **105 files traced, 0 of them TypeBox**, while `deuri` (a plain static import) traced fine. `exact-mirror` was missing for the same reason.

Measuring which constructs defeat the analysis:

| loader form | typebox files traced |
| --- | --- |
| static `import` (control) | 369 |
| `??` chain → `createRequire` | **0** |
| `process.getBuiltinModule('module').createRequire` | **0** |
| `createRequire` imported from `node:module` | 369 |
| lazy `import()` | 369 |

Both constructs used by the current loader are independently opaque — the `??` chain fails even with a proper `node:module` import.

## Fix

A single **unused export** in `src/type/compat.ts` naming the specifiers in a never-awaited `import()`.

Placement was the whole problem. Three of this repo's own invariants ruled out the obvious alternatives:

- **not `node:module`** — `test/cloudflare/wrangler.jsonc` has no `nodejs_compat`, so a static `node:module` import would break Workers.
- **not in `typebox-value.ts`** — measured leaking `value`/`schema`/`compile` into sealed bundles, breaking the test named *"omits TypeBox value, compile, and setup modules"* (gz 50000 → 51697).
- **not referenced from live code** — hanging it off the thrown `Error` made it reachable and blew the schema budget to 442775/409600.

`compat.ts` is stubbed wholesale by the AOT plugin (so sealed builds keep their TypeBox-free guarantee), is reachable from the entry (so tracers see it), and has no live-parity test. Being unused and uncalled is what lets application bundlers tree-shake it.

## Verification

| check | result |
| --- | --- |
| nft trace, CJS + ESM | 0 → **369** TypeBox files; `exact-mirror` also traced |
| `bun test test` | 25 failures vs **26 on the untouched baseline — zero new** |
| `test:types` / `test:imports` | pass |
| `test:bundle` | core 176057/256000, schema 230289/409600 (+134 / +456 B, under the 1024 B drift gate) |
| AOT + parity suites | 75/75 pass |
| node CJS + ESM | pass |

Adds `test/regression/dependency-tracing.test.ts`, which fails on all three assertions with the fix reverted.

**Not run:** `test:cf` (needs wrangler + network). The change adds no `node:module` import and is an unused export, so it should be inert there, but I have not verified it.

The baseline failures are pre-existing on this branch (error-masking, validation-detail, plus a flaky `differential:…@listen` group that gave 0/0/1 across three identical runs). Failures were compared as named lists, not counts.

## Note: `ERR_REQUIRE_ESM` is a separate problem

The issue also reports `ERR_REQUIRE_ESM`. **This PR does not fix that.** Reproduced with `node --no-experimental-require-module`, it fails on **`deuri`** first, before ever reaching TypeBox. `deuri`, `typebox` and `exact-mirror` are all ESM-only, so the CJS build cannot run on Node < 22.12 regardless of tracing. That half needs a documented Node floor rather than a code change — happy to open a separate issue if useful.

Closes #1973

I have nothing but my burger and I want nothing more
