### PR TITLE
fix(types): type onError plain returns under error statuses (#313)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,9 @@ import type {
 	ElysiaHandlerToResponseSchemas,
 	ExtractErrorFromHandle,
 	ElysiaHandlerToResponseSchemaAmbiguous,
+	ElysiaErrorHandlerToResponseSchema,
+	ElysiaErrorHandlerToResponseSchemas,
+	ElysiaErrorHandlerToResponseSchemaAmbiguous,
 	GuardLocalHook,
 	PickIfExists,
 	SimplifyToSchema,
@@ -3146,7 +3149,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchema<Handler>
+				ElysiaErrorHandlerToResponseSchema<Handler>
 			>
 		}
 	>
@@ -3199,7 +3202,7 @@ export default class Elysia<
 			standaloneSchema: Volatile['standaloneSchema']
 			response: UnionResponseStatus<
 				Volatile['response'],
-				ElysiaHandlerToResponseSchemas<Handlers>
+				ElysiaErrorHandlerToResponseSchemas<Handlers>
 			>
 		}
 	>
@@ -3289,7 +3292,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchema<Handler>
+						ElysiaErrorHandlerToResponseSchema<Handler>
 					>
 				},
 				Routes,
@@ -3310,7 +3313,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					},
 					Volatile
@@ -3329,7 +3332,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchema<Handler>
+							ElysiaErrorHandlerToResponseSchema<Handler>
 						>
 					}
 				>
@@ -3419,7 +3422,7 @@ export default class Elysia<
 					parser: Metadata['parser']
 					response: UnionResponseStatus<
 						Metadata['response'],
-						ElysiaHandlerToResponseSchemas<Handlers>
+						ElysiaErrorHandlerToResponseSchemas<Handlers>
 					>
 				},
 				Routes,
@@ -3440,7 +3443,7 @@ export default class Elysia<
 						standaloneSchema: Ephemeral['standaloneSchema']
 						response: UnionResponseStatus<
 							Ephemeral['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					},
 					Volatile
@@ -3459,7 +3462,7 @@ export default class Elysia<
 						standaloneSchema: Volatile['standaloneSchema']
 						response: UnionResponseStatus<
 							Volatile['response'],
-							ElysiaHandlerToResponseSchemas<Handlers>
+							ElysiaErrorHandlerToResponseSchemas<Handlers>
 						>
 					}
 				>
@@ -3931,7 +3934,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,
@@ -4181,7 +4184,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4220,7 +4223,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4256,7 +4259,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4290,7 +4293,7 @@ export default class Elysia<
 						response: Volatile['response'] &
 							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 							// @ts-ignore
 							MacroContext['return']
 					}
@@ -4327,7 +4330,7 @@ export default class Elysia<
 							response: Metadata['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4361,7 +4364,7 @@ export default class Elysia<
 							response: Ephemeral['response'] &
 								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle> &
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
 								// @ts-ignore
 								MacroContext['return']
 						},
@@ -4435,7 +4438,7 @@ export default class Elysia<
 						MacroContext['response'] &
 						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
 						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
 				},
 				{},
 				Ephemeral,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3929,12 +3929,14 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
-						// @ts-ignore
-						MacroContext['response'] &
-						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+					response: UnionResponseStatus<
+						Metadata['response'] &
+							// @ts-ignore
+							MacroContext['response'] &
+							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle>,
 						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+					>
 				},
 				{},
 				Ephemeral,
@@ -4181,12 +4183,14 @@ export default class Elysia<
 								>
 						standaloneSchema: Volatile['standaloneSchema'] &
 							SimplifyToSchema<MacroContext>
-						response: Volatile['response'] &
-							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-							// @ts-ignore
-							MacroContext['return']
+						response: UnionResponseStatus<
+							Volatile['response'] &
+								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+								// @ts-ignore
+								MacroContext['return'],
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						>
 					}
 				>
 			: AsType extends 'global'
@@ -4220,12 +4224,14 @@ export default class Elysia<
 							macro: Metadata['macro']
 							macroFn: Metadata['macroFn']
 							parser: Metadata['parser']
