### PR TITLE
fix(types): type plain onError returns under error statuses so Eden sees the error body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,9 @@ import type {
 	ElysiaHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -3179,7 +3182,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3232,7 +3235,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3322,7 +3325,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3343,7 +3346,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3362,7 +3365,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3452,7 +3455,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3473,7 +3476,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3492,7 +3495,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3964,7 +3967,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4214,7 +4217,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4253,7 +4256,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4289,7 +4292,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4323,7 +4326,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4360,7 +4363,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4394,7 +4397,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4468,7 +4471,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2228,6 +2228,85 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 				? ElysiaHandlerToResponseSchemas<Schemas>
 				: {}
 
+/**
+ * HTTP statuses an error may resolve to when it reaches an `onError`
+ * handler, as assigned by Elysia's built-in error handling:
+ *
+ * - `400` - `PARSE`
+ * - `404` - `NOT_FOUND`
+ * - `422` - `VALIDATION`
+ * - `500` - unhandled errors (`INTERNAL_ERROR` and unknown errors)
+ *
+ * Which one applies is decided at runtime by the thrown error, so a plain
+ * value returned from an `onError` handler (without an explicit
+ * `status(code, value)`) is recorded under all of them.
+ */
+type DefaultErrorStatusesToResponseSchema<Response> = {
+	400: Response
+	404: Response
+	422: Response
+	500: Response
+}
+
+/**
+ * Like {@link ValueToResponseSchema} but for values returned from an
+ * `onError` handler: explicit `status(code, value)` returns keep their
+ * exact status, while plain returns become the body of the runtime error
+ * status (see {@link DefaultErrorStatusesToResponseSchema}) instead of
+ * being recorded as a `200` response.
+ *
+ * When a plain return coexists with an explicit `status(code, value)`
+ * whose code is one of the default error statuses, both bodies are
+ * unioned under that status.
+ */
+type ErrorValueToResponseSchema<Value> =
+	ExtractErrorFromHandle<Value> extends infer Explicit
+		? Extract200<Value> extends infer Plain
+			? undefined extends Plain
+				? Explicit
+				: IsNever<Plain> extends true
+					? Explicit
+					: Prettify<
+						Omit<Explicit, 400 | 404 | 422 | 500> & {
+							[K in 400 | 404 | 422 | 500]: K extends keyof Explicit
+								? Explicit[K] | Plain
+								: Plain
+						}
+					>
+			: never
+		: never
+
+export type ElysiaErrorHandlerToResponseSchema<
+	in out Handle extends Function
+> = Prettify<
+	Handle extends (...a: any) => MaybePromise<infer R>
+		? ErrorValueToResponseSchema<Exclude<R, undefined>>
+		: {}
+>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			// @ts-ignore Trust me bro
+			UnionResponseStatus<ElysiaErrorHandlerToResponseSchema<Current>, Carry>
+		>
+	: Prettify<Carry>
+
+export type ElysiaErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ElysiaErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ElysiaErrorHandlerToResponseSchemas<Schemas>
+				: {}
+
 type ReconcileStatus<
 	in out A extends Record<number, unknown>,
 	in out B extends Record<number, unknown>

--- a/src/types.ts
+++ b/src/types.ts
@@ -2255,13 +2255,14 @@ type DefaultErrorStatusesToResponseSchema<Response> = {
  * status (see {@link DefaultErrorStatusesToResponseSchema}) instead of
  * being recorded as a `200` response.
  *
- * When a plain return coexists with an explicit `status(code, value)`
- * whose code is one of the default error statuses, both bodies are
- * unioned under that status.
+ * When a plain return coexists with an explicit `status(code, value)`, only
+ * plain returns become error-status bodies; the explicit statuses keep their
+ * exact code (so e.g. `status(200, value)` is never merged into the 4xx/5xx
+ * error bodies).
  */
 type ErrorValueToResponseSchema<Value> =
 	ExtractErrorFromHandle<Value> extends infer Explicit
-		? Extract200<Value> extends infer Plain
+		? Exclude<Value, AnyElysiaCustomStatusResponse> extends infer Plain
 			? undefined extends Plain
 				? Explicit
 				: IsNever<Plain> extends true

--- a/test/types/lifecycle/on-error-response.ts
+++ b/test/types/lifecycle/on-error-response.ts
@@ -53,3 +53,22 @@ import { Prettify } from '../../../src/types'
 		500: { failure: boolean }
 	}>()
 }
