### PR TITLE
fix(aot): run vite plugin during dev when targeting workerd

### DIFF
--- a/src/plugin/aot/vite.ts
+++ b/src/plugin/aot/vite.ts
@@ -5,6 +5,7 @@ export interface ElysiaAotVitePlugin {
 	name: string
 	enforce?: 'pre'
 	apply?: 'build'
+	configResolved?(config: { command: string }): void
 	buildStart(): Promise<void>
 	buildEnd(): void
 	resolveId(id: string): string | undefined
@@ -35,12 +36,26 @@ export const aot = (
 ): ElysiaAotVitePlugin => {
 	const hooks = createAotPluginHooks(entry, options)
 
+	// workerd bans runtime codegen (`new Function`), so a workerd target must
+	// run the AOT manifest in `vite dev` too — `core.ts` already refuses to
+	// build a workerd bundle whose JIT is reachable. Every other target keeps
+	// the runtime JIT path in dev.
+	const runsInDev = options?.target === 'workerd'
+	let serving = false
+
 	return {
 		name: 'elysia-aot',
 		enforce: 'pre',
-		apply: 'build',
+		...(runsInDev ? {} : { apply: 'build' as const }),
+		configResolved(config) {
+			serving = config.command === 'serve'
+		},
 		buildStart: hooks.buildStart,
-		buildEnd: hooks.buildEnd,
+		buildEnd() {
+			// `serve` calls buildEnd on server close; the entry may never have
+			// been requested, which is expected (not the `build` invariant).
+			if (!serving) hooks.buildEnd()
+		},
 		resolveId: hooks.resolveId,
 		load: hooks.load,
 		transform: hooks.transform

--- a/src/type/validator/exact-mirror.ts
+++ b/src/type/validator/exact-mirror.ts
@@ -1,6 +1,15 @@
+import { isCloudflareWorker } from '../../universal/constants'
+
 export type CreateMirror = (schema: any, options?: any) => any
 
 function loadExactMirror(): CreateMirror | undefined {
+	// workerd has no CJS loader, so this probe can only fail — and its module
+	// fallback service asserts in the host process before the catch below ever
+	// sees it, printing an unsuppressable stack trace on every dev boot.
+	// On workerd the supported paths are the AOT `-live` reroute or
+	// `setupTypebox({ exactMirror })`.
+	if (isCloudflareWorker) return undefined
+
 	try {
 		const meta = import.meta as ImportMeta & {
 			require?: (specifier: string) => any

--- a/src/universal/constants.ts
+++ b/src/universal/constants.ts
@@ -16,6 +16,10 @@ export const isCloudflareWorker = (() => {
 
 		// @ts-ignore
 		if (typeof WebSocketPair !== 'undefined') return true
+
+		// @ts-ignore
+		if (typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers')
+			return true
 	} catch {
 		return false
 	}

--- a/test/aot/exact-mirror-workerd.test.ts
+++ b/test/aot/exact-mirror-workerd.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+/**
+ * `isCloudflareWorker` is computed once at module load, so the only way to
+ * observe both branches is a subprocess with the workerd global pre-set
+ * before `exact-mirror.ts` is ever imported.
+ */
+describe('exact-mirror under workerd', () => {
+	it('skips the require probe when a workerd global is present', () => {
+		const src = resolve(import.meta.dir, '../../src')
+		const script =
+			`;(globalThis as any).WebSocketPair = class {}\n` +
+			`import { getExactMirror } from '${src}/type/validator/exact-mirror.ts'\n` +
+			`console.log(JSON.stringify({ mirror: getExactMirror() }))\n`
+
+		const child = spawnSync('bun', ['-e', script], { encoding: 'utf8' })
+
+		expect(child.status).toBe(0)
+		expect(JSON.parse(child.stdout.trim())).toEqual({})
+	})
+
+	it('still resolves the real mirror off workerd', () => {
+		const src = resolve(import.meta.dir, '../../src')
+		const script =
+			`import { getExactMirror } from '${src}/type/validator/exact-mirror.ts'\n` +
+			`console.log(typeof getExactMirror())\n`
+
+		const child = spawnSync('bun', ['-e', script], { encoding: 'utf8' })
+
+		expect(child.status).toBe(0)
+		expect(child.stdout.trim()).toBe('function')
+	})
+})

--- a/test/aot/vite-plugin-dev.test.ts
+++ b/test/aot/vite-plugin-dev.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { aot } from '../../src/plugin/aot/vite'
+
+describe('vite plugin dev mode', () => {
+	it("omits apply for target 'workerd' — workerd cannot run the JIT path apply: 'build' falls back to", () => {
+		const plugin = aot('src/index.ts', { target: 'workerd' })
+		expect(plugin.apply).toBeUndefined()
+	})
+
+	it("keeps apply: 'build' with no target — no dev-startup regression for runtimes that can JIT", () => {
+		const plugin = aot('src/index.ts')
+		expect(plugin.apply).toBe('build')
+	})
+
+	it("keeps apply: 'build' for target 'bun' — only workerd needs the manifest in dev", () => {
+		const plugin = aot('src/index.ts', { target: 'bun' })
+		expect(plugin.apply).toBe('build')
+	})
+
+	it('does not throw buildEnd on an unmatched entry while serving', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'elysia-aot-vite-dev-'))
+		const entry = join(directory, 'app.ts')
+		const sourceEntry = resolve(import.meta.dir, '../../src/index.ts')
+
+		await writeFile(
+			entry,
+			`import { Elysia } from ${JSON.stringify(sourceEntry)}\n` +
+				`export const app = new Elysia().get('/', () => 'ok')\n`
+		)
+
+		try {
+			const plugin = aot(entry, { target: 'workerd', strip: false })
+			plugin.configResolved!({ command: 'serve' })
+			await plugin.buildStart()
+
+			// entry never transformed (no request came in before shutdown) —
+			// serve must not treat this as the build-time invariant failure
+			expect(() => plugin.buildEnd()).not.toThrow()
+		} finally {
+			await rm(directory, { recursive: true, force: true })
+		}
+	})
+
+	it('still throws buildEnd on an unmatched entry for command: build', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'elysia-aot-vite-build-'))
+		const entry = join(directory, 'app.ts')
+		const sourceEntry = resolve(import.meta.dir, '../../src/index.ts')
+
+		await writeFile(
+			entry,
+			`import { Elysia } from ${JSON.stringify(sourceEntry)}\n` +
+				`export const app = new Elysia().get('/', () => 'ok')\n`
+		)
+
+		try {
+			const plugin = aot(entry, { target: 'workerd', strip: false })
+			plugin.configResolved!({ command: 'build' })
+			await plugin.buildStart()
+
+			expect(() => plugin.buildEnd()).toThrow(
+				/never appeared in the Vite module graph/
+			)
+		} finally {
+			await rm(directory, { recursive: true, force: true })
+		}
+	})
+})


### PR DESCRIPTION
## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue
Solves: #1975 

## Description
In dev, the plugin only runs during vite build, so it does not build the precompiled routes. On Cloudflare Workers, the plugin does not build them, so the plugin's fallback does not run. The plugin also requires exact-mirror, and the error occurs before the plugin's try/catch catches it, so it prints an exact-mirror error.
