### PR TITLE
:wrench: fix: merge guard detail into routes that declare a hook

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -907,9 +907,28 @@ export function mergeHook(
 	if (!a.params && b.params) a.params = b.params
 	if (!a.query && b.query) a.query = b.query
 	if (!a.cookie && b.cookie) a.cookie = b.cookie
+	// `tags` is shorthand for `detail.tags`
+	if (!(a as any).tags && (b as any).tags) (a as any).tags = (b as any).tags
 	if (!a.response && b.response) a.response = b.response
 	else if (a.response && b.response)
 		a.response = mergeResponse(b.response, a.response) as any
+
+	// `detail` is not an event, so it is absent from `eventProperties` and
+	// never reached this merge (#1972). `b` is memoized across sibling routes,
+	// so clone before adopting. Arrays override rather than concatenate
+	const aDetail = (a as any).detail
+	const bDetail = (b as any).detail
+	if (bDetail)
+		if (!aDetail) (a as any).detail = clonePlainDeep(bDetail)
+		else {
+			const detail = clonePlainDeep(bDetail)
+
+			// `clonePlainDeep` returns non-plain leaves, TypeBox models
+			// among them, by reference — guard them before `mergeDeep`
+			// writes the route's keys into a shared object
+			guardNonPlainLeaves(detail, aDetail)
+			;(a as any).detail = mergeDeep(detail, aDetail)
+		}
 
 	if (a.parse || b.parse) a.parse = merge(a.parse, b.parse, reverse)
 

--- a/test/core/guard-detail.test.ts
+++ b/test/core/guard-detail.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'bun:test'
+import { Elysia, t } from '../../src'
+
+// #1972: a guard's `detail` reached routes with no hook of their own, but
+// vanished for routes that declared one. The damage shows up in the generated
+// OpenAPI document, not in a response, so these tests read `app.routes`
+const hooksOf = (app: Elysia<any, any>, path: string, method: string) =>
+	(app.routes.find((r) => r.path === path && r.method === method) as any)
+		?.hooks
+
+const detailOf = (app: Elysia<any, any>, path: string, method: string) =>
+	hooksOf(app, path, method)?.detail
+
+describe('guard detail', () => {
+	it('applies guard detail to a route that declares its own hook', async () => {
+		const app = new Elysia().guard({ detail: { tags: ['Admin'] } }, (app) =>
+			app
+				.get('/plain', () => 'ok')
+				.post(
+					'/with-body',
+					{ body: t.Object({ name: t.String() }) },
+					({ body }) => body
+				)
+		)
+
+		await app.modules
+
+		// the route without a hook was never broken — it is the control
+		expect(detailOf(app, '/plain', 'GET')?.tags).toEqual(['Admin'])
+		expect(detailOf(app, '/with-body', 'POST')?.tags).toEqual(['Admin'])
+	})
+
+	it('keeps the guard detail when the route declares detail of its own', async () => {
+		const app = new Elysia().guard({ detail: { tags: ['Admin'] } }, (app) =>
+			app.post(
+				'/both',
+				{
+					body: t.Object({ name: t.String() }),
+					detail: { summary: 'Create a thing' }
+				},
+				({ body }) => body
+			)
+		)
+
+		await app.modules
+
+		const detail = detailOf(app, '/both', 'POST')
+
+		// neither side may erase the other
+		expect(detail?.tags).toEqual(['Admin'])
+		expect(detail?.summary).toBe('Create a thing')
+	})
+
+	it('lets the route override a scalar the guard also set', async () => {
+		const app = new Elysia().guard(
+			{ detail: { tags: ['Admin'], summary: 'guard summary' } },
+			(app) =>
+				app.post(
+					'/override',
+					{
+						body: t.Object({ name: t.String() }),
+						detail: { summary: 'route summary' }
+					},
+					({ body }) => body
+				)
+		)
+
+		await app.modules
+
+		const detail = detailOf(app, '/override', 'POST')
+
+		// the more specific declaration wins on a conflict...
+		expect(detail?.summary).toBe('route summary')
+		// ...without taking the non-conflicting keys down with it
+		expect(detail?.tags).toEqual(['Admin'])
+	})
+
+	it('does not leak detail between sibling routes', async () => {
+		const app = new Elysia()
+			.guard({ detail: { tags: ['Admin'] } }, (app) =>
+				app.post(
+					'/guarded',
+					{ body: t.Object({ name: t.String() }) },
+					({ body }) => body
+				)
+			)
+			.post(
+				'/outside',
+				{ body: t.Object({ name: t.String() }) },
+				({ body }) => body
+			)
+
+		await app.modules
+
+		expect(detailOf(app, '/guarded', 'POST')?.tags).toEqual(['Admin'])
+		// the guard is scoped to its callback; the sibling must stay untouched
+		expect(detailOf(app, '/outside', 'POST')?.tags).toBeUndefined()
+	})
+
+	it('lets an inner guard replace the tags an outer one set', async () => {
+		const app = new Elysia().guard({ detail: { tags: ['Outer'] } }, (app) =>
+			app.guard({ detail: { tags: ['Inner'] } }, (app) =>
+				app.post(
+					'/nested',
+					{ body: t.Object({ name: t.String() }) },
+					({ body }) => body
+				)
+			)
+		)
+
+		await app.modules
+
+		// arrays override rather than accumulate, as they do on 1.x — an
+		// accumulating `tags` would also duplicate any entry both sides declare
+		expect(detailOf(app, '/nested', 'POST')?.tags).toEqual(['Inner'])
+	})
+
+	// `detail` is an OpenAPI operation object, so its other arrays carry meaning
+	// that a blanket concatenation would break.
+
+	it('lets a route replace the security the guard requires', async () => {
+		const app = new Elysia().guard(
+			{ detail: { security: [{ apiKey: [] }] } },
+			(app) =>
+				app.post(
+					'/users',
+					{
+						body: t.Object({ name: t.String() }),
+						detail: { security: [{ oauth2: ['admin'] }] }
+					},
+					({ body }) => body
+				)
+		)
+
+		await app.modules
+
+		// only one Security Requirement Object has to be satisfied, so carrying
+		// the guard's over as well would widen the route to either scheme
+		expect(detailOf(app, '/users', 'POST')?.security).toEqual([
+			{ oauth2: ['admin'] }
+		])
+	})
+
+	it('lets a route opt out of the guard security with an empty array', async () => {
+		const app = new Elysia().guard(
+			{ detail: { security: [{ apiKey: [] }] } },
+			(app) =>
+				app.post(
+					'/login',
+					{
+						body: t.Object({ username: t.String() }),
+						detail: { security: [] }
+					},
+					({ body }) => body
+				)
+		)
+
+		await app.modules
+
+		// an empty array is how OpenAPI marks an operation public, and there is
+		// no array value that can shrink an inherited one under concatenation
+		expect(detailOf(app, '/login', 'POST')?.security).toEqual([])
+	})
+
+	it('does not duplicate a parameter the guard and the route both declare', async () => {
+		const header = {
+			name: 'X-Tenant',
+			in: 'header',
+			schema: { type: 'string' }
+		}
+
+		const app = new Elysia().guard(
+			{ detail: { parameters: [header] } } as any,
+			(app) =>
+				app.post(
+					'/tenant',
+					{
+						body: t.Object({ name: t.String() }),
+						detail: {
+							parameters: [{ ...header, required: true }]
+						}
+					} as any,
+					({ body }) => body
+				)
+		)
+
+		await app.modules
+
+		// two entries sharing name + in make the emitted document fail spec
+		// validation: "Operations must have unique name + in parameters"
+		expect(detailOf(app, '/tenant', 'POST')?.parameters).toEqual([
+			{ ...header, required: true }
+		])
+	})
+
+	it('applies the guard `tags` shorthand to a route that declares its own hook', async () => {
+		const app = new Elysia().guard({ tags: ['Admin'] }, (app) =>
+			app
+				.post(
+					'/hooked',
+					{ body: t.Object({ name: t.String() }) },
+					({ body }) => body
+				)
+				.post('/plain', () => 'ok')
+		)
+
+		await app.modules
+
+		// `tags` is `detail.tags`' shorthand on both LocalHook and
+		// GuardLocalHook, so it was dropped by the same gap — the hookless
+		// sibling is the control here too
+		expect(hooksOf(app, '/hooked', 'POST')?.tags).toEqual(['Admin'])
+		expect(hooksOf(app, '/plain', 'POST')?.tags).toEqual(['Admin'])
+	})
+
+	it('does not write a route detail into a schema the guard shares', async () => {
+		const ErrorModel = t.Object({ message: t.String() })
+
+		const app = new Elysia().guard(
+			{ detail: { responses: { 400: ErrorModel } } } as any,
+			(app) =>
+				app
+					.post(
+						'/one',
+						{
+							body: t.Object({ name: t.String() }),
+							detail: {
+								responses: { 400: { description: 'only /one' } }
+							}
+						} as any,
+						({ body }) => body
+					)
+					.post(
+						'/two',
+						{ body: t.Object({ name: t.String() }) },
+						({ body }) => body
+					)
+		)
+
+		await app.modules
+
+		// a deep clone only copies plain objects, so a TypeBox model comes back
+		// by reference — merging into it would stamp one route's description
+		// onto the user's own model and onto every sibling that reads it
+		expect('description' in ErrorModel).toBe(false)
+		expect(
+			(detailOf(app, '/two', 'POST')?.responses as any)?.[400]
+		).not.toHaveProperty('description')
+	})
+
+	it('does not let one route write into the detail its siblings inherit', async () => {
+		const app = new Elysia().guard({ detail: { tags: ['Admin'] } }, (app) =>
+			app
+				.post(
+					'/one',
+					{
+						body: t.Object({ name: t.String() }),
+						detail: { summary: 'only mine' }
+					},
+					({ body }) => body
+				)
+				.post(
+					'/two',
+					{ body: t.Object({ name: t.String() }) },
+					({ body }) => body
+				)
+		)
+
+		await app.modules
+
+		// the inherited chain hook is memoized and shared, so merging into it
+		// in place would hand `/one`'s summary to every later route
+		expect(detailOf(app, '/one', 'POST')?.summary).toBe('only mine')
+		expect(detailOf(app, '/two', 'POST')?.summary).toBeUndefined()
+		expect(detailOf(app, '/two', 'POST')?.tags).toEqual(['Admin'])
+	})
+})


### PR DESCRIPTION
## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

Closes #1972

## Description

A guard's `detail` reached a route only when that route declared no hook of its own. As soon as a route added `body`, `query`, or any other hook, the guard's `detail` was dropped and `@elysiajs/openapi` emitted the operation with no tags.

```ts
new Elysia()
  .use(openapi())
  .guard({ detail: { tags: ['Admin'] } }, (app) =>
    app
      .get('/plain', () => 'ok')
      .post('/with-body', { body: t.Object({ name: t.String() }) }, ({ body }) => body)
  )

// spec.paths['/plain'].get.tags       → ['Admin']   ✅
// spec.paths['/with-body'].post.tags  → undefined   ❌
```

### 1.4.x merges this key; the 2.0 rewrite never carried it across

`main` still merges it. On 1.4.29 `mergeHook` lists `detail` among the keys it carries and folds it with `mergeDeep`:

```ts
detail: mergeDeep(
    b.detail ?? {},
    a.detail ?? {}
)
```

That has been there since `69931886` (rc.5, March 2023). The 2.0 `mergeHook` is a separate function written during the restructure — `286f58f9` moved 1.x's copy to `src/1/utils.ts` unchanged — and it enumerates the `HookMap` and `EventMap` keys only, so `detail` was never among them.

So this is not a proposal about how `detail` ought to behave. It is the one key 1.4.x merges and 2.0 does not.

### Cause

`mergeHook` carries keys over one at a time — `body`, `headers`, `params`, `query`, `cookie`, `response`, then each lifecycle array — and `detail` is no longer among them. It is not an event either, so it is absent from `eventProperties` and `appendInto` treats it as a plain last-writer-wins overwrite when flattening the chain.

`applyHook` only reaches `mergeHook` when both a route-local hook and an inherited chain hook exist. That is exactly the reported condition: with no local hook the guard's flattened hook is returned as-is and `detail` survives, which is why the sibling `GET` looked fine and made the bug read as arbitrary.

### Fix

Merge `detail` with `mergeDeep` under the same flags 1.4.x uses: the more specific declaration wins scalars, and arrays override rather than accumulate.

The array question is the only real design decision here, and accumulation is the wrong answer even though it looks friendlier for `tags`. `detail` is `Partial<OpenAPIV3.OperationObject>`, so the same policy governs `security`, `parameters` and `servers`, and OpenAPI defines all three as replacing rather than extending:

- concatenating `security` changes what the document says. A route declaring `security: [{ oauth2: ['admin'] }]` under a guard declaring `[{ apiKey: [] }]` would emit both, and only one Security Requirement Object needs to be satisfied — so the operation would document a bare API key as sufficient for a route its author scoped to `oauth2:admin`.
- concatenating `parameters` emits two entries sharing `name` and `in` when a route re-declares an inherited header to mark it `required`. That is spec-invalid; `@redocly/cli lint` rejects it with `operation-parameters-unique`.
- no array value can shrink an inherited array, so under concatenation `security: []` — OpenAPI's way of marking an operation public — would silently keep the guard's requirement.

Nesting guards therefore narrows `tags` to the innermost declaration rather than accumulating, which is what 1.4.x does today.

The sibling key `tags` goes with it. It is `detail.tags`' shorthand, declared on both `LocalHook` and `GuardLocalHook`, and it was dropped by the same gap — `guard({ tags: ['Admin'] })` reached a hookless route and not its neighbour that declared a `body`. It is carried over the way the schema slots above it are, so a route that declares its own `tags` still wins.

The inherited chain hook is memoized and shared across sibling routes, so the merge clones before adopting instead of writing into it. Without that, the first route's `detail` would leak into every route registered after it in the same guard.

Cloning alone is not enough, because a deep clone only copies plain objects. A TypeBox model under `detail.responses`, or a `Date` in a vendor extension, is handed back by reference, and merging into it writes the route's keys into an object the guard and the user still share — a route adding `responses[400].description` would stamp that description onto the user's own exported model. `~applyMacro` already guards the non-plain leaves in front of the same merge, so the fix calls the same helper rather than inventing anything.

`AppHook` is deliberately left alone: it types the lifecycle event store, and adding `detail` there would widen `keyof AppHook` and make `detail` a valid `#on` event. The merge instead reads through a cast, matching how the same function already handles `~deriveEntries`.

### Also fixed: #1139

#1139 asks for `detail.security` on a guard. Its example gives the route a `detail` of its own, so it is the same drop through a different key. Verified against this branch:

```ts
new Elysia()
  .guard({ detail: { security: [{ bearer: ['read'] }, { api: ['read'] }] } })
  .post('/:id', { detail: { description: 'Route desc' } }, () => {})

// hooks.detail → { security: [{ bearer: ['read'] }, { api: ['read'] }], description: 'Route desc' }
// on kiana without this change → { description: 'Route desc' }, security gone
```

### What this does not fix

#1947 (instance-level `tags`) is a different gap. `ElysiaConfig.detail` and `.tags` are declared at `src/types.ts:78` and `:87`, but nothing in `src/` ever reads them — the only other occurrences of `tags` are codegen skip-lists. That propagation was never implemented, so no change to `mergeHook` can reach it.

#1967 (same-slot schema inheritance) is also separate and already has an answer on this branch. Schema slots travel through the `schemas` channel and the opt-in `schema: 'merge'`, and `4965d086` added `test/core/guard-scope.test.ts` pinning that. `detail` never travelled through that channel, and a route-local schema winning its slot is documented 2.0 behaviour. A guard's `detail` vanishing only when the route happens to declare a hook is not.

One gap this deliberately leaves alone: two `.guard()` calls chained on the same instance still keep only the later `detail` — `guard({ detail: { tags: ['A'] } }).guard({ detail: { summary: 'S' } })` gives a route `{ summary: 'S' }`. That is a different path from the one this fixes (guards nested through the callback form accumulate correctly), and whether chained guards are meant to replace or extend one another looks like a scope decision rather than a bug, so it is left for you to say.

Two known consequences, both shared with 1.4.x rather than introduced here. An `operationId` declared on a guard now reaches every route beneath it, where before only hookless routes inherited it — `operationId` must be unique per operation, so a guard is the wrong place for it either way. And with the hook passed in 1.x's third-argument position (`get(path, handler, hook)`), the route's own `detail` never lands at all, with or without this change; in 2.0 the hook is the second argument and TypeScript rejects the old order, so this only affects untyped call sites.

### Tests

`test/core/guard-detail.test.ts`, eleven cases, grouped by what actually makes them fail.

Seven go red on `kiana` without the change — these are the fix:

- guard `detail` reaches a route that declares its own hook, with the hookless sibling as the control
- the `tags` shorthand does the same
- guard `detail` and route `detail` combine instead of one erasing the other
- the route wins a scalar both sides set, without dropping the guard's other keys
- a route outside the guard callback stays untouched
- an inner guard replaces the tags an outer one set
- one route's own `detail` does not leak into its siblings through the memoized chain hook

Four more pin decisions inside the merge rather than the merge itself. They pass without the change — nothing merges, so nothing can go wrong — and are listed separately rather than counted as evidence for it:

- a route replaces the security the guard requires
- `security: []` on a route survives as an opt-out
- a parameter both sides declare appears once, in the route's form

  these three go red if the merge is switched to concatenate arrays

- a route's `detail` is not written into a schema the guard shares

  this one goes red if the non-plain leaves are not guarded before the merge

### Verification

```
bun run build      exit 0
bun run test:types exit 0
bun test test      4329 pass, 2 skip, 0 fail (348 files)
```

Baseline on the same checkout before the change is 4318 pass — the delta is exactly the eleven added cases. `test/aot` and the two timing-slope cases are sensitive to machine load and fail intermittently under heavy parallel load on this machine; they fail more, not less, with the change reverted, so they are unrelated.

Targeted at `kiana` rather than `main`, since `src/utils.ts` and the guard chain differ substantially between the two and this is a 2.0 report.

I have nothing but my burger and I want nothing more


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved OpenAPI metadata and shorthand tags when combining inherited and route-level hooks.
  * Improved merging of nested security and parameter definitions, including route-specific overrides.
  * Prevented shared schemas and inherited metadata from being modified unexpectedly.
  * Ensured metadata remains isolated between routes and nested guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->