### PR TITLE
fix(compose): don't mutate the thrown error when onError returns status()

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -2697,8 +2697,7 @@ export const composeErrorHandler = (app: AnyElysia) => {
 					afterResponse() +
 					`return mapResponse(_r,set${adapter.mapResponseContext})}` +
 					`if(_r instanceof ElysiaCustomStatusResponse){` +
-					`error.status=error.code\n` +
-					`error.message=error.response` +
+					`if(set.status===200||!set.status)set.status=_r.code` +
 					`}` +
 					`if(set.status===200||!set.status)set.status=error.status\n`
 

--- a/test/lifecycle/error.test.ts
+++ b/test/lifecycle/error.test.ts
@@ -2,6 +2,7 @@
 import {
 	Elysia,
 	InternalServerError,
+	NotFoundError,
 	ParseError,
 	ValidationError,
 	t,
@@ -527,5 +528,32 @@ describe('error', () => {
 		}
 
 		expect(res.status).toBe(422)
+	})
+
+	it('onError returning status() must not corrupt the shared NotFoundError singleton', async () => {
+		const errors: Array<{ status: unknown; message: unknown }> = []
+
+		const app = new Elysia().onError(({ error, status }) => {
+			if (error instanceof NotFoundError)
+				errors.push({ status: error.status, message: error.message })
+
+			return status(404, 'custom not found body')
+		})
+
+		const res1 = await app.handle(req('/missing'))
+		expect(res1.status).toBe(404)
+		expect(await res1.text()).toBe('custom not found body')
+
+		const res2 = await app.handle(req('/missing'))
+		expect(res2.status).toBe(404)
+		expect(await res2.text()).toBe('custom not found body')
+
+		expect(errors[0].status).toBe(404)
+		expect(errors[0].message).toBe('NOT_FOUND')
+
+		// the thrown NotFoundError is a shared instance created once per compiled
+		// handler — it must not be mutated by the onError return value
+		expect(errors[1].status).toBe(404)
+		expect(errors[1].message).toBe('NOT_FOUND')
 	})
 })


### PR DESCRIPTION
## Problem

When a global `onError` handler returns a `status(...)` response, Elysia mutates the thrown error instead of using the returned response. For unmatched routes this mutates the single `NotFoundError` instance that the compiled general handler creates once (`const notFound=new NotFoundError()` in `composeGeneralHandler`) and reuses for every request, so the corruption persists for the lifetime of the server:

- 1st unmatched request: `error.status === 404`, `error.message === "NOT_FOUND"`
- every subsequent unmatched request: `error.status === "NOT_FOUND"` (the string code), `error.message === undefined`

Custom error-translation logic reading `error.status` then misbehaves from the second 404 onward (in the reporter's production app, all unmatched routes returned 500 after the first 404).

Fixes #1969

## Root cause

In `composeErrorHandler` (src/compose.ts), the block handling an `onError` handler's return value generated:

```js
if(_r instanceof ElysiaCustomStatusResponse){
  error.status=error.code
  error.message=error.response
}
```

The returned `ElysiaCustomStatusResponse` is already passed to `mapResponse(_r, ...)` as the response body and its code is applied to `set.status`, so mutating the thrown error serves no purpose here — and when `error` is the shared 404 singleton, it poisons every later request.

## Fix

Remove both mutations of `error` in that branch. The generated code now only applies `_r.code` to `set.status` (when not already set) and lets `mapResponse(_r)` carry the response body. The thrown error is left untouched.

## Verification

- New regression test (`test/lifecycle/error.test.ts`): two consecutive unmatched requests through an `onError` that returns `status(404, ...)` — both responses are `404 / "custom not found body"` and both observed thrown errors keep `status === 404`, `message === "NOT_FOUND"`. Confirmed failing on unpatched main first (second request saw `status === "NOT_FOUND"`).
- Full suite: 1615 pass, 0 fail, 2 skip (134 files).
- `tsc --noEmit` crashes (V8 OOM, exit 134) identically on a clean checkout of `main` on this Windows machine — pre-existing environment issue, not related to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed error handling for custom status responses so HTTP status codes are preserved correctly.
  - Prevented repeated missing-route requests from mutating shared not-found error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->