### PR TITLE
fix(types): type plain onError returns under error statuses (#313)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,9 @@ import type {
 	ElysiaHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -3146,7 +3149,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3199,7 +3202,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3289,7 +3292,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3310,7 +3313,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3329,7 +3332,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3419,7 +3422,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3440,7 +3443,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3459,7 +3462,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3931,7 +3934,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4181,7 +4184,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4220,7 +4223,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4256,7 +4259,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4290,7 +4293,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4327,7 +4330,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4361,7 +4364,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4435,7 +4438,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2228,6 +2228,54 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 				? ElysiaHandlerToResponseSchemas<Schemas>
 				: {}
 
+// Statuses a plain onError return keeps at runtime: PARSE 400, NOT_FOUND 404,
+// VALIDATION 422, unhandled / INTERNAL_SERVER_ERROR 500.
+type OnErrorDefaultStatus = 400 | 404 | 422 | 500
+
+type OnErrorPlainReturn<Value> = Exclude<
+	Value,
+	AnyElysiaCustomStatusResponse | undefined
+>
+
+type OnErrorPlainToResponseSchema<Plain> = IsNever<Plain> extends true
+	? {}
+	: { [Status in OnErrorDefaultStatus]: Plain }
+
+type OnErrorValueToResponseSchema<Value> = UnionResponseStatus<
+	ExtractErrorFromHandle<Value>,
+	OnErrorPlainToResponseSchema<OnErrorPlainReturn<Value>>
+>
+
+export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
+	Prettify<
+		Handle extends (...a: any) => MaybePromise<infer R>
+			? OnErrorValueToResponseSchema<Exclude<R, undefined>>
+			: {}
+	>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			// @ts-ignore Trust me bro
+			UnionResponseStatus<ElysiaErrorHandlerToResponseSchema<Current>, Carry>
+		>
+	: Prettify<Carry>
+
+export type ElysiaErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ElysiaErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ElysiaErrorHandlerToResponseSchemas<Schemas>
+				: {}
+
 type ReconcileStatus<
 	in out A extends Record<number, unknown>,
 	in out B extends Record<number, unknown>

--- a/test/types/lifecycle/on-error.ts
+++ b/test/types/lifecycle/on-error.ts
@@ -1,0 +1,114 @@
+import { Elysia } from '../../../src'
+import { expectTypeOf } from 'expect-type'
+import { Prettify } from '../../../src/types'
+// I have nothing but my burger and I want nothing more
+
+// Issue #313 — a plain onError body is sent with the thrown error's HTTP
+// status (PARSE 400, NOT_FOUND 404, VALIDATION 422, unhandled 500). Eden
+// reads those codes as `error`, so the body must not be typed as 200.
+{
+	const app = new Elysia()
+		.onError(() => ({ failure: 'maintenance' as const }))
+		.get('/', () => {
+			throw new Error('Server is during maintenance')
+		})
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		400: { failure: 'maintenance' }
+		404: { failure: 'maintenance' }
+		422: { failure: 'maintenance' }
+		500: { failure: 'maintenance' }
+	}>()
+}
+
+// Explicit status(...) from onError keeps that status only.
+{
+	const app = new Elysia()
+		.onError(({ status }) => status(418, "I'm a teapot" as const))
+		.get('/', () => 'ok' as const)
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: 'ok'
+		418: "I'm a teapot"
+	}>()
+}
+
+// Mixed: plain body is under default error statuses; status(404, ...) stays 404.
+{
+	const app = new Elysia()
+		.onError(({ status }) =>
+			Math.random() > 0.5
+				? status(404, 'not found' as const)
+				: { failure: true as const }
+		)
+		.get('/', () => 'ok' as const)
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: 'ok'
+		400: { failure: true }
+		404: 'not found' | { failure: true }
+		422: { failure: true }
+		500: { failure: true }
+	}>()
+}
+
+// status(200, ...) from onError is not remapped onto 4xx/5xx.
+{
+	const app = new Elysia()
+		.onError(({ status }) => status(200, 'recovered' as const))
+		.get('/', () => 'ok' as const)
+
+	type Response = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<Response>().toEqualTypeOf<{
+		200: 'ok' | 'recovered'
+	}>()
+}
+
+// Scoped / global onError use the same mapping.
+{
+	const scoped = new Elysia()
+		.onError({ as: 'scoped' }, () => ({ scoped: true as const }))
+		.get('/', () => 'ok' as const)
+
+	expectTypeOf<
+		Prettify<(typeof scoped)['~Routes']['get']['response']>
+	>().toEqualTypeOf<{
+		200: 'ok'
+		400: { scoped: true }
+		404: { scoped: true }
+		422: { scoped: true }
+		500: { scoped: true }
+	}>()
+
+	const global = new Elysia()
+		.onError({ as: 'global' }, () => ({ global: true as const }))
+		.get('/', () => 'ok' as const)
+
+	expectTypeOf<
+		Prettify<(typeof global)['~Routes']['get']['response']>
+	>().toEqualTypeOf<{
+		200: 'ok'
+		400: { global: true }
+		404: { global: true }
+		422: { global: true }
+		500: { global: true }
+	}>()
+}
+
+// Route handlers still type a plain success return as 200.
+{
+	const app = new Elysia().get('/', () => ({ ok: true as const }))
+
+	expectTypeOf<
+		Prettify<(typeof app)['~Routes']['get']['response']>
+	>().toEqualTypeOf<{
+		200: { ok: true }
+	}>()
+}

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1007,10 +1007,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1028,10 +1030,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1049,10 +1053,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 


### PR DESCRIPTION
@algora-pbc /claim #313
Fixes #313

## Prerequisites

- [x] I have run `bun test` (1614 pass, 2 pre-existing skips) and `bun run test:types`
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

https://github.com/elysiajs/elysia/issues/313

## Description

Plain objects returned from `onError` keep the thrown error's HTTP status at runtime (`PARSE` 400, `NOT_FOUND` 404, `VALIDATION` 422, unhandled 500), but route metadata typed those bodies as `200`. Eden then treats the custom JSON as a success payload, so clients miss it under `error`.

This is a type-only change. `onError` (and guard `error`) now infer through a dedicated mapper:

- A **plain** return is recorded under 400 / 404 / 422 / 500.
- An explicit **`status(code, value)`** return keeps that code only.
- Overlapping codes union the bodies.
- Route handlers are unchanged — a plain success return is still `200`.

Coverage is in `test/types/lifecycle/on-error.ts`. Existing onError soundness cases were updated so they no longer expect those plain values as `200`.

I have nothing but my burger and I want nothing more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript response inference for error handlers.
  - Plain error responses now correctly reflect applicable HTTP statuses, including 400, 404, 422, and 500.
  - Explicitly assigned custom statuses are preserved accurately, including mixed response branches and successful status 200 responses.
  - Error response typing is now consistent across global, scoped, grouped, and guarded error handlers.
- **Tests**
  - Added coverage for error-handler response inference and type safety across lifecycle configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->