### PR TITLE
fix(compose): incorrect setImmediate detection breaks afterResponse in browsers

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -18,7 +18,7 @@ import {
 import {
 	ELYSIA_REQUEST_ID,
 	getLoosePath,
-	hasSetImmediate,
+	scheduleImmediate,
 	lifeCycleToFn,
 	randomId,
 	redirect,
@@ -469,10 +469,6 @@ const coerceTransformDecodeError = (
 	`throw error.error ?? new ValidationError('${type}',validator.${type},${value},${allowUnsafeValidationDetails})}` +
 	`}`
 
-const setImmediateFn = hasSetImmediate
-	? 'setImmediate'
-	: 'Promise.resolve().then'
-
 export const composeHandler = ({
 	app,
 	path,
@@ -845,7 +841,7 @@ export const composeHandler = ({
 		let afterResponse = ''
 
 		afterResponse +=
-			`\n${setImmediateFn}(async()=>{` +
+			`\nsetImmediate(async()=>{` +
 			`if(c.responseValue){` +
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n` +
 			(hasStream
@@ -1823,7 +1819,7 @@ export const composeHandler = ({
 					(hasTrace || hooks.afterResponse?.length
 						? `afterHandlerStreamListener=stream[2]\n`
 						: '') +
-					`${setImmediateFn}(async ()=>{` +
+					`setImmediate(async ()=>{` +
 					`if(listener)for await(const v of listener){}\n`
 				handleReporter.resolve()
 				fnLiteral += `})` + (maybeAsync ? '' : `})()`) + `}else{`
@@ -2129,6 +2125,7 @@ export const composeHandler = ({
 		`const {` +
 		`handler,` +
 		`handleError,` +
+		`setImmediate,` +
 		`hooks:e, ` +
 		allocateIf(`validator,`, hasValidation) +
 		`mapResponse,` +
@@ -2178,6 +2175,7 @@ export const composeHandler = ({
 		)({
 			handler,
 			hooks: lifeCycleToFn(hooks),
+			setImmediate: scheduleImmediate,
 			validator: hasValidation ? validator : undefined,
 			// @ts-expect-error
 			handleError: app.handleError,
@@ -2389,7 +2387,7 @@ export const composeGeneralHandler = (
 
 		const prefix = app.event.afterResponse.some(isAsync) ? 'async' : ''
 		afterResponse +=
-			`\n${setImmediateFn}(${prefix}()=>{` +
+			`\nsetImmediate(${prefix}()=>{` +
 			`if(c.responseValue instanceof ElysiaCustomStatusResponse) c.set.status=c.responseValue.code\n`
 
 		for (let i = 0; i < app.event.afterResponse.length; i++) {
@@ -2493,6 +2491,7 @@ export const composeGeneralHandler = (
 		`NotFoundError,` +
 		`randomId,` +
 		`handleError,` +
+		`setImmediate,` +
 		`status,` +
 		`redirect,` +
 		`getResponseLength,` +
@@ -2560,6 +2559,7 @@ export const composeGeneralHandler = (
 		NotFoundError,
 		randomId,
 		handleError,
+		setImmediate: scheduleImmediate,
 		status,
 		redirect,
 		getResponseLength,
@@ -2600,6 +2600,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 		allocateIf(`onMapResponse,`, app.event.mapResponse) +
 		allocateIf(`ELYSIA_TRACE,`, hasTrace) +
 		allocateIf(`ELYSIA_REQUEST_ID,`, hasTrace) +
+		`setImmediate,` +
 		adapterVariables +
 		`}=inject\n`
 
@@ -2623,7 +2624,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 
 		let afterResponse = ''
 		const prefix = hooks.afterResponse?.some(isAsync) ? 'async' : ''
-		afterResponse += `\n${setImmediateFn}(${prefix}()=>{`
+		afterResponse += `\nsetImmediate(${prefix}()=>{`
 
 		const reporter = createReport({
 			context: 'context',
@@ -2795,6 +2796,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 		TransformDecodeError,
 		onError: app.event.error?.map(mapFn),
 		afterResponse: app.event.afterResponse?.map(mapFn),
+		setImmediate: scheduleImmediate,
 		trace: app.event.trace?.map(mapFn),
 		onMapResponse: app.event.mapResponse?.map(mapFn),
 		ELYSIA_TRACE: hasTrace ? ELYSIA_TRACE : undefined,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -402,6 +402,13 @@ export const lifeCycleToArray = (a: LifeCycleStore) => {
 export const hasHeaderShorthand = isBun ? 'toJSON' in new Headers() : false
 export const hasSetImmediate = typeof setImmediate === 'function'
 
+export const scheduleImmediate: (callback: () => unknown) => void =
+	hasSetImmediate
+		? setImmediate
+		: (callback) => {
+				void Promise.resolve().then(callback)
+			}
+
 // https://stackoverflow.com/a/52171480
 export const checksum = (s: string) => {
 	let h = 9


### PR DESCRIPTION

alt textalt textBug Report:

in playground

run code below:

```ts
import { Elysia } from 'elysia'

new Elysia()
	.get('/QoQ', ({query: { name }})=>`OMO ${name}`)
	.guard({
		beforeHandle:[({query : {name}, status})=>{
			if(!name) return status(401)
		}],
		afterResponse(){ console.log("omo") }
	})
	.get('/auth', ({ query: { name = 'anon' } }) => `Hello ${name}!`)
	.listen(3000)
```

```bashanonymous/<@https://esm.sh/elysia@1.4.30/es2022/compose.mjs
handle@https://esm.sh/elysia@1.4.30/es2022/compose.mjs line 231 > Function:52:8
anonymous/<@https://esm.sh/elysia@1.4.30/es2022/compose.mjs line 314 > Function:36:1
handle@https://esm.sh/elysia@1.4.30/es2022/compose.mjs line 231 > Function:52:8
```
<img width="2349" height="1381" alt="1" src="https://github.com/user-attachments/assets/ea3563f7-5efd-4db7-8018-0f638f6e2eca" />



del line 9, it works:
<img width="2349" height="1381" alt="2" src="https://github.com/user-attachments/assets/556dff4d-3a31-450e-8071-8953474465b3" />


found that it can only be triggered in playgroud.

bun and node are ok:

```js
//s.js
const { Elysia } = await import('elysia') 

const app = new Elysia()
	.get('/omo', ({ query: { name } }) => `OMO ${name}`)
	.guard({
		beforeHandle: [
			({ query: { name }, status }) => {
				if (!name) return status(401)
			}
		],
		afterResponse: () => console.log('  afterResponse ran')
	})
	.get('/auth', ({ query: { name = 'anon' } }) => `Hello ${name}!`)

for (const path of ['/auth?name=x', '/auth', '/omo?name=x', '/nope']) {
	try {
		const res = await app.fetch(new Request('http://localhost' + path))
		console.log(path, '->', res.status)
	} catch (err) {
		console.log(path, '-> THREW:', err.constructor.name + ': ' + err.message)
	}
}
```

```ts
import { Elysia } from 'elysia'
const app = new Elysia()
	.get('/omo', ({ query: { name } }: any) => `OMO ${name}`)
	.guard({
		beforeHandle: [({ query: { name }, status }: any) => { if (!name) return (status as any)(401) }],
		afterResponse() { console.log('omo') }
	})
	.get('/auth', ({ query: { name = 'anon' } }: any) => `Hello ${name}!`)
	.listen(3123)
for (const p of ['/omo?name=x', '/auth?name=x', '/auth']) {
	const r = await fetch('http://localhost:3123' + p)
	console.log(p, r.status, await r.text())
}
process.exit(0)

```
<img width="1001" height="531" alt="nodeandbun" src="https://github.com/user-attachments/assets/c2993b69-9d78-4ec8-adfb-33a0caebba08" />


use the browser environmet to locate the bug:

```html
<!doctype html>
<html>
<head><meta charset="utf-8"><title>elysia afterResponse repro</title></head>
<body>
<pre id="out">running repro...</pre>
<script type="module">

const out = document.getElementById('out')
const log = (s) => { out.textContent += '\n' + s; console.log(s) }

const { Elysia } = await import('https://esm.sh/elysia@1.4.30')

const app = new Elysia()
	.get('/omo', ({ query: { name } }) => `OMO ${name}`)
	.guard({
		beforeHandle: [
			({ query: { name }, status }) => {
				if (!name) return status(401)
			}
		],
		afterResponse() {
			console.log('afterResponse ran')
		}
	})
	.get('/auth', ({ query: { name = 'anon' } }) => `Hello ${name}!`)

for (const path of ['/auth?name=x', '/auth', '/omo?name=x', '/nope']) {
	try {
		const res = await app.fetch(new Request('http://localhost' + path))
		log(path + ' -> ' + res.status)
	} catch (err) {
		log(path + ' -> THREW: ' + err.constructor.name + ': ' + err.message)
	}
}
log('done')
</script>
</body>
</html>

```

<img width="1280" height="720" alt="pr-screenshot-browser" src="https://github.com/user-attachments/assets/d16e3645-ff09-44ed-b705-7f06dcb9642c" />


found code at `src/utils.ts:403`

```ts
export const hasSetImmediate = typeof setImmediate === 'function'
```

this will be rewritten by esm.sh, check the deployed code:

`https://esm.sh/elysia@1.4.30/es2022/utils.mjs`:

```js
// injected by esm.sh, top of the file
var __setImmediate$ = (cb, ...args) => ( { $t: setTimeout(cb, 0, ...args), [Symbol.dispose](){ clearTimeout(this.t) } });

// src/utils.ts:403 after rewrite (x = hasSetImmediate)
x=typeof __setImmediate$=="function"
```

the shim is a function, so `hasSetImmediate` is `true` in browser.

`https://esm.sh/elysia@1.4.30/es2022/compose.mjs`:

```js
fe=Ie?"setImmediate":"Promise.resolve().then"    // src/compose.ts:472
```

then `setImmediate` injected into the compiled handler in string, the only interpolation (src/compose.ts:848 / 1826 / 2392 / 2626):

```js
${fe}(async()=>{
```

the runtime compiled code looks like this (the `anonymous/< ... Function:36:1` frame in the stack):

```js
setImmediate(()=>{
afterResponse[0](context)
})
```

esm.sh only rewrites identifiers (`setImmediate` → `__setImmediate$`; elysia.mjs gets the same shim and its identifier usage works fine).
code emitted as string, so the `setImmediate(` above resolves against the real browser global, which doesn't exist...

fix:
pass function into the compiled scopes, instead of global name as string.

`src/utils.ts`:

```ts
export const scheduleImmediate: (callback: () => unknown) => void =
	hasSetImmediate
		? setImmediate
		: (callback) => {
				void Promise.resolve().then(callback)
			}
```

```ts
// injected
)({
	handler,
	hooks: lifeCycleToFn(hooks),
	setImmediate: scheduleImmediate,    // ← added
	...
})

// destructured inside the generated function
const {
	handler,
	handleError,
	setImmediate,                       // ← added
	hooks: e,
	...
} = hooks
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred task scheduling across supported runtime environments.
  * Ensured asynchronous handler operations continue to run reliably when native immediate scheduling is unavailable.

* **Compatibility**
  * Added a fallback scheduling mechanism for environments that do not provide native immediate execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->