-							response: Metadata['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: UnionResponseStatus<
+								Metadata['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									// @ts-ignore
+									MacroContext['return'],
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+							>
 						},
 						Routes,
 						Ephemeral,
@@ -4256,12 +4262,14 @@ export default class Elysia<
 									>
 							standaloneSchema: Ephemeral['standaloneSchema'] &
 								SimplifyToSchema<MacroContext>
-							response: Ephemeral['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: UnionResponseStatus<
+								Ephemeral['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									// @ts-ignore
+									MacroContext['return'],
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+							>
 						},
 						Volatile
 					>
@@ -4290,12 +4298,14 @@ export default class Elysia<
 											Input,
 											Definitions['typebox']
 										>)
-						response: Volatile['response'] &
-							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-							// @ts-ignore
-							MacroContext['return']
+						response: UnionResponseStatus<
+							Volatile['response'] &
+								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+								// @ts-ignore
+								MacroContext['return'],
+							ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+						>
 					}
 				>
 			: AsType extends 'global'
@@ -4327,12 +4337,14 @@ export default class Elysia<
 							macro: Metadata['macro']
 							macroFn: Metadata['macroFn']
 							parser: Metadata['parser']
-							response: Metadata['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: UnionResponseStatus<
+								Metadata['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									// @ts-ignore
+									MacroContext['return'],
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+							>
 						},
 						Routes,
 						Ephemeral,
@@ -4361,12 +4373,14 @@ export default class Elysia<
 												Input,
 												Definitions['typebox']
 											>)
-							response: Ephemeral['response'] &
-								ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-								ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
-								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle> &
-								// @ts-ignore
-								MacroContext['return']
+							response: UnionResponseStatus<
+								Ephemeral['response'] &
+									ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+									ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+									// @ts-ignore
+									MacroContext['return'],
+								ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+							>
 						},
 						Volatile
 					>
@@ -4433,12 +4447,14 @@ export default class Elysia<
 					macro: Metadata['macro']
 					macroFn: Metadata['macroFn']
 					parser: Metadata['parser']
-					response: Metadata['response'] &
-						// @ts-ignore
-						MacroContext['response'] &
-						ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
-						ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle> &
+					response: UnionResponseStatus<
+						Metadata['response'] &
+							// @ts-ignore
+							MacroContext['response'] &
+							ElysiaHandlerToResponseSchemaAmbiguous<BeforeHandle> &
+							ElysiaHandlerToResponseSchemaAmbiguous<AfterHandle>,
 						ElysiaErrorHandlerToResponseSchemaAmbiguous<ErrorHandle>
+					>
 				},
 				{},
 				Ephemeral,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1016,6 +1016,19 @@ type ExtractAllResponseFromMacro<A> =
 						: {})
 			}
 
+type ExtractAllErrorResponseFromMacro<A> =
+	IsNever<A> extends true
+		? {}
+		: Exclude<A, undefined | void> extends infer A
+			? IsAny<A> extends true
+				? {}
+				: IsNever<A> extends true
+					? {}
+					: {
+							return: ErrorValueToResponseSchema<A>
+						}
+			: {}
+
 type FlattenMacroResponse<T> = T extends object
 	? '_' extends keyof T
 		? MergeFlattenMacroResponse<
@@ -1108,7 +1121,7 @@ type InnerMacroToContext<
 										Value['afterHandle']
 									>
 								> &
-								ExtractAllResponseFromMacro<
+								ExtractAllErrorResponseFromMacro<
 									// @ts-expect-error type is checked in key mapping
 									FunctionArrayReturnType<Value['error']>
 								> &
@@ -2226,6 +2239,65 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 			? ElysiaHandlerToResponseSchema<Schemas>
 			: Schemas extends Function[]
 				? ElysiaHandlerToResponseSchemas<Schemas>
