### PR TITLE
:bug: fix: HEAD request returns 404 in non-AOT (dynamic) mode

### DIFF
--- a/src/dynamic-handle.ts
+++ b/src/dynamic-handle.ts
@@ -13,7 +13,13 @@ import { parseQuery } from './parse-query'
 import { getSchemaProperties, type ElysiaTypeCheck } from './schema'
 import type { TypeCheck } from './type-system'
 import type { Handler, LifeCycleStore, SchemaValidator } from './types'
-import { hasSetImmediate, redirect, StatusMap, signCookie } from './utils'
+import {
+	getResponseLength,
+	hasSetImmediate,
+	redirect,
+	StatusMap,
+	signCookie
+} from './utils'
 
 // JIT Handler
 export type DynamicHandler = {
@@ -261,10 +267,16 @@ export const createDynamicHandler = (app: AnyElysia) => {
 
 			const methodKey = isWS ? 'WS' : request.method
 
-			const handler =
+			let handler =
 				app.router.dynamic.find(request.method, path) ??
 				app.router.dynamic.find(methodKey, path) ??
 				app.router.dynamic.find('ALL', path)
+
+			// Align with composeGeneralHandler: when HEAD is not
+			// registered, fall back to the GET route (auto HEAD)
+			const isHeadFallback = !handler && request.method === 'HEAD'
+			if (isHeadFallback)
+				handler = app.router.dynamic.find('GET', path)
 
 			if (!handler) {
 				// @ts-expect-error
@@ -919,8 +931,25 @@ export const createDynamicHandler = (app: AnyElysia) => {
 				}
 			}
 
+			const result = mapResponse((context.response = response), context.set)
+
+			// Auto HEAD: mirror composeGeneralHandler — resolve the body
+			// length, set content-length, then respond without the body
+			if (isHeadFallback)
+				return Promise.resolve(result as Response).then((result) =>
+					getResponseLength(result).then((length) => {
+						result.headers.set('content-length', String(length))
+
+						return new Response(null, {
+							status: result.status,
+							statusText: result.statusText,
+							headers: result.headers
+						})
+					})
+				)
+
 			// @ts-expect-error
-			return mapResponse((context.response = response), context.set)
+			return result
 		} catch (error) {
 			const reportedError =
 				error instanceof TransformDecodeError && error.error

--- a/test/core/elysia.test.ts
+++ b/test/core/elysia.test.ts
@@ -420,6 +420,36 @@ describe('Edge Case', () => {
 		})
 	})
 
+	it('automatically handle HEAD request for GET static path (aot: false)', async () => {
+		const app = new Elysia({ aot: false }).get('/', () => 'hello world')
+
+		const response = await app.handle(
+			new Request('http://localhost', {
+				method: 'HEAD'
+			})
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.headers.toJSON()).toEqual({
+			'content-length': '11'
+		})
+	})
+
+	it('automatically handle HEAD request for GET dynamic path (aot: false)', async () => {
+		const app = new Elysia({ aot: false }).get('/:id', () => 'hello world')
+
+		const response = await app.handle(
+			new Request('http://localhost/1', {
+				method: 'HEAD'
+			})
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.headers.toJSON()).toEqual({
+			'content-length': '11'
+		})
+	})
+
 	it('handle arbitrary code execution from cookie', async () => {
 		const app = new Elysia({
 			cookie: {


### PR DESCRIPTION
## Problem

With `aot: false` (dynamic/JIT mode), a HEAD request to a route registered only with GET returns 404 instead of the GET route's headers:

```ts
const app = new Elysia({ aot: false }).get('/', () => 'hello world')

await app.handle(new Request('http://localhost', { method: 'HEAD' }))
// Before: 404 Not Found
// After:  200, content-length: 11 (same as AOT mode)
```

Wire-level (both Bun and Node adapters): GET returns `200 content-length: 6`, HEAD returns `404 content-length: 9`.

## Root cause

`createDynamicHandler` looks up `find(method) ?? find(methodKey) ?? find('ALL')` without falling back to the GET route, while the AOT `composeGeneralHandler` already implements auto HEAD (fall back to GET, resolve content-length, drop the body). The HEAD fallback was only ever wired into the AOT path — #861 and the follow-up HEAD fixes (#1522, #1524, #1579) all landed in `compose.ts`.

## Fix

Mirror `composeGeneralHandler` auto HEAD in `createDynamicHandler`:

- when HEAD is not registered, fall back to the GET route
- after the handler runs, resolve the body length with `getResponseLength`, set `content-length`, and respond with `new Response(null, ...)` — same shape as `compose.ts`

## Testing

- Added two regression tests in `test/core/elysia.test.ts` (static + dynamic path, `aot: false`), matching the existing AOT auto HEAD tests
- Verified the new tests fail without the fix and pass with it
- `bun run test` — 1616 pass, 0 fail
- `bun run test:types` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HEAD requests now automatically use matching GET routes when no dedicated HEAD route exists.
  * HEAD responses correctly include the response size in the `content-length` header while returning an empty body.
  * Automatic HEAD handling now works for both static and dynamic routes when ahead-of-time compilation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->