### PR TITLE
fix: fall back from exact mirror for wildcard params

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -408,6 +408,54 @@ const createCleaner = (schema: TAnySchema) => (value: unknown) => {
 	return value
 }
 
+const canUseExactMirrorSchemas = (schemas?: readonly TSchema[]): boolean => {
+	if (!schemas) return true
+
+	for (let i = 0; i < schemas.length; i++)
+		if (!canUseExactMirror(schemas[i])) return false
+
+	return true
+}
+
+const canUseExactMirror = (schema: TAnySchema): boolean => {
+	if (schema.properties) {
+		if ('*' in schema.properties) return false
+
+		for (const key in schema.properties)
+			if (!canUseExactMirror(schema.properties[key])) return false
+	}
+
+	if (schema.items)
+		if (Array.isArray(schema.items)) {
+			if (!canUseExactMirrorSchemas(schema.items)) return false
+		} else if (!canUseExactMirror(schema.items)) return false
+
+	if (
+		!canUseExactMirrorSchemas(schema.anyOf) ||
+		!canUseExactMirrorSchemas(schema.allOf) ||
+		!canUseExactMirrorSchemas(schema.oneOf)
+	)
+		return false
+
+	if (schema.not && !canUseExactMirror(schema.not)) return false
+
+	if (
+		typeof schema.additionalProperties === 'object' &&
+		!canUseExactMirror(schema.additionalProperties)
+	)
+		return false
+
+	if (schema.patternProperties)
+		for (const key in schema.patternProperties)
+			if (!canUseExactMirror(schema.patternProperties[key])) return false
+
+	if (schema.$defs)
+		for (const key in schema.$defs)
+			if (!canUseExactMirror(schema.$defs[key])) return false
+
+	return true
+}
+
 // const caches = <Record<string, ElysiaTypeCheck<any>>>{}
 
 export const getSchemaValidator = <T extends AnySchema | string | undefined>(
@@ -544,19 +592,21 @@ export const getSchemaValidator = <T extends AnySchema | string | undefined>(
 		): StandardSchemaV1LikeValidate => {
 			let mirror: Function
 			if (normalize === true || normalize === 'exactMirror')
-				try {
-					mirror = createMirror(schema as TSchema, {
-						TypeCompiler,
-						sanitize: sanitize?.(),
-						modules
-					})
-				} catch {
-					console.warn(
-						'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
-					)
-					console.warn(schema)
-					mirror = createCleaner(schema as TSchema)
-				}
+				if (canUseExactMirror(schema as TSchema))
+					try {
+						mirror = createMirror(schema as TSchema, {
+							TypeCompiler,
+							sanitize: sanitize?.(),
+							modules
+						})
+					} catch {
+						console.warn(
+							'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
+						)
+						console.warn(schema)
+						mirror = createCleaner(schema as TSchema)
+					}
+				else mirror = createCleaner(schema as TSchema)
 
 			const vali = getSchemaValidator(schema, {
 				models,
@@ -861,19 +911,21 @@ export const getSchemaValidator = <T extends AnySchema | string | undefined>(
 
 			if (normalize && schema.additionalProperties === false) {
 				if (normalize === true || normalize === 'exactMirror') {
-					try {
-						validator.Clean = createMirror(schema, {
-							TypeCompiler,
-							sanitize: sanitize?.(),
-							modules
-						})
-					} catch {
-						console.warn(
-							'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
-						)
-						console.warn(schema)
-						validator.Clean = createCleaner(schema)
-					}
+					if (canUseExactMirror(schema))
+						try {
+							validator.Clean = createMirror(schema, {
+								TypeCompiler,
+								sanitize: sanitize?.(),
+								modules
+							})
+						} catch {
+							console.warn(
+								'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
+							)
+							console.warn(schema)
+							validator.Clean = createCleaner(schema)
+						}
+					else validator.Clean = createCleaner(schema)
 				} else validator.Clean = createCleaner(schema)
 			}
 
@@ -999,22 +1051,24 @@ export const getSchemaValidator = <T extends AnySchema | string | undefined>(
 		}
 
 		if (normalize === true || normalize === 'exactMirror') {
-			try {
-				compiled.Clean = createMirror(schema, {
-					TypeCompiler,
-					sanitize: sanitize?.(),
-					modules
-				})
-			} catch (error) {
-				console.warn(
-					'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
-				)
-				console.dir(schema, {
-					depth: null
-				})
+			if (canUseExactMirror(schema))
+				try {
+					compiled.Clean = createMirror(schema, {
+						TypeCompiler,
+						sanitize: sanitize?.(),
+						modules
+					})
+				} catch (error) {
+					console.warn(
+						'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
+					)
+					console.dir(schema, {
+						depth: null
+					})
 
-				compiled.Clean = createCleaner(schema)
-			}
+					compiled.Clean = createCleaner(schema)
+				}
+			else compiled.Clean = createCleaner(schema)
 		} else if (normalize === 'typebox')
 			compiled.Clean = createCleaner(schema)
 	} else {

--- a/test/path/path.test.ts
+++ b/test/path/path.test.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from '../../src'
 
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, spyOn } from 'bun:test'
 import { post, req } from '../utils'
 
 describe('Path', () => {
@@ -113,6 +113,124 @@ describe('Path', () => {
 		const res = await app.handle(req('/wildcard/okayu'))
 
 		expect(await res.text()).toBe('Wildcard')
+	})
+
+	it('parse wildcard params with an explicit schema without warning', async () => {
+		const warn = spyOn(console, 'warn').mockImplementation(() => {})
+
+		try {
+			const app = new Elysia().get(
+				'/uploads/:type/*',
+				({ params }) => ({
+					type: params.type,
+					path: params['*']
+				}),
+				{
+					params: t.Object({
+						type: t.String(),
+						'*': t.String()
+					})
+				}
+			)
+			const response = await app.handle(
+				req('/uploads/images/2024-11-08/a.jpg')
+			)
+
+			expect(await response.json()).toEqual({
+				type: 'images',
+				path: '2024-11-08/a.jpg'
+			})
+			expect(warn).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it('normalize nested wildcard response schemas without warning', async () => {
+		const warn = spyOn(console, 'warn').mockImplementation(() => {})
+
+		try {
+			const app = new Elysia().get(
+				'/uploads',
+				() => ({
+					files: {
+						'*': '2024-11-08/a.jpg'
+					}
+				}),
+				{
+					response: t.Object({
+						files: t.Object({
+							'*': t.String()
+						})
+					})
+				}
+			)
+			const response = await app.handle(req('/uploads'))
+
+			expect(await response.json()).toEqual({
+				files: {
+					'*': '2024-11-08/a.jpg'
+				}
+			})
+			expect(warn).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it('normalize wildcard array response schemas without warning', async () => {
+		const warn = spyOn(console, 'warn').mockImplementation(() => {})
+
+		try {
+			const app = new Elysia().get(
+				'/uploads',
+				() => [{ '*': '2024-11-08/a.jpg' }],
+				{
+					response: t.Array(
+						t.Object({
+							'*': t.String()
+						})
+					)
+				}
+			)
+			const response = await app.handle(req('/uploads'))
+
+			expect(await response.json()).toEqual([
+				{ '*': '2024-11-08/a.jpg' }
+			])
+			expect(warn).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it('normalize wildcard union response schemas without warning', async () => {
+		const warn = spyOn(console, 'warn').mockImplementation(() => {})
+
+		try {
+			const app = new Elysia().get(
+				'/uploads',
+				() => ({ '*': '2024-11-08/a.jpg' }),
+				{
+					response: t.Union([
+						t.Object({
+							'*': t.String()
+						}),
+						t.Object({
+							path: t.String()
+						})
+					])
+				}
+			)
+			const response = await app.handle(req('/uploads'))
+
+			expect(await response.json()).toEqual({
+				'*': '2024-11-08/a.jpg'
+			})
+			expect(warn).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
 	})
 
 	it('custom error', async () => {


### PR DESCRIPTION
Fixes #1992.

`exact-mirror` generates invalid code for an object schema containing the wildcard parameter key `"*"`. Route validation now uses the existing `createCleaner` fallback only for that unsupported property; normal schemas keep the exact-mirror path.

Verification:
- Added a regression test for wildcard params that verifies the response and no warning is emitted.
- `bun run build && bun run test` passed in the detached runner.

I have nothing but my burger and I want nothing more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wildcard route handling so named and wildcard parameters return correctly.
  * Improved validation and cleaning for schemas containing wildcard properties, including nested objects, arrays, and unions.
  * Corrected JSON output for routes with explicit parameter schemas and wildcard response schemas.
  * Reduced unnecessary console warnings when processing wildcard-parameter routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->