+				: {}
+
+export type ErrorValueToResponseSchema<Value> =
+	ExtractErrorFromHandle<Value> extends infer Explicit
+		? Prettify<
+				(Extract<Value, Response> extends infer NativeResponse
+					? [NativeResponse] extends [never]
+						? {}
+						: { 200: NativeResponse }
+					: {}) &
+					(Exclude<
+						Value,
+						AnyElysiaCustomStatusResponse | Response | undefined | void
+					> extends infer Plain
+						? [Plain] extends [never]
+							? Explicit
+							: Prettify<
+									Omit<Explicit, 400 | 404 | 422 | 500> & {
+										[K in 400 | 404 | 422 | 500]: K extends keyof Explicit
+											? Explicit[K] | Plain
+											: Plain
+									}
+							  >
+						: never)
+		  >
+		: never
+
+export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
+	Prettify<
+		Handle extends (...a: any) => MaybePromise<infer R>
+			? ErrorValueToResponseSchema<R>
+			: {}
+	>
+
+export type ElysiaErrorHandlerToResponseSchemas<
+	Handle extends Function[],
+	Carry extends PossibleResponse = {}
+> = Handle extends [infer Current, ...infer Rest]
+	? ElysiaErrorHandlerToResponseSchemas<
+			// @ts-ignore Trust me bro
+			Rest,
+			Current extends Function
+				? UnionResponseStatus<
+						ElysiaErrorHandlerToResponseSchema<Current>,
+						Carry
+					>
+				: Carry
+		>
+	: Prettify<Carry>
+
+export type ElysiaErrorHandlerToResponseSchemaAmbiguous<
+	Schemas extends MaybeArray<Function>
+> =
+	MaybeArray<(...a: any) => any> extends Schemas
+		? {}
+		: Schemas extends Function
+			? ElysiaErrorHandlerToResponseSchema<Schemas>
+			: Schemas extends Function[]
+				? ElysiaErrorHandlerToResponseSchemas<Schemas>
 				: {}
 
 type ReconcileStatus<

--- a/src/types.ts
+++ b/src/types.ts
@@ -2242,34 +2242,38 @@ export type ElysiaHandlerToResponseSchemaAmbiguous<
 				: {}
 
 export type ErrorValueToResponseSchema<Value> =
-	ExtractErrorFromHandle<Value> extends infer Explicit
-		? Prettify<
-				(Extract<Value, Response> extends infer NativeResponse
-					? [NativeResponse] extends [never]
-						? {}
-						: { 200: NativeResponse }
-					: {}) &
-					(Exclude<
-						Value,
-						AnyElysiaCustomStatusResponse | Response | undefined | void
-					> extends infer Plain
-						? [Plain] extends [never]
-							? Explicit
-							: Prettify<
-									Omit<Explicit, 400 | 404 | 422 | 500> & {
-										[K in 400 | 404 | 422 | 500]: K extends keyof Explicit
-											? Explicit[K] | Plain
-											: Plain
-									}
-							  >
-						: never)
-		  >
-		: never
+	IsAny<Value> extends true
+		? {}
+		: ExtractErrorFromHandle<Value> extends infer Explicit
+			? Prettify<
+					(Extract<Value, Response> extends infer NativeResponse
+						? [NativeResponse] extends [never]
+							? {}
+							: { 200: NativeResponse }
+						: {}) &
+						(Exclude<
+							Value,
+							AnyElysiaCustomStatusResponse | Response | undefined | void
+						> extends infer Plain
+							? [Plain] extends [never]
+								? Explicit
+								: Prettify<
+										Omit<Explicit, 400 | 404 | 422 | 500> & {
+											[K in 400 | 404 | 422 | 500]: K extends keyof Explicit
+												? Explicit[K] | Plain
+												: Plain
+										}
+								  >
+							: never)
+			  >
+			: never
 
 export type ElysiaErrorHandlerToResponseSchema<in out Handle extends Function> =
 	Prettify<
 		Handle extends (...a: any) => MaybePromise<infer R>
-			? ErrorValueToResponseSchema<R>
+			? IsAny<R> extends true
+				? {}
+				: ErrorValueToResponseSchema<R>
 			: {}
 	>
 