+
+// An explicit status(200, value) returned from onError keeps its 200 body
+// only under 200 — it is NOT merged into the default error statuses
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			status(
+				200,
+				'ok' as string | number
+			)
+		)
+		.get('/', () => 'ok')
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: string | number
+	}>()
+}

--- a/test/types/lifecycle/on-error-response.ts
+++ b/test/types/lifecycle/on-error-response.ts
@@ -1,0 +1,55 @@
+import { Elysia } from '../../../src'
+import { expectTypeOf } from 'expect-type'
+import { Prettify } from '../../../src/types'
+
+// A plain value returned from onError becomes the body of the runtime
+// error status instead of being recorded as a 200 response
+{
+	const app = new Elysia()
+		.onError(() => ({ failure: true }))
+		.get('/', () => 'ok')
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: string
+		400: { failure: boolean }
+		404: { failure: boolean }
+		422: { failure: boolean }
+		500: { failure: boolean }
+	}>()
+}
+
+// An explicit status(code, value) returned from onError keeps its exact
+// status and is not duplicated across default error statuses
+{
+	const app = new Elysia()
+		.onError(({ status }) => status(418, "I'm a teapot"))
+		.get('/', () => 'ok')
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: string
+		418: "I'm a teapot"
+	}>()
+}
+
+// Mixed explicit statuses and plain returns are unioned per status
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			Math.random() > 0.5 ? status(404, 'not found') : { failure: true }
+		)
+		.get('/', () => 'ok')
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: string
+		400: { failure: boolean }
+		404: 'not found' | { failure: boolean }
+		422: { failure: boolean }
+		500: { failure: boolean }
+	}>()
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1007,10 +1007,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1028,10 +1030,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1049,10 +1053,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 


### PR DESCRIPTION
Fixes #313

## Problem

When an `onError` handler returns a plain value, Elysia keeps the runtime error status (500 for unhandled errors, 422 for validation, etc.) but the response is *typed* as a `200` response. Eden clients then see `{ status: unknown; value: unknown }` instead of the actual body — exactly what @EvHaus describes in the issue.

## What changed

`onError` handlers now infer through a dedicated `ElysiaErrorHandlerToResponseSchema*` type instead of reusing the regular handler mapping:

- A **plain return** is recorded under `400 / 404 / 422 / 500` — the statuses Elysia's built-in error handling assigns at runtime (`PARSE`, `NOT_FOUND`, `VALIDATION`, `INTERNAL_ERROR`). Which one applies depends on the thrown error, so statically it belongs to all of them.
- An explicit **`status(code, value)`** return keeps its exact code and is not duplicated.
- If a plain return coexists with an explicit status that lands on one of those four codes, both bodies are **unioned** under that code (e.g. `404: 'not found' | { failure: boolean }`), rather than intersected into an impossible type.
- Route handlers are untouched — their `200` inference works exactly as before.

This also fixes a latent soundness issue: previously two `onError` sources claiming the same status were intersected (`A & B`) instead of unioned.

## Testing

- New `test/types/lifecycle/on-error-response.ts` covers: plain returns, explicit `status()` returns, mixed unions, and that route handlers keep their `200`
- Updated the three existing `onError` expectations in `soundness.ts` (local/scoped/global) to reflect plain values now landing on error statuses
- `bun run test:types` passes; full `bun test` shows no new failures

@algora-pbc /claim #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response type inference for error handlers across local, scoped, and global configurations.
  - Plain error responses now map to the appropriate error status codes instead of defaulting to success.
  - Explicit status codes, including successful responses, are preserved accurately and are not merged with default error responses.
  - Improved type inference for grouped and guarded error-handling configurations.

- **Tests**
  - Added coverage for plain, explicit, mixed, and ambiguous error-handler responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->