### PR TITLE
fix(schema): handle wildcard keys in exact mirror

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -408,6 +408,43 @@ const createCleaner = (schema: TAnySchema) => (value: unknown) => {
 	return value
 }
 
+const isExactMirrorCompatible = (
+	schema: TAnySchema,
+	seen = new WeakSet<object>()
+): boolean => {
+	if (seen.has(schema)) return true
+	seen.add(schema)
+
+	if (schema.$ref && schema.$defs?.[schema.$ref])
+		return isExactMirrorCompatible(schema.$defs[schema.$ref], seen)
+
+	if (schema.type === 'object' && schema.properties)
+		for (const [key, property] of Object.entries(schema.properties)) {
+			if (
+				!/^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u.test(key) ||
+				!isExactMirrorCompatible(property as TAnySchema, seen)
+			)
+				return false
+		}
+
+	if (schema.type === 'array' && schema.items) {
+		const items = Array.isArray(schema.items)
+			? schema.items
+			: [schema.items]
+
+		for (const item of items)
+			if (!isExactMirrorCompatible(item as TAnySchema, seen)) return false
+	}
+
+	for (const combinator of [schema.allOf, schema.anyOf, schema.oneOf])
+		if (combinator)
+			for (const subSchema of combinator)
+				if (!isExactMirrorCompatible(subSchema as TAnySchema, seen))
+					return false
+
+	return true
+}
+
 // const caches = <Record<string, ElysiaTypeCheck<any>>>{}
 
 export const getSchemaValidator = <T extends AnySchema | string | undefined>(
@@ -543,20 +580,23 @@ export const getSchemaValidator = <T extends AnySchema | string | undefined>(
 			schema: TSchema
 		): StandardSchemaV1LikeValidate => {
 			let mirror: Function
-			if (normalize === true || normalize === 'exactMirror')
-				try {
-					mirror = createMirror(schema as TSchema, {
-						TypeCompiler,
-						sanitize: sanitize?.(),
-						modules
-					})
-				} catch {
-					console.warn(
-						'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
-					)
-					console.warn(schema)
-					mirror = createCleaner(schema as TSchema)
-				}
+			if (normalize === true || normalize === 'exactMirror') {
+				if (isExactMirrorCompatible(schema))
+					try {
+						mirror = createMirror(schema as TSchema, {
+							TypeCompiler,
+							sanitize: sanitize?.(),
+							modules
+						})
+					} catch {
+						console.warn(
+							'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
+						)
+						console.warn(schema)
+						mirror = createCleaner(schema as TSchema)
+					}
+				else mirror = createCleaner(schema as TSchema)
+			}
 
 			const vali = getSchemaValidator(schema, {
 				models,
@@ -861,19 +901,21 @@ export const getSchemaValidator = <T extends AnySchema | string | undefined>(
 
 			if (normalize && schema.additionalProperties === false) {
 				if (normalize === true || normalize === 'exactMirror') {
-					try {
-						validator.Clean = createMirror(schema, {
-							TypeCompiler,
-							sanitize: sanitize?.(),
-							modules
-						})
-					} catch {
-						console.warn(
-							'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
-						)
-						console.warn(schema)
-						validator.Clean = createCleaner(schema)
-					}
+					if (isExactMirrorCompatible(schema))
+						try {
+							validator.Clean = createMirror(schema, {
+								TypeCompiler,
+								sanitize: sanitize?.(),
+								modules
+							})
+						} catch {
+							console.warn(
+								'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
+							)
+							console.warn(schema)
+							validator.Clean = createCleaner(schema)
+						}
+					else validator.Clean = createCleaner(schema)
 				} else validator.Clean = createCleaner(schema)
 			}
 
@@ -999,22 +1041,24 @@ export const getSchemaValidator = <T extends AnySchema | string | undefined>(
 		}
 
 		if (normalize === true || normalize === 'exactMirror') {
-			try {
-				compiled.Clean = createMirror(schema, {
-					TypeCompiler,
-					sanitize: sanitize?.(),
-					modules
-				})
-			} catch (error) {
-				console.warn(
-					'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
-				)
-				console.dir(schema, {
-					depth: null
-				})
+			if (isExactMirrorCompatible(schema))
+				try {
+					compiled.Clean = createMirror(schema, {
+						TypeCompiler,
+						sanitize: sanitize?.(),
+						modules
+					})
+				} catch (error) {
+					console.warn(
+						'Failed to create exactMirror. Please report the following code to https://github.com/elysiajs/elysia/issues'
+					)
+					console.dir(schema, {
+						depth: null
+					})
 
-				compiled.Clean = createCleaner(schema)
-			}
+					compiled.Clean = createCleaner(schema)
+				}
+			else compiled.Clean = createCleaner(schema)
 		} else if (normalize === 'typebox')
 			compiled.Clean = createCleaner(schema)
 	} else {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -408,24 +408,93 @@ const createCleaner = (schema: TAnySchema) => (value: unknown) => {
 	return value
 }
 
+type ExactMirrorScope = {
+	definitions: Record<string, TSchema>
+	parent?: ExactMirrorScope
+}
+
+type ExactMirrorTraversal = {
+	root: ExactMirrorScope
+	scopes: WeakMap<object, WeakMap<object, ExactMirrorScope>>
+	seen: WeakMap<object, WeakSet<object>>
+}
+
+const createExactMirrorScope = (
+	definitions: Record<string, TSchema>,
+	parent: ExactMirrorScope | undefined,
+	traversal: ExactMirrorTraversal
+) => {
+	const parentScope = parent ?? traversal.root
+	let scopes = traversal.scopes.get(definitions)
+
+	if (!scopes)
+		traversal.scopes.set(definitions, (scopes = new WeakMap()))
+
+	let scope = scopes.get(parentScope)
+
+	if (!scope) {
+		scope = { definitions, parent }
+		scopes.set(parentScope, scope)
+	}
+
+	return scope
+}
+
+const resolveExactMirrorReference = (
+	reference: string,
+	scope?: ExactMirrorScope
+) => {
+	for (let current = scope; current; current = current.parent)
+		if (reference in current.definitions)
+			return current.definitions[reference]
+}
+
 const isExactMirrorCompatible = (
 	schema: TAnySchema,
-	seen = new WeakSet<object>()
+	scope?: ExactMirrorScope,
+	traversal: ExactMirrorTraversal = {
+		root: { definitions: {} },
+		scopes: new WeakMap(),
+		seen: new WeakMap()
+	}
 ): boolean => {
-	if (seen.has(schema)) return true
-	seen.add(schema)
+	if (schema.$defs)
+		scope = createExactMirrorScope(
+			schema.$defs as Record<string, TSchema>,
+			scope,
+			traversal
+		)
 
-	if (schema.$ref && schema.$defs?.[schema.$ref])
-		return isExactMirrorCompatible(schema.$defs[schema.$ref], seen)
+	const currentScope = scope ?? traversal.root
+	let scopes = traversal.seen.get(schema)
+
+	if (scopes?.has(currentScope)) return true
+
+	if (!scopes)
+		traversal.seen.set(schema, (scopes = new WeakSet()))
+
+	scopes.add(currentScope)
+
+	if (schema.$ref) {
+		const reference = resolveExactMirrorReference(schema.$ref, scope)
+
+		if (reference)
+			return isExactMirrorCompatible(reference, scope, traversal)
+	}
 
 	if (schema.type === 'object' && schema.properties)
 		for (const [key, property] of Object.entries(schema.properties)) {
 			if (
 				!/^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u.test(key) ||
-				!isExactMirrorCompatible(property as TAnySchema, seen)
+				!isExactMirrorCompatible(property as TAnySchema, scope, traversal)
 			)
 				return false
 		}
+
+	if (schema.patternProperties)
+		for (const property of Object.values(schema.patternProperties))
+			if (!isExactMirrorCompatible(property as TAnySchema, scope, traversal))
+				return false
 
 	if (schema.type === 'array' && schema.items) {
 		const items = Array.isArray(schema.items)
@@ -433,17 +502,25 @@ const isExactMirrorCompatible = (
 			: [schema.items]
 
 		for (const item of items)
-			if (!isExactMirrorCompatible(item as TAnySchema, seen)) return false
+			if (!isExactMirrorCompatible(item as TAnySchema, scope, traversal))
+				return false
 	}
 
 	for (const combinator of [schema.allOf, schema.anyOf, schema.oneOf])
 		if (combinator)
 			for (const subSchema of combinator)
-				if (!isExactMirrorCompatible(subSchema as TAnySchema, seen))
+				if (
+					!isExactMirrorCompatible(
+						subSchema as TAnySchema,
+						scope,
+						traversal
+					)
+				)
 					return false
 
 	return true
 }
+
 
 // const caches = <Record<string, ElysiaTypeCheck<any>>>{}
 

--- a/test/core/sanitize.test.ts
+++ b/test/core/sanitize.test.ts
@@ -28,6 +28,26 @@ describe('Sanitize', () => {
 		expect(response).toEqual({ a: 'ok', b: 'b', c: 'c' })
 	})
 
+	it('sanitize unicode property key', async () => {
+		const app = new Elysia({
+			sanitize: (v) => (v === 'a' ? 'ok' : v)
+		}).post('/', ({ body }) => body, {
+			body: t.Object({
+				tên: t.String()
+			})
+		})
+
+		const response = await app
+			.handle(
+				post('/', {
+					tên: 'a'
+				})
+			)
+			.then((x) => x.json())
+
+		expect(response).toEqual({ tên: 'ok' })
+	})
+
 	it('multiple sanitize', async () => {
 		const app = new Elysia({
 			sanitize: [

--- a/test/validator/exact-mirror.test.ts
+++ b/test/validator/exact-mirror.test.ts
@@ -15,6 +15,78 @@ describe('Exact Mirror', () => {
 		})
 	})
 
+	it('normalizes nested module refs with wildcard keys without warnings', async () => {
+		const warn = console.warn
+		let warnings = 0
+		console.warn = () => warnings++
+
+		try {
+			const schema = t
+				.Module({
+					Foo: t.Object({
+						child: t.Ref('Bar')
+					}),
+					Bar: t.Object({
+						'*': t.String()
+					})
+				})
+				.Import('Foo')
+			const app = new Elysia().post('/', ({ body }) => body, {
+				body: schema
+			})
+
+			const response = await app
+				.handle(
+					post('/', {
+						child: { '*': 'file' }
+					})
+				)
+				.then((x) => x.json())
+
+			expect(response).toEqual({
+				child: { '*': 'file' }
+			})
+		} finally {
+			console.warn = warn
+		}
+
+		expect(warnings).toBe(0)
+	})
+
+	it('normalizes records with wildcard keys without warnings', async () => {
+		const warn = console.warn
+		let warnings = 0
+		console.warn = () => warnings++
+
+		try {
+			const app = new Elysia().post('/', ({ body }) => body, {
+				body: t.Record(
+					t.String(),
+					t.Object({
+						'*': t.String()
+					})
+				)
+			})
+
+			const response = await app
+				.handle(
+					post('/', {
+						file: { '*': 'ok' }
+					})
+				)
+				.then((x) => x.json())
+
+			expect(response).toEqual({
+				file: { '*': 'ok' }
+			})
+		} finally {
+			console.warn = warn
+		}
+
+		expect(warnings).toBe(0)
+	})
+
+
 	it('leave incorrect union field as-is', async () => {
 		const app = new Elysia().post(
 			'/test',

--- a/test/validator/params.test.ts
+++ b/test/validator/params.test.ts
@@ -44,6 +44,38 @@ describe('Params Validator', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('handles wildcard params without exactMirror warning', async () => {
+		const warn = console.warn
+		let warnings = 0
+		console.warn = () => warnings++
+
+		try {
+			const app = new Elysia().get(
+				'/uploads/:type/*',
+				({ params }) => params,
+				{
+					params: t.Object({
+						type: t.String(),
+						'*': t.String()
+					})
+				}
+			)
+			const response = await app.handle(
+				req('/uploads/images/2024-11-08/a.jpg')
+			)
+
+			expect(await response.json()).toEqual({
+				type: 'images',
+				'*': '2024-11-08/a.jpg'
+			})
+			expect(response.status).toBe(200)
+		} finally {
+			console.warn = warn
+		}
+
+		expect(warnings).toBe(0)
+	})
+
 	it('parse without reference', async () => {
 		const app = new Elysia().get('/id/:id', () => '', {
 			params: t.Object({


### PR DESCRIPTION
## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

Fixes #1992

## Description

Fix repeated "Failed to create exactMirror" warnings for schemas containing wildcard route parameter keys such as "*".

"exact-mirror@0.2.x" emits non-identifier property names incorrectly. Before compiling an exact mirror, validate that all object property names are valid JavaScript identifiers. Schemas with unsupported property keys now use the existing "Value.Clean" fallback without logging a warning.

Added regressions covering:

- A wildcard route params schema with "'*': t.String()", asserting the expected response and no warning.
- A Unicode identifier key, asserting it continues using the exact-mirror sanitizer path.

## Verification

- "bun run test"
  - 1616 passed
  - 2 skipped
  - 0 failed
- Reproduced the reported wildcard route using the issue runner:
  - "200 {"ok":true,"type":"images","p":"2024-11-08/a.jpg"}"
  - No "Failed to create exactMirror" warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation and sanitization for schemas with Unicode property names.
  - Improved handling of wildcard route parameters and responses.
  - Prevented unnecessary compatibility warnings for supported wildcard schemas and routes.
  - Improved processing of nested, referenced, circular, and pattern-based schema definitions.

- **Tests**
  - Added coverage for Unicode property-key sanitization.
  - Added coverage for wildcard parameter validation and successful responses.
  - Added coverage ensuring supported wildcard schemas and routes do not emit compatibility warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->