--- a/test/core/handle-error.test.ts
+++ b/test/core/handle-error.test.ts
@@ -656,4 +656,20 @@ describe('Handle Error', () => {
 		expect(res.headers.get('set-cookie')).toContain('session=test-session-id')
 		expect(res.headers.get('x-custom')).toBe('value')
 	})
+
+	it('return JSON error with preserved status code (issue #313)', async () => {
+		const app = new Elysia()
+			.onError(({ error }) => {
+				return { failure: error.message }
+			})
+			.get('/', () => {
+				throw new Error('Server is during maintenance')
+			})
+
+		const res = await app.handle(req('/'))
+		expect(res.status).toBe(500)
+		expect(res.headers.get('content-type')).toContain('application/json')
+		const json = await res.json()
+		expect(json).toEqual({ failure: 'Server is during maintenance' })
+	})
 })

--- a/test/types/lifecycle/on-error.ts
+++ b/test/types/lifecycle/on-error.ts
@@ -1,6 +1,6 @@
 import { Elysia, status } from '../../../src'
 import { expectTypeOf } from 'expect-type'
-import type { Prettify } from '../../../src/types'
+import type { Prettify, ErrorHandler } from '../../../src/types'
 
 // Issue #313: plain onError return is typed under error statuses (400, 404, 422, 500)
 // and not under 200, so Eden clients type error.value correctly without polluting data.
@@ -166,3 +166,17 @@ import type { Prettify } from '../../../src/types'
 	type TreatyData<Res> = Res extends { 200: infer D } ? D : never
 	expectTypeOf<TreatyData<RouteResponse>>().toEqualTypeOf<'ok'>()
 }
+
+// Explicitly typed ErrorHandler does not produce broad 200 or [x: number] schema
+{
+	const handler: ErrorHandler = () => {}
+	const app = new Elysia()
+		.onError(handler)
+		.get('/', () => 'ok' as const)
+
+	type AppResponse = (typeof app)['~Routes']['get']['response']
+	expectTypeOf<AppResponse>().toEqualTypeOf<{
+		200: 'ok'
+	}>()
+}
+

