### PR TITLE
fix(sucrose): add word boundary to context regex in isContextPassToFunction

### DIFF
--- a/src/sucrose.ts
+++ b/src/sucrose.ts
@@ -551,7 +551,7 @@ export const isContextPassToFunction = (
 	// ! Function is passed to another function, assume as all is accessed
 	try {
 		const captureFunction = new RegExp(
-			`\\w\\((?:.*?)?${context}(?:.*?)?\\)`,
+			`\\w\\((?:.*?)?\\b${context}\\b(?:.*?)?\\)`,
 			'gs'
 		)
 		const exactParameter = new RegExp(`${context}(,|\\))`, 'gs')


### PR DESCRIPTION
when the context parameter name is a single character (e.g. `c`), the regex `\w\((?:.*?)?c(?:.*?)?\)` matches any word character before `(` followed by `c` anywhere inside. this causes false positives — e.g. `myFunc(cache)` incorrectly matches because `e(` satisfies `\w\(` and `c` inside `cache` satisfies the context match.

adding `\b` word boundaries around the context name fixes this — `\w\((?:.*?)?\bc\b(?:.*?)?\)` now only matches when `c` appears as a standalone identifier, not as part of a longer word.

this is the root cause of the "Body already used" errors and incorrect inference reported in #1945 when using short context names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved context detection for function calls by matching standalone context names only.
  - Prevented false positives when a context name appears as part of a larger identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->