### PR TITLE
fix(error): prevent onError hook from mutating the shared NotFoundError singleton (resolves #1969)

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2697,8 +2697,8 @@ export const composeErrorHandler = (app: AnyElysia) => {
 					afterResponse() +
 					`return mapResponse(_r,set${adapter.mapResponseContext})}` +
 					`if(_r instanceof ElysiaCustomStatusResponse){` +
-					`error.status=error.code\n` +
-					`error.message=error.response` +
+					`set.status=_r.code\n` +
+					`_r=_r.response` +
 					`}` +
 					`if(set.status===200||!set.status)set.status=error.status\n`
 


### PR DESCRIPTION
Resolves #1969

### Description
When returning an `ElysiaCustomStatusResponse` from an `onError` hook (such as `status(500, "Error")`), the framework was mistakenly mutating the global singleton `NotFoundError` instance if the original error was a 404. This caused all subsequent 404 requests to return as 500 errors.

### Fix
Updated `src/compose.ts` so that when `_r instanceof ElysiaCustomStatusResponse` evaluates to true in the generated error handler, it sets `set.status = _r.code` and safely unpacks the response to `_r = _r.response`. It no longer mutates the `error.status` or `error.message` of the caught Error object directly.

I have nothing but my burger and I want nothing more


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for custom status responses.
  * Ensured returned status codes and response payloads are correctly preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->