--- a/test/types/lifecycle/on-error.ts
+++ b/test/types/lifecycle/on-error.ts
@@ -1,0 +1,168 @@
+import { Elysia, status } from '../../../src'
+import { expectTypeOf } from 'expect-type'
+import type { Prettify } from '../../../src/types'
+
+// Issue #313: plain onError return is typed under error statuses (400, 404, 422, 500)
+// and not under 200, so Eden clients type error.value correctly without polluting data.
+{
+	const app = new Elysia()
+		.onError(() => ({ failure: 'maintenance' as const }))
+		.get('/', () => 'ok' as const)
+
+	type RouteResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<RouteResponse>().toEqualTypeOf<{
+		200: 'ok'
+		400: { failure: 'maintenance' }
+		404: { failure: 'maintenance' }
+		422: { failure: 'maintenance' }
+		500: { failure: 'maintenance' }
+	}>()
+}
+
+// Conditional onError return (union with undefined) correctly preserves the error body
+// rather than collapsing into {}
+{
+	const app = new Elysia()
+		.onError(({ code, error }) => {
+			if (code === 'VALIDATION') {
+				return { failure: error.message }
+			}
+		})
+		.get('/', () => 'hello' as const)
+
+	type RouteResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<RouteResponse>().toEqualTypeOf<{
+		200: 'hello'
+		400: { failure: string }
+		404: { failure: string }
+		422: { failure: string }
+		500: { failure: string }
+	}>()
+}
+
+// Explicit status(code, value) preserves exact code without defaulting to 400/404/422/500
+{
+	const app = new Elysia()
+		.onError(() => status(418, 'teapot' as const))
+		.get('/', () => 'tea' as const)
+
+	type RouteResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<RouteResponse>().toEqualTypeOf<{
+		200: 'tea'
+		418: 'teapot'
+	}>()
+}
+
+// Async onError handler resolves return type correctly
+{
+	const app = new Elysia()
+		.onError(async () => ({ asyncError: true as const }))
+		.get('/', () => 'async' as const)
+
+	type RouteResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<RouteResponse>().toEqualTypeOf<{
+		200: 'async'
+		400: { asyncError: true }
+		404: { asyncError: true }
+		422: { asyncError: true }
+		500: { asyncError: true }
+	}>()
+}
+
+// Array of onError handlers unions the error response schemas
+{
+	const app = new Elysia()
+		.onError([
+			() => ({ errorA: 1 as const }),
+			() => ({ errorB: 2 as const })
+		])
+		.get('/', () => 'array' as const)
+
+	type RouteResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<RouteResponse>().toEqualTypeOf<{
+		200: 'array'
+		400: { errorA: 1 } | { errorB: 2 }
+		404: { errorA: 1 } | { errorB: 2 }
+		422: { errorA: 1 } | { errorB: 2 }
+		500: { errorA: 1 } | { errorB: 2 }
+	}>()
+}
+
+// Guard error handlers map to error statuses
+{
+	const app = new Elysia().guard({
+		error: () => ({ guardError: true as const })
+	})
+
+	type GuardResponse = Prettify<(typeof app)['~Volatile']['response']>
+
+	expectTypeOf<GuardResponse>().toEqualTypeOf<{
+		400: { guardError: true }
+		404: { guardError: true }
+		422: { guardError: true }
+		500: { guardError: true }
+	}>()
+}
+
+// Macro error handlers map to error statuses
+{
+	const app = new Elysia()
+		.macro({
+			customAuth: {
+				error() {
+					return { macroError: 'unauthorized' as const }
+				}
+			}
+		})
+		.get('/', () => 'ok' as const, {
+			customAuth: true
+		})
+
+	type RouteResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+
+	expectTypeOf<RouteResponse>().toEqualTypeOf<{
+		200: 'ok'
+		400: { macroError: 'unauthorized' }
+		404: { macroError: 'unauthorized' }
+		422: { macroError: 'unauthorized' }
+		500: { macroError: 'unauthorized' }
+	}>()
+}
+
+// Eden Treaty client error type inference contract verification
+{
+	const app = new Elysia()
+		.onError(() => ({ failure: 'maintenance' as const }))
+		.get('/', () => 'ok' as const)
+
+	type RouteResponse = (typeof app)['~Routes']['get']['response']
+
+	// Simulating TreatyResponse error mapping:
+	type TreatyError<Res> = {
+		[Status in Exclude<
+			keyof Res,
+			200 | 201 | 204 | 206
+		>]: Res[Status] extends infer Value
+			? {
+					status: Status
+					value: Value
+				}
+			: never
+	}[Exclude<keyof Res, 200 | 201 | 204 | 206>]
+
+	type ErrorType = TreatyError<RouteResponse>
+
+	// error.value is strictly typed as { failure: 'maintenance' }
+	expectTypeOf<ErrorType['value']>().toEqualTypeOf<{
+		failure: 'maintenance'
+	}>()
+
+	// data only contains 'ok', not the failure object
+	type TreatyData<Res> = Res extends { 200: infer D } ? D : never
+	expectTypeOf<TreatyData<RouteResponse>>().toEqualTypeOf<'ok'>()
+}

--- a/test/types/lifecycle/on-error.ts
+++ b/test/types/lifecycle/on-error.ts
@@ -1,4 +1,4 @@
-import { Elysia, status } from '../../../src'
+import { Elysia, status, t } from '../../../src'
 import { expectTypeOf } from 'expect-type'
 import type { Prettify, ErrorHandler } from '../../../src/types'
 
@@ -179,4 +179,42 @@ import type { Prettify, ErrorHandler } from '../../../src/types'
 		200: 'ok'
 	}>()
 }
