### PR TITLE
feat: `minTotalSize` and `maxTotalSize` for `t.Files()`

### DIFF
--- a/src/type-system/index.ts
+++ b/src/type-system/index.ts
@@ -28,6 +28,7 @@ import {
 	compile,
 	createType,
 	loadFileType,
+	parseFileUnit,
 	tryParse,
 	validateFile
 } from './utils'
@@ -79,10 +80,32 @@ const internalFiles = createType<FilesOptions, File[]>(
 		if (options.minItems && options.minItems > 1 && !Array.isArray(value))
 			return false
 
-		if (!Array.isArray(value)) return validateFile(options, value)
+		if (!Array.isArray(value))
+			return validateFile(
+				{
+					...options,
+					minSize: options.minTotalSize,
+					maxSize: options.maxTotalSize
+				},
+				value
+			)
 
 		if (options.minItems && value.length < options.minItems) return false
 		if (options.maxItems && value.length > options.maxItems) return false
+
+		const totalSize = value.reduce((sum, file) => sum + file.size, 0)
+
+		if (
+			options.minTotalSize &&
+			totalSize < parseFileUnit(options.minTotalSize)
+		)
+			return false
+
+		if (
+			options.maxTotalSize &&
+			totalSize > parseFileUnit(options.maxTotalSize)
+		)
+			return false
 
 		for (let i = 0; i < value.length; i++)
 			if (!validateFile(options, value[i])) return false

--- a/src/type-system/types.ts
+++ b/src/type-system/types.ts
@@ -96,6 +96,18 @@ export interface FileOptions extends SchemaOptions {
 export interface FilesOptions extends FileOptions {
 	minItems?: number
 	maxItems?: number
+	/**
+	 * The total file size must be at least the specified size.
+	 *
+	 * @example '600k' (600 kilobytes), '3m' (3 megabytes)
+	 */
+	minTotalSize?: FileUnit
+	/**
+	 * The total file size must be less than or equal to the specified size.
+	 *
+	 * @example '3m' (3 megabytes), '600k' (600 kilobytes)
+	 */
+	maxTotalSize?: FileUnit
 }
 
 export interface CookieValidatorOptions<T extends Object = {}>

--- a/test/type-system/files.test.ts
+++ b/test/type-system/files.test.ts
@@ -120,4 +120,63 @@ describe('Files', () => {
 
 		expect(response.status).toBe(200)
 	})
+
+	it('validate minTotalSize, maxTotalSize', async () => {
+		const app = new Elysia().post('/', () => 'ok', {
+			body: t.Object({
+				file: t.Files({
+					minTotalSize: '70k',
+					maxTotalSize: '500k'
+				})
+			})
+		})
+
+		// case 1 fail: single file (30.2 KiB)
+		{
+			const body = new FormData()
+			body.append('file', Bun.file('test/images/kozeki-ui.webp'))
+
+			const response = await app.handle(
+				new Request('http://localhost/', {
+					method: 'POST',
+					body
+				})
+			)
+
+			expect(response.status).toBe(422)
+		}
+
+		// case 2 pass: two files (30.2 KiB and 70.9 KiB -> 101.1 KiB)
+		{
+			const body = new FormData()
+			body.append('file', Bun.file('test/images/kozeki-ui.webp'))
+			body.append('file', Bun.file('test/images/midori.png'))
+
+			const response = await app.handle(
+				new Request('http://localhost/', {
+					method: 'POST',
+					body
+				})
+			)
+
+			expect(response.status).toBe(200)
+		}
+
+		// case 3 fail: three files (30.2 KiB, 70.9 KiB and 480.1 KiB -> 581.2 KiB)
+		{
+			const body = new FormData()
+			body.append('file', Bun.file('test/images/kozeki-ui.webp'))
+			body.append('file', Bun.file('test/images/midori.png'))
+			body.append('file', Bun.file('test/images/millenium.jpg'))
+
+			const response = await app.handle(
+				new Request('http://localhost/', {
+					method: 'POST',
+					body
+				})
+			)
+
+			expect(response.status).toBe(422)
+		}
+	})
 })


### PR DESCRIPTION
## Prerequisted

- [x] I have run the tests via `bun run test` and they pass
- [x] I have added tests to prevent regression in the future that prove my fix is effective or that my feature works
- [x] I understand that I'll write a detailed description of the PR and that it will be reviewed by a human

## Related issue

#1944 

## Description

This PR adds two fields `maxTotalSize` and `minTotalSize` to Elysia's file validation. Instead of `maxSize` and `minSize` it limits the total size files are allowed to have when being submitted. 

```js
// `mediaFiles`' total file size is capped at 64 MiB 
body: t.Object({ mediaFiles: t.Files({ maxTotalSize: "64m" }) })
```

Just using `totalSize` in an array-like field would limit the size for each single file which is not what I want, therefore this addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added minimum and maximum combined file-size limits for multi-file uploads.
  - File-size limits support unit-based values and apply to both individual files and combined uploads.
  - Combined upload validation now checks the total size of all selected files.

- **Bug Fixes**
  - Corrected file validation so configured per-file and total-size limits are consistently enforced, including zero-value limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->