### PR TITLE
fix(query): keep scalar values as strings in union query schemas with an array variant

### DIFF
--- a/src/replace-schema.ts
+++ b/src/replace-schema.ts
@@ -244,11 +244,20 @@ export const queryCoercions = () => {
 					);
 					if (stringIndex === -1) return schema;
 
-					const reordered = [...variants];
-					reordered[arrayIndex] = variants[stringIndex];
-					reordered[stringIndex] = variants[arrayIndex];
+					// Only reorder when the ArrayQuery variant sits BEFORE the
+					// string variant — the shape that makes Union.Decode take the
+					// transform and wrap scalars. If the user already declared the
+					// string variant first, leave the order alone: swapping would
+					// REGRESS that shape by moving the transform in front
+					// (CodeRabbit caught this on #1988).
+					if (arrayIndex < stringIndex) {
+						const reordered = [...variants];
+						reordered[arrayIndex] = variants[stringIndex];
+						reordered[stringIndex] = variants[arrayIndex];
+						return { ...schema, anyOf: reordered };
+					}
 
-					return { ...schema, anyOf: reordered };
+					return schema;
 				},
 			},
 		] satisfies ReplaceSchemaTypeOptions[];

--- a/src/replace-schema.ts
+++ b/src/replace-schema.ts
@@ -217,6 +217,40 @@ export const queryCoercions = () => {
 				from: t.Array(t.Any()),
 				to: (schema) => t.ArrayQuery(schema.items ?? t.Any(), schema),
 			},
+			{
+				// A union mixing an array variant with a plain string variant
+				// (e.g. `t.Union([t.Array(t.String()), t.String()])` in a query)
+				// must keep scalar values as strings. After the array→ArrayQuery
+				// replacement above, the ArrayQuery transform sits FIRST and its
+				// Check matches scalars too, so Union.Decode never reaches the
+				// string variant and wraps every scalar into a 1-element array
+				// (#1028). Reorder so the string variant is checked first; arrays
+				// still fall through to the ArrayQuery branch. Unions without an
+				// (already-replaced) ArrayQuery + String shape are returned as-is.
+				// `from` needs Kind 'Union' to match union nodes. NOTE: TypeBox
+				// collapses single-member unions to the member itself (Kind
+				// 'String'), so the probe union needs 2 members to survive as
+				// Kind 'Union'; the shape check happens in `to`.
+				from: t.Union([t.String(), t.Number()]),
+				to: (schema) => {
+					const variants = (schema as { anyOf?: TSchema[] }).anyOf;
+					if (!variants || variants.length < 2) return schema;
+
+					const arrayIndex = variants.findIndex((v) => v.elysiaMeta === "ArrayQuery");
+					if (arrayIndex === -1) return schema;
+
+					const stringIndex = variants.findIndex(
+						(v, i) => i !== arrayIndex && (v as { type?: string }).type === "string" && !v.elysiaMeta,
+					);
+					if (stringIndex === -1) return schema;
+
+					const reordered = [...variants];
+					reordered[arrayIndex] = variants[stringIndex];
+					reordered[stringIndex] = variants[arrayIndex];
+
+					return { ...schema, anyOf: reordered };
+				},
+			},
 		] satisfies ReplaceSchemaTypeOptions[];
 	}
 

--- a/test/validator/query-union-string-array.test.ts
+++ b/test/validator/query-union-string-array.test.ts
@@ -21,4 +21,24 @@ describe('query union string|string[] (#1028)', () => {
 		expect(res.status).toBe(200)
 		expect(await res.json()).toEqual({ tags: 'a' })
 	})
+
+	it('string-first union (t.String() before t.Array) behaves identically', async () => {
+		const server2 = new Elysia().get(
+			'/query',
+			({ query: { tags } }) => ({ tags }),
+			{
+				query: t.Partial(
+					t.Object({
+						tags: t.Union([t.String(), t.Array(t.String())])
+					})
+				)
+			}
+		)
+
+		const multi = await server2.handle(new Request('http://localhost/query?tags=a&tags=b&tags=c'))
+		expect(await multi.json()).toEqual({ tags: ['a', 'b', 'c'] })
+
+		const single = await server2.handle(new Request('http://localhost/query?tags=a'))
+		expect(await single.json()).toEqual({ tags: 'a' })
+	})
 })

--- a/test/validator/query-union-string-array.test.ts
+++ b/test/validator/query-union-string-array.test.ts
@@ -1,0 +1,24 @@
+import { Elysia, t } from '../../src'
+import { describe, expect, it } from 'bun:test'
+
+describe('query union string|string[] (#1028)', () => {
+	const server = new Elysia().get('/query', ({ query: { tags } }) => ({ tags }), {
+		query: t.Partial(
+			t.Object({
+				tags: t.Union([t.Array(t.String()), t.String()])
+			})
+		)
+	})
+
+	it('array of values stays an array', async () => {
+		const res = await server.handle(new Request('http://localhost/query?tags=a&tags=b&tags=c'))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ tags: ['a', 'b', 'c'] })
+	})
+
+	it('single value stays a string', async () => {
+		const res = await server.handle(new Request('http://localhost/query?tags=a'))
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ tags: 'a' })
+	})
+})


### PR DESCRIPTION
## Problem

For a query schema that mixes an array variant with a plain string variant:

```ts
query: t.Object({
    tags: t.Union([t.Array(t.String()), t.String()])
})
```

a single repeated value (`?tags=a`) is decoded as `['a']` instead of `'a'` — the string variant of the union is unreachable, so the `t.String()` branch never wins. (Reported on 1.2.10 in #1028 with the inverse emphasis; on current main the multi-value aggregation works, but the scalar-keeps-string half is still broken.)

## Root cause

The query-coercion pipeline (`queryCoercions` in `src/replace-schema.ts`) replaces every `t.Array` inside a query schema with the `t.ArrayQuery` transform so repeated keys aggregate. Inside a union, that transform lands FIRST, and its `Check` matches scalars too (its input side is `t.Union([t.String(), t.Array])`). `Union.Decode` takes the first passing variant, so the `ArrayQuery` transform swallows scalars into 1-element arrays before the plain `t.String()` variant is ever consulted.

## Fix

Add a third query coercion that matches union nodes (`Kind: 'Union'`) after the array replacement and reorders the variants when — and only when — the union has the exact shape that causes the bug: an `ArrayQuery`-meta variant plus a plain string variant. Scalars then hit the string variant; arrays still fall through to `ArrayQuery`. Unions without that shape (and pure `t.Array` query keys, whose single-value wrapping is pinned by existing tests) are untouched.

Implementation note: the probe `from` schema must be a **2-member** union (`t.Union([t.String(), t.Number()])`) — TypeBox collapses single-member unions to the member's own `Kind`, so `t.Union([t.String()])` has Kind `'String'` and never matches union nodes.

## Verification

- New test (`test/validator/query-union-string-array.test.ts`): `?tags=a&tags=b&tags=c` → `['a','b','c']` AND `?tags=a` → `'a'` (this half failed before the fix).
- Existing pinned behavior intact: 262 validator tests, 226 core tests, 74 type-system tests all green — including `handle single query array` (pure `t.Array` still wraps a single value to `['rapi']`) and the nuqs-format tests.
- Full suite: 1615 pass, 1 fail — the `Stream > stop stream on canceled request` flake previously proven to flake on clean `main` at the same rate.

Fixes #1028


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query parameter parsing for values that may be either a string or an array.
  * Repeated query parameters are now parsed as arrays, while single values remain strings.

* **Tests**
  * Added coverage for string-or-array query parameter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->