+
+// Guard: parent error handler and guard error handler union instead of intersect
+{
+	const app = new Elysia()
+		.onError(() => ({ firstError: '1' as const }))
+		.guard({
+			error: () => ({ secondError: '2' as const })
+		})
+		.get('/', () => 'ok' as const)
+
+	type AppResponse = Prettify<(typeof app)['~Routes']['get']['response']>
+	expectTypeOf<AppResponse[500]>().toEqualTypeOf<
+		{ firstError: '1' } | { secondError: '2' }
+	>()
+}
+
+// Group: parent error handler and group error handler union instead of intersect
+{
+	const app = new Elysia()
+		.onError(() => ({ firstError: '1' as const }))
+		.group(
+			'/api',
+			{
+				error: () => ({ secondError: '2' as const })
+			},
+			(app) => app.get('/test', () => 'ok' as const)
+		)
+
+	type AppResponse = Prettify<
+		(typeof app)['~Routes']['api']['test']['get']['response']
+	>
+	expectTypeOf<AppResponse[500]>().toEqualTypeOf<
+		{ firstError: '1' } | { secondError: '2' }
+	>()
+}
+
+
+
 

--- a/test/types/lifecycle/soundness.ts
+++ b/test/types/lifecycle/soundness.ts
@@ -1007,10 +1007,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Volatile']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1028,10 +1030,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Ephemeral']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 
@@ -1049,10 +1053,12 @@ import { Prettify } from '../../../src/types'
 		])
 
 	expectTypeOf<(typeof app)['~Metadata']['response']>().toEqualTypeOf<{
-		200: 'fouco' | 'sartre' | 'lilith'
+		400: 'fouco' | 'sartre' | 'lilith'
 		401: 'fouco'
-		404: 'lilith'
+		404: 'lilith' | 'fouco' | 'sartre'
 		418: 'sartre'
+		422: 'fouco' | 'sartre' | 'lilith'
+		500: 'fouco' | 'sartre' | 'lilith'
 	}>()
 }
 


### PR DESCRIPTION
Resolves #313
@algora-pbc /claim #313

### Problem
When returning a plain object/primitive from `onError`, Elysia sends the response with the error's status code (`400` PARSE, `404` NOT_FOUND, `422` VALIDATION, or `500` unhandled error).
However, `ElysiaHandlerToResponseSchema` previously mapped plain returns to `{ 200: R }`.
As a result:
- Eden Treaty clients recorded the custom error under `data` (status 200) instead of `error`.
- `error.value` was typed as `unknown`.

### Solution
1. **`ErrorValueToResponseSchema<Value>` in `src/types.ts`**:
   - Preserves explicit `status(code, value)` / `error(code, value)` responses with their exact status codes.
   - Preserves native `Response` returns under status `200`.
   - Filters out `undefined` and `void` so conditional returns (`Value | undefined`) don't collapse into `{}`.
   - Maps plain return values across default error statuses (`400 | 404 | 422 | 500`).
2. **Error Handler Response Schema Types**:
   - Added `ElysiaErrorHandlerToResponseSchema`, `ElysiaErrorHandlerToResponseSchemas`, and `ElysiaErrorHandlerToResponseSchemaAmbiguous`.
   - Updated `onError`, `guard`, and `group` overloads in `src/index.ts` to use the error handler response schema mappers.
3. **Macro Error Support**:
   - Added `ExtractAllErrorResponseFromMacro` in `src/types.ts` so macro-defined `error` hooks also infer under error statuses.
4. **Comprehensive Tests**:
   - Added type tests in `test/types/lifecycle/on-error.ts` covering plain returns, conditional returns, async handlers, explicit `status()`, guard hooks, macro error handlers, and Eden Treaty client type inference.
   - Added runtime test in `test/core/handle-error.test.ts` ensuring JSON error response preservation and Content-Type header.
   - Updated existing assertions in `test/types/lifecycle/soundness.ts`.

### Verification
- `bun run test:types` passes (0 errors).
- `bun test test/core/handle-error.test.ts test/lifecycle/error.test.ts` passes (65/65 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error response handling so objects returned by error hooks are serialized as JSON while preserving the original error status.
  * Improved error response type inference across error hooks, guards, groups, macros, asynchronous handlers, and handler arrays.
  * Prevented conflicting error responses from producing invalid combined schemas.

* **Tests**
  * Added coverage for error status mappings, conditional returns, explicit status codes, and client-side error typing.
  * Updated type-soundness expectations for error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->